### PR TITLE
Added restart routing to routeAsync. Fixes #384.

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/AutoRouter.Graph.js
+++ b/src/client/js/Widgets/DiagramDesigner/AutoRouter.Graph.js
@@ -1950,8 +1950,13 @@ define([
             time = options.time || 5,
             optimizeFn = function (state) {
 
+                // If a path has been disconnected, start the routing over
+                if (!self.completelyConnected) {
+                    return setTimeout(startRouting, time);
+                }
+
                 updateFn(self.paths);
-                if (state.finished || !self.completelyConnected) {
+                if (state.finished) {
                     return callbackFn(self.paths);
                 } else {
                     state = self._optimize(state);

--- a/test-karma/client/js/autorouter.spec.js
+++ b/test-karma/client/js/autorouter.spec.js
@@ -536,27 +536,26 @@ describe('AutoRouter', function () {
                 assert(path.points.length >= 2, 'Path missing temporary points');
             });
 
-            it('routeAsync should stop optimizing if path is disconnected', function (done) {
+            it('should reconnect paths disconnected during routeAsync', function (done) {
                 var boxes = utils.addBoxes([[100, 100], [200, 200], [300, 300]]),
-                    called = false,
-                    testFn = function () {
-                        assert(called, 'Callback (redrawing connections) was not called!');
-                        done();
-                    },
+                    first = true,
                     path;
 
                 utils.connectAll(boxes);
                 router.routeAsync({
                     update: function () {
-                        path = router.graph.paths[0];
-                        router.graph.disconnect(path);
+                        if (first) {
+                            path = router.graph.paths[0];
+                            router.graph.disconnect(path);
+                            first = false;
+                        }
                     },
                     callback: function (/* paths */) {
-                        called = true;
+                        // Check that the disconnected path has been connected
+                        assert(router.graph.paths[0].points.length > 0);
+                        done();
                     }
                 });
-
-                setTimeout(testFn, 100);
             });
         });
 


### PR DESCRIPTION
If the a path is disconnected during the routing optimization, the routing will first reconnect any disconnected paths then resume optimizing the routes. Previously, it would simply terminate and draw what it could and assume that there would be another call to routeAsync when the adjustments were complete.

Added test for #384