### PR TITLE
Fixes #344 Now it works under Safari again.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.10.1",
     "q": "=1.2.0",
     "requirejs": "=2.1.16",
-    "socket.io": "lattmann/socket.io#6c79ed30cd36f7aff4b16d90b5248bd5c5f17011",
-    "socket.io-client": "lattmann/socket.io-client#aa78f2d2a27b9ba824a589ad8e504e93045cb22b",
+    "socket.io": "lattmann/socket.io#3dc6e73bfad4fcd2a11462744bb50b53f8cd03a7",
+    "socket.io-client": "lattmann/socket.io-client#44adc25cb5597a80ba76d9d070f457815d0f34bf",
     "superagent": "=1.1.0",
     "unzip": "=0.1.11",
     "winston": "=0.9.0"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.10.1",
     "q": "=1.2.0",
     "requirejs": "=2.1.16",
-    "socket.io": "lattmann/socket.io#c1d50aa470b0d452cc60ad9df1be815b8d657b21",
-    "socket.io-client": "lattmann/socket.io-client#9115a5fd7aa799786fd94244a868b5ac9ee7aa10",
+    "socket.io": "lattmann/socket.io#6c79ed30cd36f7aff4b16d90b5248bd5c5f17011",
+    "socket.io-client": "lattmann/socket.io-client#aa78f2d2a27b9ba824a589ad8e504e93045cb22b",
     "superagent": "=1.1.0",
     "unzip": "=0.1.11",
     "winston": "=0.9.0"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.10.1",
     "q": "=1.2.0",
     "requirejs": "=2.1.16",
-    "socket.io": "lattmann/socket.io#6d38a946278e728e1c0fe61ef7ac3a280cd2df42",
-    "socket.io-client": "lattmann/socket.io-client#ccaa0401267e0fdd3d26fd8500054070b1bccbcd",
+    "socket.io": "lattmann/socket.io#3524a02c6a432e625716730a2f68c7da0849da9a",
+    "socket.io-client": "lattmann/socket.io-client#b0e850d6126ef6f87efef87ec92fd099134ac727",
     "superagent": "=1.1.0",
     "unzip": "=0.1.11",
     "winston": "=0.9.0"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.10.1",
     "q": "=1.2.0",
     "requirejs": "=2.1.16",
-    "socket.io": "lattmann/socket.io#a80238dba8e132570b85257a57ad0b9ee22f70d3",
-    "socket.io-client": "lattmann/socket.io-client#7f46360ff2ba2f32f405289d953862d52386823f",
+    "socket.io": "lattmann/socket.io#6d38a946278e728e1c0fe61ef7ac3a280cd2df42",
+    "socket.io-client": "lattmann/socket.io-client#ccaa0401267e0fdd3d26fd8500054070b1bccbcd",
     "superagent": "=1.1.0",
     "unzip": "=0.1.11",
     "winston": "=0.9.0"

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.10.1",
     "q": "=1.2.0",
     "requirejs": "=2.1.16",
-    "socket.io": "lattmann/socket.io#3dc6e73bfad4fcd2a11462744bb50b53f8cd03a7",
-    "socket.io-client": "lattmann/socket.io-client#44adc25cb5597a80ba76d9d070f457815d0f34bf",
+    "socket.io": "lattmann/socket.io#a80238dba8e132570b85257a57ad0b9ee22f70d3",
+    "socket.io-client": "lattmann/socket.io-client#7f46360ff2ba2f32f405289d953862d52386823f",
     "superagent": "=1.1.0",
     "unzip": "=0.1.11",
     "winston": "=0.9.0"


### PR DESCRIPTION
socket.io-client 1.3.5 bug fixed verison is used.
- https://github.com/lattmann/socket.io/commit/6c79ed30cd36f7aff4b16d90b5248bd5c5f17011
- https://github.com/lattmann/socket.io-client/commit/aa78f2d2a27b9ba824a589ad8e504e93045cb22b

Note: you have to run `npm install socket.io socket.io-client` otherwise it will not pick up the changes.