### PR TITLE
#222 now the inherited - empty children will not indicate mutation

### DIFF
--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -441,7 +441,7 @@ define([ "util/assert", "util/key", "core/future", "core/tasync", 'util/canon' ]
 		};
 
 		var __areEquivalent = function (data1, data2) {
-			return data1 === data2 || (typeof data1 === "string" && data1 === __getChildData(data2, ID_NAME)) || (__isEmptyData(data1) && __isEmptyData(data2));
+            return data1 === data2 || (typeof data1 === "string" && data1 === __getChildData(data2, ID_NAME)) || (__isEmptyData(data1) && __isEmptyData(data2));
 		};
 
 		var mutateCount = 0;
@@ -488,7 +488,7 @@ define([ "util/assert", "util/key", "core/future", "core/tasync", 'util/canon' ]
 			}
 
 			if (node.parent !== null) {
-				ASSERT(__areEquivalent(__getChildData(node.parent.data, node.relid), node.data));
+                ASSERT(__areEquivalent(__getChildData(node.parent.data, node.relid), node.data));
 				node.parent.data[node.relid] = copy;
 			}
 
@@ -684,13 +684,15 @@ define([ "util/assert", "util/key", "core/future", "core/tasync", 'util/canon' ]
 			return typeof node.data === "object" && node.data !== null && typeof node.data[ID_NAME] === "string";
 		};
 
-		var setHashed = function (node, hashed) {
+		var setHashed = function (node, hashed, noMutate) {
 			ASSERT(typeof hashed === "boolean");
 
 			node = normalize(node);
-			if (!mutate(node)) {
-				throw new Error("incorrect node data");
-			}
+            if(!noMutate){
+                if (!mutate(node)) {
+                    throw new Error("incorrect node data");
+                }
+            }
 
 			if (hashed) {
 				node.data[ID_NAME] = "";

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -92,10 +92,16 @@ define([ "util/assert", "core/core", "core/tasync" ], function(ASSERT, Core, TAS
                     }
                     basechild = core.loadChild( base, relid);
                     return TASYNC.call(function(b,c,n,r){
-                        child = c || core.getChild(n,r);
-                        child.base = b;
-                        core.getCoreTree().setHashed(child,true);
-                        return child;
+                        if(c){
+                            child = c;
+                            child.base = b;
+                            return child;
+                        } else {
+                            child = core.getChild(n,r);
+                            core.setHashed(child,true,true);
+                            child.base = b;
+                            return child;
+                        }
                     },basechild,child,node,relid);
                 }
             }


### PR DESCRIPTION


- new parameter to setHashed function so it can be called without mutate functionality (when we add an empty-inherited child that should not cause mutation)
- during load of empty-inherited child we set the hashed values with the new way