### PR TITLE
Fix double base pointer creation

### DIFF
--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -965,7 +965,7 @@ define(['common/util/canon',
             for (i = 0; i < keys.length; i++) {
                 if (pointerDiff[keys[i]] === TODELETESTRING) {
                     _core.deletePointer(node, keys[i]);
-                } else if (diff.removed !== false) {
+                } else if (diff.removed !== false || keys[i] !== 'base') {
                     done = setPointer(node, keys[i], pointerDiff[keys[i]]);
                 }
             }

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -897,7 +897,7 @@ define(['common/util/canon',
                 }
                 applyAttributeChanges(n, nodeDiff.attr || {});
                 applyRegistryChanges(n, nodeDiff.reg || {});
-                done = applyPointerChanges(n, nodeDiff.pointer || {});
+                done = applyPointerChanges(n, nodeDiff);
                 done = TASYNC.call(applySetChanges, n, nodeDiff.set || {}, done);
                 if (nodeDiff.meta) {
                     delete nodeDiff.meta.empty;
@@ -957,14 +957,15 @@ define(['common/util/canon',
             }, targetNode);
         }
 
-        function applyPointerChanges(node, pointerDiff) {
+        function applyPointerChanges(node, diff) {
             var done,
+                pointerDiff = diff.pointer || {},
                 keys = Object.keys(pointerDiff),
                 i;
             for (i = 0; i < keys.length; i++) {
                 if (pointerDiff[keys[i]] === TODELETESTRING) {
                     _core.deletePointer(node, keys[i]);
-                } else {
+                } else if (diff.removed !== false) {
                     done = setPointer(node, keys[i], pointerDiff[keys[i]]);
                 }
             }


### PR DESCRIPTION
Now when applying the node data, core will not add the base pointer as it already did that when it created the empty new object.

Fix has to be transferred to the correction release 0.13.1 as well.