### PR TITLE
Blob: send 404 when appropriate.

### DIFF
--- a/src/server/middleware/blob/BlobError.js
+++ b/src/server/middleware/blob/BlobError.js
@@ -1,0 +1,11 @@
+/* globals module */
+
+
+module.exports = function BlobError(message, statusCode) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+    this.statusCode = statusCode;
+};
+
+require('util').inherits(module.exports, Error);

--- a/src/server/middleware/blob/BlobFSBackend.js
+++ b/src/server/middleware/blob/BlobFSBackend.js
@@ -14,7 +14,8 @@ var fs = require('fs'),
     GUID = requireJS('common/util/guid'),
 
     ensureDir = require('../../util/ensureDir'),
-    BlobBackendBase = require('./BlobBackendBase');
+    BlobBackendBase = require('./BlobBackendBase'),
+    BlobError = require('./BlobError');
 
 var BlobFSBackend = function (gmeConfig) {
     BlobBackendBase.call(this);
@@ -101,7 +102,7 @@ BlobFSBackend.prototype.getObject = function (hash, writeStream, bucket, callbac
 
     fs.lstat(filename, function (err, stat) {
         if ((err && err.code === 'ENOENT') || !stat.isFile()) {
-            return callback('Requested object does not exist: ' + hash); // FIXME: make the request have status 404
+            return callback(new BlobError('Requested object does not exist: ' + hash, 404));
         } else if (err) {
             return callback('getObject error: ' + err.code || 'unknown');
         }

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -837,7 +837,7 @@ function StandAloneServer(gmeConfig) {
     });
 
 
-    BlobServer.createExpressBlob(__app, '/rest/blob', middlewareOpts);
+    __app.use('/rest/blob', BlobServer.createExpressBlob(middlewareOpts));
 
     //client contents - js/html/css
     //stuff that considered not protected

--- a/test/server/middleware/blob/BlobServer.spec.js
+++ b/test/server/middleware/blob/BlobServer.spec.js
@@ -52,9 +52,23 @@ describe('BlobServer', function () {
         });
     });
 
-    it('should return 500 at /rest/blob/metadata/non-existing-hash', function (done) {
+    it('should return 404 at /rest/blob/metadata/non-existing-hash', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/metadata/non-existing-hash').end(function (err, res) {
-            should.equal(res.status, 500, err);
+            should.equal(res.status, 404, err);
+            done();
+        });
+    });
+
+    it('should return 404 at /rest/blob/download/non-existing-hash', function (done) {
+        agent.get(serverBaseUrl + '/rest/blob/download/non-existing-hash').end(function (err, res) {
+            should.equal(res.status, 404, err);
+            done();
+        });
+    });
+
+    it('should return 404 at /rest/blob/view/non-existing-hash', function (done) {
+        agent.get(serverBaseUrl + '/rest/blob/view/non-existing-hash').end(function (err, res) {
+            should.equal(res.status, 404, err);
             done();
         });
     });


### PR DESCRIPTION
Also, refactor to use express.Router(), so we can use blob-specific middleware