### PR TITLE
Make nodemanager more suitable for tests. Storage makeCommit should work with referenced rootNode.

### DIFF
--- a/src/common/storage/project/project.js
+++ b/src/common/storage/project/project.js
@@ -72,7 +72,7 @@ define([
         };
     }
 
-    Project.prototype = Object.create(ProjectInterface);
+    Project.prototype = Object.create(ProjectInterface.prototype);
     Project.prototype.constructor = Project;
 
     return Project;

--- a/src/common/storage/storageclasses/objectloaders.js
+++ b/src/common/storage/storageclasses/objectloaders.js
@@ -7,6 +7,9 @@
  * that is loaded when the bucket is full (gmeConfig.storage.loadBucketSize) or when a
  * timeout is triggered (gmeConfig.storage.loadBucketTimer).
  *
+ * N.B. when used directly, the user need to make sure that the same object (by hash) is not loaded within in the
+ * same bucket, (see the project-cache for example).
+ *
  * @author pmeijer / https://github.com/pmeijer
  */
 

--- a/src/plugin/climanager.js
+++ b/src/plugin/climanager.js
@@ -10,6 +10,13 @@ var PluginNodeManagerBase = require('./nodemanagerbase'),
     BlobFSBackend = require('../server/middleware/blob/BlobFSBackend'),
     BlobRunPluginClient = require('../server/middleware/blob/BlobRunPluginClient');
 
+/**
+ * Creates a new instance of PluginCliManager
+ * @param {UserProject} [project] - optional default project, can be passed during initialization of plugin too.
+ * @param {object} - mainLogger - logger for manager, plugin-logger will fork from this logger.
+ * @param {object} gmeConfig - global configuration
+ * @constructor
+ */
 function PluginCliManager(project, mainLogger, gmeConfig) {
     var blobBackend = new BlobFSBackend(gmeConfig),
         blobClient = new BlobRunPluginClient(blobBackend);

--- a/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
+++ b/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
@@ -52,6 +52,14 @@ define(['plugin/PluginConfig', 'plugin/PluginBase'], function (PluginConfig, Plu
                 value: false,
                 valueType: 'boolean',
                 readOnly: false
+            },
+            {
+                name: 'save',
+                displayName: 'Should save the model',
+                description: 'Will update the model if true',
+                value: true,
+                valueType: 'boolean',
+                readOnly: false
             }
         ];
     };
@@ -96,13 +104,23 @@ define(['plugin/PluginConfig', 'plugin/PluginBase'], function (PluginConfig, Plu
         // This will save the changes. If you don't want to save;
         // exclude self.save and call callback directly from this scope.
         self.result.setSuccess(true);
-        self.save('added obj', function (err, status) {
-            if (err) {
-                self.result.setSuccess(false);
-                self.result.setError(err);
-            }
-            self.logger.info('saved returned with status', status);
+        if (currentConfiguration.save === true) {
+            self.save('added obj', function (err, status) {
+                if (err) {
+                    self.result.setSuccess(false);
+                    self.result.setError(err);
+                }
+                self.logger.info('saved returned with status', status);
 
+                if (currentConfiguration.shouldFail) {
+                    self.result.setSuccess(false);
+                    self.result.setError('Failed on purpose.');
+                    callback('Failed on purpose.', self.result);
+                } else {
+                    callback(null, self.result);
+                }
+            });
+        } else {
             if (currentConfiguration.shouldFail) {
                 self.result.setSuccess(false);
                 self.result.setError('Failed on purpose.');
@@ -110,7 +128,7 @@ define(['plugin/PluginConfig', 'plugin/PluginBase'], function (PluginConfig, Plu
             } else {
                 callback(null, self.result);
             }
-        });
+        }
 
     };
 

--- a/src/plugin/nodemanagerbase.js
+++ b/src/plugin/nodemanagerbase.js
@@ -8,13 +8,13 @@
 var Core = requireJS('common/core/core'),
     PluginResult = requireJS('plugin/PluginResult'),
     PluginMessage = requireJS('plugin/PluginMessage'),
+    ProjectInterface = requireJS('common/storage/project/interface'),
     Q = require('q');
 
 /**
- * TODO: A single instance should be able to run on different projects (and cores)..
  *
  * @param blobClient
- * @param project
+ * @param [project]
  * @param mainLogger
  * @param gmeConfig
  * @constructor
@@ -23,7 +23,6 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
     var self = this;
 
     this.logger = mainLogger.fork('PluginNodeManagerBase');
-    this.core = null;
 
     /**
      *
@@ -32,86 +31,136 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
      * @param {object} context
      * @param {string} context.commitHash - commit from which to start the plugin.
      * @param {string} context.branchName - name of branch that should be updated
+     * @param {ProjectInterface} [context.project=project] - project instance if different from the one passed in ctor.
      * @param {string} [context.activeNode=''] - path to active node
      * @param {string[]} [context.activeSelection=[]] - paths to selected nodes.
-     * @param callback
+     * @param {function} callback
      */
     this.executePlugin = function (pluginName, pluginConfig, context, callback) {
-        var plugin,
-            Plugin,
-            pluginLogger = self.logger.fork('plugin:' + pluginName);
+        var plugin;
 
         try {
-            Plugin = getPlugin(pluginName);
+            plugin = self.initializePlugin(pluginName);
         } catch (err) {
             callback(err.toString(), self.getPluginErrorResult(pluginName, 'Failed to load plugin.'));
             return;
         }
-        plugin = new Plugin();
-        plugin.initialize(pluginLogger, blobClient, gmeConfig);
 
-        if (!pluginConfig) {
-            pluginConfig = plugin.getDefaultConfig();
-        }
-        //TODO: Check that a passed config is consistent with the structure..
-        plugin.setCurrentConfig(pluginConfig);
-
-        this.core = new Core(project, {
-            globConf: gmeConfig,
-            logger: pluginLogger.fork('core')
-        });
-
-        self.loadContext(context)
-            .then(function (pluginContext) {
-                var startTime = (new Date()).toISOString(),
-                    mainCallbackCalls = 0,
-                    multiCallbackHandled = false;
-
-                self.logger.debug('context loaded');
-                pluginContext.project = project;
-                pluginContext.branch = null; // Branch is only applicable on client side.
-                pluginContext.projectName = project.projectId;
-                pluginContext.core = self.core;
-
-                plugin.configure(pluginContext); // (This does not modify pluginContext.)
-
-                self.logger.debug('plugin configured, invoking main');
-                plugin.main(function (err, result) {
-                    var stackTrace;
-                    if (result) {
-                        self.logger.debug('plugin main callback called', {result: result.serialize()});
-                    }
-                    mainCallbackCalls += 1;
-                    // set common information (meta info) about the plugin and measured execution times
-                    result.setFinishTime((new Date()).toISOString());
-                    result.setStartTime(startTime);
-
-                    result.setPluginName(plugin.getName());
-
-                    if (mainCallbackCalls > 1) {
-                        stackTrace = new Error().stack;
-                        self.logger.error('The main callback is being called more than once!', {metadata: stackTrace});
-                        result.setError('The main callback is being called more than once!');
-                        if (multiCallbackHandled === true) {
-                            plugin.createMessage(null, stackTrace);
-                            return;
-                        }
-                        multiCallbackHandled = true;
-                        result.setSuccess(false);
-                        plugin.createMessage(null, 'The main callback is being called more than once.');
-                        plugin.createMessage(null, stackTrace);
-                        callback('The main callback is being called more than once!', result);
-                    } else {
-                        result.setError(err);
-                        callback(err, result);
-                    }
-                });
+        self.configurePlugin(plugin, pluginConfig, context)
+            .then(function () {
+                self.runPluginMain(plugin, callback);
             })
             .catch(function (err) {
                 var pluginResult = self.getPluginErrorResult(pluginName, 'Exception got thrown');
                 self.logger.error(err.stack);
                 callback(err.message, pluginResult);
             });
+    };
+
+    /**
+     *
+     * @param {string} - pluginName
+     * @returns {object} the initialized plugin.
+     */
+    this.initializePlugin = function (pluginName) {
+        var plugin,
+            Plugin,
+            pluginLogger = self.logger.fork('plugin:' + pluginName);
+
+        Plugin = getPlugin(pluginName);
+        plugin = new Plugin();
+        plugin.initialize(pluginLogger, blobClient, gmeConfig);
+
+        return plugin;
+    };
+
+    /**
+     *
+     * @param {object} plugin
+     * @param {object} pluginConfig - configuration for the plugin.
+     * @param {object} context
+     * @param {string} context.commitHash - commit from which to start the plugin.
+     * @param {string} context.branchName - name of branch that should be updated
+     * @param {ProjectInterface} [context.project=project] - project instance if different from the one passed in ctor.
+     * @param {string} [context.activeNode=''] - path to active node
+     * @param {string[]} [context.activeSelection=[]] - paths to selected nodes.
+     * @param {function} callback
+     * @returns {promise}
+     */
+    this.configurePlugin = function (plugin, pluginConfig, context, callback) {
+        var deferred = Q.defer();
+        if (!pluginConfig) {
+            pluginConfig = plugin.getDefaultConfig();
+        }
+
+        //TODO: Check that a passed config is consistent with the structure..
+        plugin.setCurrentConfig(pluginConfig);
+
+        context.project = context.project || project;
+
+        if (context.project instanceof ProjectInterface === false) {
+            deferred.reject(new Error('project is not an instance of ProjectInterface, pass it via context or set it ' +
+                'in the constructor of NodeManagerBase.'));
+        } else {
+            self.loadContext(context)
+                .then(function (pluginContext) {
+                    plugin.configure(pluginContext);
+                    deferred.resolve();
+                })
+                .catch(deferred.reject);
+        }
+
+        return deferred.promise.nodeify(callback);
+    };
+
+    /**
+     *
+     * @param plugin
+     * @param callback
+     */
+    this.runPluginMain = function (plugin, callback) {
+        var startTime = (new Date()).toISOString(),
+            mainCallbackCalls = 0,
+            multiCallbackHandled = false;
+
+        self.logger.debug('plugin configured, invoking main');
+
+        if (plugin.isConfigured === false) {
+            callback('Plugin is not configured.', self.getPluginErrorResult(plugin.getName(),
+                'Plugin is not configured.'));
+            return;
+        }
+
+        plugin.main(function (err, result) {
+            var stackTrace;
+            if (result) {
+                self.logger.debug('plugin main callback called', {result: result.serialize()});
+            }
+            mainCallbackCalls += 1;
+            // set common information (meta info) about the plugin and measured execution times
+            result.setFinishTime((new Date()).toISOString());
+            result.setStartTime(startTime);
+
+            result.setPluginName(plugin.getName());
+
+            if (mainCallbackCalls > 1) {
+                stackTrace = new Error().stack;
+                self.logger.error('The main callback is being called more than once!', {metadata: stackTrace});
+                result.setError('The main callback is being called more than once!');
+                if (multiCallbackHandled === true) {
+                    plugin.createMessage(null, stackTrace);
+                    return;
+                }
+                multiCallbackHandled = true;
+                result.setSuccess(false);
+                plugin.createMessage(null, 'The main callback is being called more than once.');
+                plugin.createMessage(null, stackTrace);
+                callback('The main callback is being called more than once!', result);
+            } else {
+                result.setError(err);
+                callback(err, result);
+            }
+        });
     };
 
     function getPlugin(name) {
@@ -131,15 +180,19 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
         pluginResult.setStartTime((new Date()).toISOString());
         pluginResult.setFinishTime((new Date()).toISOString());
         pluginResult.setError(pluginMessage.message);
+
+        return pluginResult;
     };
 
     /**
      *
      * @param {object} context
+     * @param {object} context.project - project form where to load the context.
      * @param {string} context.commitHash - commit from which to start the plugin.
      * @param {string} context.branchName - name of branch that should be updated
      * @param {string} [context.activeNode=''] - path to active node
      * @param {string[]} [context.activeSelection=[]] - paths to selected nodes.
+     * @param {object} pluginLogger - logger for the plugin.
      */
     this.loadContext = function (context) {
         var deferred = Q.defer(),
@@ -150,14 +203,23 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
                 rootNode: null,
                 activeNode: null,
                 activeSelection: null,
-                META: null
+                META: null,
+
+                project: context.project,
+                projectName: context.project.projectId,
+                core: new Core(context.project, {
+                    globConf: gmeConfig,
+                    logger: self.logger.fork('core')
+                })
             };
+
         self.logger.debug('loading context');
-        Q.ninvoke(project, 'loadObject', context.commitHash)
+
+        Q.ninvoke(pluginContext.project, 'loadObject', context.commitHash)
             .then(function (commitObject) {
                 var rootDeferred = Q.defer();
                 self.logger.debug('commitObject loaded', {metadata: commitObject});
-                self.core.loadRoot(commitObject.root, function (err, rootNode) {
+                pluginContext.core.loadRoot(commitObject.root, function (err, rootNode) {
                     if (err) {
                         rootDeferred.reject(err);
                     } else {
@@ -171,20 +233,20 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
             .then(function (rootNode) {
                 pluginContext.rootNode = rootNode;
                 // Load active node
-                return self.loadNodeByPath(rootNode, context.activeNode || '');
+                return self.loadNodeByPath(pluginContext, context.activeNode || '');
             })
             .then(function (activeNode) {
                 pluginContext.activeNode = activeNode;
                 self.logger.debug('activeNode loaded');
                 // Load active selection
-                return self.loadNodesByPath(pluginContext.rootNode, context.activeSelection || []);
+                return self.loadNodesByPath(pluginContext, context.activeSelection || []);
             })
             .then(function (activeSelection) {
                 pluginContext.activeSelection = activeSelection;
                 self.logger.debug('activeSelection loaded');
                 // Load meta nodes
-                var metaIds = self.core.getMemberPaths(pluginContext.rootNode, 'MetaAspectSet');
-                return self.loadNodesByPath(pluginContext.rootNode, metaIds, true);
+                var metaIds = pluginContext.core.getMemberPaths(pluginContext.rootNode, 'MetaAspectSet');
+                return self.loadNodesByPath(pluginContext, metaIds, true);
             })
             .then(function (metaNodes) {
                 pluginContext.META = metaNodes;
@@ -198,9 +260,9 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
         return deferred.promise;
     };
 
-    this.loadNodeByPath = function (rootNode, path) {
+    this.loadNodeByPath = function (pluginContext, path) {
         var deferred = Q.defer();
-        self.core.loadByPath(rootNode, path, function (err, rootNode) {
+        pluginContext.core.loadByPath(pluginContext.rootNode, path, function (err, rootNode) {
             if (err) {
                 deferred.reject(err);
             } else {
@@ -210,7 +272,7 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
         return deferred.promise;
     };
 
-    this.loadNodesByPath = function (rootNode, nodePaths, returnNameMap) {
+    this.loadNodesByPath = function (pluginContext, nodePaths, returnNameMap) {
         var deferred = Q.defer(),
             len = nodePaths.length,
             error = '',
@@ -227,7 +289,7 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
             if (returnNameMap) {
                 nodes.map(function (node) {
                     //TODO: what if the names are equal?
-                    nameToNode[self.core.getAttribute(node, 'name')] = node;
+                    nameToNode[pluginContext.core.getAttribute(node, 'name')] = node;
                 });
                 deferred.resolve(nameToNode);
             } else {
@@ -250,7 +312,7 @@ function PluginNodeManagerBase(blobClient, project, mainLogger, gmeConfig) {
             allNodesLoadedHandler();
         }
         while (len--) {
-            self.core.loadByPath(rootNode, nodePaths[len], loadedNodeHandler);
+            pluginContext.core.loadByPath(pluginContext.rootNode, nodePaths[len], loadedNodeHandler);
         }
 
         return deferred.promise;

--- a/src/server/storage/memory.js
+++ b/src/server/storage/memory.js
@@ -359,30 +359,6 @@ function Memory(mainLogger, gmeConfig) {
         return deferred.promise.nodeify(callback);
     }
 
-    function getProjectIds(callback) {
-        var deferred = Q.defer();
-
-        if (storage.connected) {
-            var projectIds = [];
-            for (var i = 0; i < storage.length; i += 1) {
-                var key = storage.key(i);
-                var keyArray = key.split(SEPARATOR);
-                ASSERT(keyArray.length === 3);
-                if (keyArray[0] === database) {
-                    if (projectIds.indexOf(keyArray[1]) === -1) {
-                        ASSERT(REGEXP.PROJECT.test(keyArray[1]));
-                        projectIds.push(keyArray[1]);
-                    }
-                }
-            }
-            deferred.resolve(projectIds);
-        } else {
-            deferred.reject(new Error('In-memory database has to be initialized. Call openDatabase first.'));
-        }
-
-        return deferred.promise.nodeify(callback);
-    }
-
     function createProject(projectId, callback) {
         var deferred = Q.defer(),
             project;
@@ -468,8 +444,6 @@ function Memory(mainLogger, gmeConfig) {
 
     this.openDatabase = openDatabase;
     this.closeDatabase = closeDatabase;
-
-    this.getProjectIds = getProjectIds;
 
     this.createProject = createProject;
     this.deleteProject = deleteProject;

--- a/src/server/storage/mongo.js
+++ b/src/server/storage/mongo.js
@@ -385,36 +385,6 @@ function Mongo(mainLogger, gmeConfig) {
         return deferred.promise.nodeify(callback);
     }
 
-    function getProjectIds(callback) {
-        var deferred = Q.defer();
-
-        if (mongo) {
-            Q.ninvoke(mongo, 'collectionNames')
-                .then(function (collections) {
-                    var projectIds = [],
-                        i, p, n;
-
-                    for (i = 0; i < collections.length; i++) {
-                        if (!REGEXP.PROJECT.test(collections[i].name)) {
-                            continue;
-                        }
-                        p = collections[i].name.indexOf('.');
-                        n = collections[i].name.substring(p + 1);
-                        if (n.indexOf('system') === -1 && n.indexOf('.') === -1 && n.indexOf('_') !== 0) {
-                            projectIds.push(n);
-                        }
-                    }
-
-                    deferred.resolve(projectIds);
-                })
-                .catch(deferred.reject);
-        } else {
-            deferred.reject(new Error('Database is not open.'));
-        }
-
-        return deferred.promise.nodeify(callback);
-    }
-
     function deleteProject(projectId, callback) {
         var deferred = Q.defer();
 
@@ -499,8 +469,6 @@ function Mongo(mainLogger, gmeConfig) {
 
     this.openDatabase = openDatabase;
     this.closeDatabase = closeDatabase;
-
-    this.getProjectIds = getProjectIds;
 
     this.openProject = openProject;
     this.deleteProject = deleteProject;

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -58,12 +58,6 @@ function SafeStorage(mongo, logger, gmeConfig, gmeAuth) {
 SafeStorage.prototype = Object.create(Storage.prototype);
 SafeStorage.prototype.constructor = SafeStorage;
 
-SafeStorage.prototype.getProjectIds = function (data, callback) {
-    var deferred = Q.defer();
-    deferred.reject(new Error('getProjectIds is deprecated, use getProjects instead.'));
-    return deferred.promise.nodeify(callback);
-};
-
 /**
  * Returns and array of dictionaries for each project the user has at least read access to.
  * If branches is set, the returned array will be filtered based on if the projects really do exist as
@@ -513,9 +507,10 @@ SafeStorage.prototype.makeCommit = function (data, callback) {
         check(data.commitObject.parents[0] === '' || REGEXP.HASH.test(data.commitObject.parents[0]), deferred,
             'data.commitObject.parents[0] is not a valid hash: ' + data.commitObject.parents[0]) ||
         check(REGEXP.HASH.test(data.commitObject.root), deferred,
-            'data.commitObject.root is not a valid hash: ' + data.commitObject.root) ||
-        check(typeof data.coreObjects[data.commitObject.root] === 'object', deferred,
-            'data.coreObjects[data.commitObject.root] is not an object');
+            'data.commitObject.root is not a valid hash: ' + data.commitObject.root);
+        // Commits without coreObjects is valid now (the assumption is that the rootObject does exist.
+        //check(typeof data.coreObjects[data.commitObject.root] === 'object', deferred,
+        //    'data.coreObjects[data.commitObject.root] is not an object');
     }
 
     if (data.hasOwnProperty('username')) {

--- a/src/server/storage/userproject.js
+++ b/src/server/storage/userproject.js
@@ -140,7 +140,7 @@ function UserProject(dbProject, storage, mainLogger, gmeConfig) {
     };
 }
 
-UserProject.prototype = Object.create(ProjectInterface);
+UserProject.prototype = Object.create(ProjectInterface.prototype);
 UserProject.prototype.constructor = UserProject;
 
 module.exports = UserProject;

--- a/test/common/core/corediff.spec.merge.js
+++ b/test/common/core/corediff.spec.merge.js
@@ -49,7 +49,7 @@ describe('corediff-merge', function () {
                     project.makeCommit(null,
                         [commit],
                         changeObject.rootHash,
-                        [], // no core-objects
+                        persisted.objects,
                         'apply change finished ' + new Date().getTime(),
                         function (err, commitResult) {
                             if (err) {

--- a/test/common/storage/storageclasses/objectloaders.js
+++ b/test/common/storage/storageclasses/objectloaders.js
@@ -214,17 +214,28 @@ describe('storage storageclasses objectloaders', function () {
     });
 
 
-    it('should reach bucket size limit loadObject root three times', function (done) {
+    it('should reach bucket size limit (2) loadObject with three objects', function (done) {
+        var counter = 3,
+            ids = [];
 
-        Q.allSettled(
-            Q.ninvoke(storage, 'loadObject', projectName2Id(projectName), importResult.rootHash),
-            Q.ninvoke(storage, 'loadObject', projectName2Id(projectName), importResult.rootHash),
-            Q.ninvoke(storage, 'loadObject', projectName2Id(projectName), importResult.rootHash)
-        )
-            .then(function (promises) {
-                expect(promises.length).to.equal(0); // FIXME: is this right? no callback called???
-            })
-            .nodeify(done);
+        function objectLoaded(err, obj) {
+            counter -= 1;
+            expect(err).to.equal(null);
+
+            expect(typeof obj).to.equal('object');
+            expect(obj).not.to.equal(null);
+            expect(typeof obj._id).to.equal('string');
+
+            ids.push(obj._id);
+            if (counter === 0) {
+                expect(ids).to.have.members([importResult.rootHash, commitHash1, commitHash2]);
+                done();
+            }
+        }
+
+        storage.loadObject(projectName2Id(projectName), importResult.rootHash, objectLoaded);
+        storage.loadObject(projectName2Id(projectName), commitHash1, objectLoaded);
+        storage.loadObject(projectName2Id(projectName), commitHash2, objectLoaded);
     });
 
 

--- a/test/plugin/nodemanagerbase.spec.js
+++ b/test/plugin/nodemanagerbase.spec.js
@@ -1,0 +1,254 @@
+/*jshint node:true, mocha:true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+var testFixture = require('../_globals');
+
+describe('climanager', function () {
+    'use strict';
+
+    var pluginName = 'MinimalWorkingExample',
+        logger = testFixture.logger.fork('climanager'),
+        gmeConfig = testFixture.getGmeConfig(),
+        storage,
+        expect = testFixture.expect,
+        Q = testFixture.Q,
+        PluginCliManager = require('../../src/plugin/climanager'),
+        project,
+        projectName = 'cliManagerProject',
+        branchName = 'master',
+        projectId = testFixture.projectName2Id(projectName),
+        commitHash,
+
+        gmeAuth;
+
+    before(function (done) {
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                var importParam = {
+                    projectSeed: './seeds/EmptyProject.json',
+                    projectName: projectName,
+                    branchName: branchName,
+                    logger: logger,
+                    gmeConfig: gmeConfig
+                };
+
+                return testFixture.importProject(storage, importParam);
+            })
+            .then(function (importResult) {
+                project = importResult.project;
+                commitHash = importResult.commitHash;
+                return project.createBranch('b1', commitHash);
+            })
+            .then(function () {
+                return project.createBranch('b2', commitHash);
+            })
+            .nodeify(done);
+    });
+
+    after(function (done) {
+        Q.allSettled([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
+            .nodeify(done);
+    });
+
+    it('should initializePlugin with an existing plugin', function () {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            plugin = manager.initializePlugin(pluginName);
+        expect(typeof plugin.main).to.equal('function');
+    });
+
+    it('should throw exception when initializePlugin on a non-existing plugin', function () {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            initBogus = function () {
+                manager.initializePlugin('bogusPlugin');
+            };
+        expect(initBogus).to.throw(Error, 'Tried loading');
+    });
+
+    it('should configurePlugin using default project from manager', function (done) {
+        var manager = new PluginCliManager(project, logger, gmeConfig),
+            pluginConfig = {},
+            context = {
+                commitHash: commitHash,
+                branchName: branchName
+            },
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.configurePlugin(plugin, pluginConfig, context)
+            .then(function () {
+                expect(plugin.isConfigured).to.equal(true);
+                expect(plugin.project).to.equal(project);
+            })
+            .nodeify(done);
+    });
+
+    it('should configurePlugin using project passed via context', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {},
+            context = {
+                commitHash: commitHash,
+                branchName: branchName,
+                project: project
+            },
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.configurePlugin(plugin, pluginConfig, context)
+            .then(function () {
+                expect(plugin.isConfigured).to.equal(true);
+                expect(plugin.project).to.equal(project);
+            })
+            .nodeify(done);
+    });
+
+    it('should fail configurePlugin with no default project in manager and no project in context ', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {},
+            context = {
+                commitHash: commitHash,
+                branchName: branchName
+            },
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.configurePlugin(plugin, pluginConfig, context)
+            .then(function () {
+                done(new Error('Should have failed to configure with no project'));
+            })
+            .catch(function (err) {
+                expect(typeof err).to.equal('object');
+                expect(err.message).to.contain('project is not an instance of ProjectInterface');
+                expect(plugin.isConfigured).to.equal(false);
+                done();
+            })
+            .done();
+    });
+
+    it('should initialize, configure and run main', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {
+                save: false
+            },
+            context = {
+                project: project,
+                commitHash: commitHash,
+                branchName: branchName
+            },
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.configurePlugin(plugin, pluginConfig, context)
+            .then(function () {
+                expect(plugin.isConfigured).to.equal(true);
+                expect(plugin.project).to.equal(project);
+                manager.runPluginMain(plugin, function (err, pluginResult) {
+                    expect(err).to.equal(null);
+                    expect(pluginResult.success).to.equal(true);
+                    done();
+                });
+            })
+            .catch(done);
+    });
+
+    it('should executePlugin', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {
+                save: false
+            },
+            context = {
+                project: project,
+                commitHash: commitHash,
+                branchName: branchName
+            };
+
+        manager.executePlugin(pluginName, pluginConfig, context, function (err, pluginResult) {
+            expect(err).to.equal(null);
+            expect(pluginResult.success).to.equal(true);
+            done();
+        });
+    });
+
+    it('should fail executePlugin with pluginResult when no default project in manager and no project in context',
+        function (done) {
+            var manager = new PluginCliManager(null, logger, gmeConfig),
+                pluginConfig = {},
+                context = {
+                    commitHash: commitHash,
+                    branchName: branchName
+                };
+
+            manager.executePlugin(pluginName, pluginConfig, context, function (err, pluginResult) {
+                expect(typeof err).to.equal('string');
+                expect(typeof pluginResult).to.equal('object');
+                expect(pluginResult.success).to.equal(false);
+                expect(err).to.contain('project is not an instance of ProjectInterface');
+                done();
+            });
+        }
+    );
+
+    it('should fail with error during runPluginMain if plugin not configured', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.runPluginMain(plugin, function (err, pluginResult) {
+            expect(pluginResult.success).to.equal(false);
+            expect(err).to.equal('Plugin is not configured.');
+
+            done();
+        });
+    });
+
+    it('should configure a plugin twice and use latest configuration', function (done) {
+        var manager = new PluginCliManager(project, logger, gmeConfig),
+            context = {
+                commitHash: commitHash,
+                branchName: 'b1'
+            },
+            plugin = manager.initializePlugin(pluginName);
+
+        manager.configurePlugin(plugin, {save: false}, context)
+            .then(function () {
+                var newContext = {
+                    commitHash: commitHash,
+                    branchName: 'b2'
+                };
+                expect(plugin.isConfigured).to.equal(true);
+                expect(plugin.project).to.equal(project);
+                expect(plugin.branchName).to.equal('b1');
+                expect(plugin.getCurrentConfig().save).to.equal(false);
+
+                return manager.configurePlugin(plugin, {save: true}, newContext);
+            })
+            .then(function () {
+                expect(plugin.isConfigured).to.equal(true);
+                expect(plugin.project).to.equal(project);
+                expect(plugin.branchName).to.equal('b2');
+                expect(plugin.getCurrentConfig().save).to.equal(true);
+
+                manager.runPluginMain(plugin, function (err, pluginResult) {
+                    var newCommitHash;
+                    expect(pluginResult.success).to.equal(true);
+                    expect(pluginResult.commits.length).to.equal(2);
+                    newCommitHash = pluginResult.commits[1].commitHash;
+
+                    project.getBranchHash('b1')
+                        .then(function (b1Hash) {
+                            expect(b1Hash).to.equal(commitHash);
+                            return project.getBranchHash('b2');
+                        })
+                        .then(function (b2Hash) {
+                            expect(b2Hash).to.equal(newCommitHash);
+                        })
+                        .nodeify(done);
+                });
+            })
+            .catch(done);
+    });
+});


### PR DESCRIPTION
WIP PluginNodeManagerBase can take a new project
when configuring a plugin.

WIP Remove getProjectIds from storage.

WIP Fix merge tests.

WIP allow makeCommit without passing rootObject.

WIP Use different hashes for loadObject and do not
use promises in the test.