### PR TITLE
BlobClient: use globalAgent's certificate authorities (unless the BloClient user passed a custom list)

### DIFF
--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -20,6 +20,8 @@ define(['blob/Artifact', 'blob/BlobMetadata', 'superagent'], function (Artifact,
             this.httpsecure = (parameters.httpsecure !== undefined) ? parameters.httpsecure : this.httpsecure;
             this.webgmeclientsession = parameters.webgmeclientsession;
             this.keepaliveAgentOptions = parameters.keepaliveAgentOptions || { /* use defaults */ };
+        } else {
+            this.keepaliveAgentOptions = { /* use defaults */ };
         }
         this.blobUrl = '';
         if (this.httpsecure !== undefined && this.server && this.serverPort) {
@@ -36,6 +38,9 @@ define(['blob/Artifact', 'blob/BlobMetadata', 'superagent'], function (Artifact,
                 this.Agent = require('agentkeepalive').HttpsAgent;
             } else {
                 this.Agent = require('agentkeepalive');
+            }
+            if (this.keepaliveAgentOptions.hasOwnProperty('ca') === false) {
+                this.keepaliveAgentOptions.ca = require('https').globalAgent.options.ca;
             }
             this.keepaliveAgent = new this.Agent(this.keepaliveAgentOptions);
         }


### PR DESCRIPTION
This fixes node executor_workers with a custom ca (broken since keepaliveagent was introduced)