### PR TITLE
PluginBase: don't read current branch state when committing results

### DIFF
--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -284,39 +284,24 @@ define(['plugin/PluginConfig',
 
                 // FIXME: what if master branch is already in a different state?
 
-                self.project.getBranchNames(function (err, branchNames) {
-                    if (branchNames.hasOwnProperty(self.branchName)) {
-                        var branchHash = branchNames[self.branchName];
-                        if (branchHash === self.branchHash) {
-                            // the branch does not have any new commits
-                            // try to fast forward branch to the current commit
-                            self.project.setBranchHash(self.branchName, self.branchHash, self.currentHash, function (err) {
-                                if (err) {
-                                    // fast forward failed
-                                    self.logger.error(err);
-                                    self.logger.info('"' + self.branchName + '" was NOT updated');
-                                    self.logger.info('Project was saved to ' + self.currentHash + ' commit.');
-                                } else {
-                                    // successful fast forward of branch to the new commit
-                                    self.logger.info('"' + self.branchName + '" was updated to the new commit.');
-                                    // roll starting point on success
-                                    self.branchHash = self.currentHash;
-                                }
-                                callback(err);
-                            });
-                        } else {
-                            // branch has changes a merge is required
-                            // TODO: try auto-merge, if fails ...
-                            self.logger.warn('Cannot fast forward "' + self.branchName + '" branch. Merge is required but not supported yet.');
-                            self.logger.info('Project was saved to ' + self.currentHash + ' commit.');
-                            callback(null);
-                        }
-                    } else {
-                        // branch was deleted or not found, do nothing
+                // try to fast forward branch to the current commit
+                self.project.setBranchHash(self.branchName, self.branchHash, self.currentHash, function (err) {
+                    if (err) {
+                        // fast forward failed
+                        // TODO: try auto-merge
+
+                        self.logger.error(err);
+                        self.logger.info('"' + self.branchName + '" was NOT updated');
                         self.logger.info('Project was saved to ' + self.currentHash + ' commit.');
-                        callback(null);
+                    } else {
+                        // successful fast forward of branch to the new commit
+                        self.logger.info('"' + self.branchName + '" was updated to the new commit.');
+                        // roll starting point on success
+                        self.branchHash = self.currentHash;
                     }
+                    callback(err);
                 });
+
                 // FIXME: is this call async??
                 // FIXME: we are not tracking all commits that we make
 


### PR DESCRIPTION
It does not help:
1. In the old code, there is a race between getBranchNames and setBranchHash, so we need to handle the failure case properly anyway
2. getBranchNames adds round-trips and slowness