### PR TITLE
Use default decorator for language to hide ports, when xmp is imported.

### DIFF
--- a/src/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.js
+++ b/src/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.js
@@ -274,6 +274,7 @@ define([
         // TODO: set default view to META
 
         self.core.setRegistry(languageNode, 'position', {x: 100, y: 200});
+        self.core.setRegistry(languageNode, 'decorator', 'DefaultDecorator');
 
 
         self.cache.languageNode = languageNode;


### PR DESCRIPTION
Please merge it to the `master` branch, too.