### PR TITLE
Improve merge dialog capabilities

### DIFF
--- a/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
+++ b/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
@@ -24,12 +24,12 @@ define(['js/util',
         RESULT_NAME_BASE = $('<span/>', {class: 'title'}),
         RESULT_TIME_BASE = $('<span/>', {class: 'time'}),
     //jscs:disable maximumLineLength
-        RESULT_DETAILS_BTN_BASE = $('<span class="btn btn-micro btn-details pull-right"><i class="glyphicon glyphicon-plus glyphicon glyphicon-plus"/></span>'),
+        RESULT_DETAILS_BTN_BASE = $('<span class="btn btn-micro btn-details pull-right"><i class="glyphicon glyphicon-plus"/></span>'),
     //jscs:enable maximumLineLength
         RESULT_DETAILS_BASE = $('<div/>', {class: 'messages collapse'}),
         NODE_ENTRY_BASE = $('<div/>', {class: 'constraint-check-result'}),
     //jscs:disable maximumLineLength
-        NODE_BTN_BASE = $('<span class="btn btn-micro btn-node pull-left"><i class="glyphicon glyphicon-eye-open glyphicon glyphicon-eye-open"/></span>'),
+        NODE_BTN_BASE = $('<span class="btn btn-micro btn-node pull-left"><i class="glyphicon glyphicon-link"/></span>'),
     //jscs:enable maximumLineLength
         MESSAGE_ENTRY_BASE = $('<div class="msg"><div class="msg-title"></div><div class="msg-body"></div></div>'),
     // FIXME: MAGIC do not we have a GUID regexp somewhere???

--- a/src/client/js/Dialogs/Merge/MergeDialog.js
+++ b/src/client/js/Dialogs/Merge/MergeDialog.js
@@ -40,6 +40,7 @@ define([
             if (mergeResult) {
                 this._addDiff(mergeResult);
                 this._btnResolve.show();
+                this._btnAbort.show();
             } else {
                 this._warningNoDiff.show();
                 this._btnOk.show();
@@ -76,6 +77,11 @@ define([
                 mergeDialog.show(err, result);
             });
         });
+
+        this.btnAbort.on('click', function () {
+            //just simply exit the dialog
+            self.hide();
+        });
     };
 
     MergeDialog.prototype._initDialog = function () {
@@ -91,6 +97,7 @@ define([
         this._diffPlaceholder = this._dialog.find('.diff-placeholder');
 
         this._btnResolve = this._dialog.find('.btn-resolve');
+        this._btnAbort = this._dialog.find('.btn-abort');
         this._btnOk = this._dialog.find('.btn-ok');
 
         this._alertSuccess.hide();
@@ -98,6 +105,7 @@ define([
 
         this._warningNoDiff.hide();
         this._btnResolve.hide();
+        this._btnAbort.hide();
         this._btnOk.hide();
     };
 
@@ -107,10 +115,10 @@ define([
             conflictsE,
             conflictItem,
             conflictItemTemplate = $('<div class="row conflict-item">' +
-                                     '<div class="col-md-6 path"></div>' +
-                                     '<div class="col-md-3 value-theirs"></div>' +
-                                     '<div class="col-md-3 value-mine"></div>' +
-                                     '</div>'),
+                '<div class="col-md-6 path"></div>' +
+                '<div class="col-md-3 value-theirs"></div>' +
+                '<div class="col-md-3 value-mine"></div>' +
+                '</div>'),
             conflictItemE,
             mineText,
             valueMineE,
@@ -123,7 +131,11 @@ define([
         // regular expression matching:
         // /1/2/3/4/5/attr/name -> '/1/2/3/4/5' -> nodeId
         // /attr/name -> '' -> root node
-            pathRegExp = /((\/\d+)*)/;
+            pathRegExp = /((\/\d+)*)/,
+            getParentPath = function (path) {
+                //in case of root object it return the root itself
+                return path.slice(0, path.lastIndexOf('/'));
+            };
 
         this.resolution = mergeResult;
 
@@ -167,15 +179,15 @@ define([
                 conflictItemE.find('.path').text(conflictItem.theirs.path);
 
                 linkTheirs = '?project=' + encodeURIComponent(self._client.getActiveProjectId()) +
-                             '&commit=' + encodeURIComponent(mergeResult.theirCommitHash) +
-                             // FIXME: regexp parses out the path
-                             '&node=' + encodeURIComponent(pathRegExp.exec(conflictItem.theirs.path)[0]);
+                    '&commit=' + encodeURIComponent(mergeResult.theirCommitHash) +
+                        // FIXME: regexp parses out the path
+                    '&node=' + encodeURIComponent(getParentPath(pathRegExp.exec(conflictItem.theirs.path)[0])) +
+                    '&selection=' + encodeURIComponent(pathRegExp.exec(conflictItem.theirs.path)[0]);
 
                 valueTheirsE = $('<div>' +
-                                 // FIXME: should we use fa-link instead ???
-                                 '<a class="fa fa-eye" href="' + linkTheirs + '" target="_blank" tooltip="Open"></a>' +
-                                 '<span>' + JSON.stringify(conflictItem.theirs.value) + '</span>' +
-                                 '</div>');
+                    '<a class="glyphicon glyphicon-link" href="' + linkTheirs + '" target="_blank" tooltip="Open"></a>' +
+                    '<span>' + JSON.stringify(conflictItem.theirs.value) + '</span>' +
+                    '</div>');
 
                 conflictItemE.find('.value-theirs').append(valueTheirsE);
 
@@ -186,14 +198,15 @@ define([
                 }
 
                 linkMine = '?project=' + encodeURIComponent(self._client.getActiveProjectId()) +
-                           '&commit=' + encodeURIComponent(mergeResult.myCommitHash) +
-                           '&node=' + encodeURIComponent(pathRegExp.exec(conflictItem.mine.path)[0]);  // FIXME: regexp parses out the path
-
+                    '&commit=' + encodeURIComponent(mergeResult.myCommitHash) +
+                        // FIXME: regexp parses out the path
+                    '&node=' + encodeURIComponent(getParentPath(pathRegExp.exec(conflictItem.mine.path)[0])) +
+                    '&selection=' + encodeURIComponent(pathRegExp.exec(conflictItem.mine.path)[0]);
                 valueMineE = $('<div>' +
-                               // FIXME: should we use fa-link instead ???
-                               '<a class="fa fa-eye" href="' + linkMine + '"  target="_blank" tooltip="Open"></a>' +
-                               '<span>' + mineText + '</span>' +
-                               '</div>');
+                        // FIXME: should we use fa-link instead ???
+                    '<a class="glyphicon glyphicon-link" href="' + linkMine + '"  target="_blank" tooltip="Open"></a>' +
+                    '<span>' + mineText + '</span>' +
+                    '</div>');
 
                 conflictItemE.find('.value-mine').append(valueMineE);
 

--- a/src/client/js/Dialogs/Merge/templates/MergeDialog.html
+++ b/src/client/js/Dialogs/Merge/templates/MergeDialog.html
@@ -19,6 +19,7 @@
                 <div class="diff-placeholder"></div>
             </div>
             <div class="modal-footer">
+                <button href="#" class="btn btn-danger btn-abort" data-dismiss="modal">Abort</button>
                 <button href="#" class="btn btn-primary btn-resolve" data-dismiss="modal">Resolve</button>
                 <button href="#" class="btn btn-primary btn-ok" data-dismiss="modal">Ok</button>
             </div>


### PR DESCRIPTION
MergeDialog: now the link on the conflict dialog will pop up a new webgme that points to the parent of the actual node in conflict and select the node in conflict
MergeDialog: an Abort button have been added to the conflict dialog
MergeDialog: the buttons to show node in conflict now have the glyphicon-link icon
ConstraintResult: the button to show conflicting node has glyphicon-link icon