### PR TITLE
#88 meta editor rm and add all attributes on change

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
@@ -252,22 +252,20 @@ define(['js/Constants',
             newAttributes = client.getOwnValidAttributeNames(this._metaInfo[CONSTANTS.GME_ID]),
             len,
             displayedAttributes = this._attributeNames.slice(0),
-            diff,
             attrLIBase = $('<li/>'),
             i;
 
+        // We have to remove all shown attributes (if type changed and name does not, we cannot detect the difference)
         //first get the ones that are not there anymore
-        diff = _.difference(displayedAttributes, newAttributes);
-        len = diff.length;
+        len = displayedAttributes.length;
         while (len--) {
-            this._removeAttribute(diff[len]);
+            this._removeAttribute(displayedAttributes[len]);
         }
 
         //second get the ones that are new
-        diff = _.difference(newAttributes, displayedAttributes);
-        len = diff.length;
+        len = newAttributes.length;
         while (len--) {
-            this._addAttribute(diff[len]);
+            this._addAttribute(newAttributes[len]);
         }
 
         //finally update UI


### PR DESCRIPTION
Do not use difference between displayed and new attributes. We cannot
detect if the type changed only and the name does not.