### PR TITLE
Various fixes to make tests succeed.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -57,14 +57,6 @@ var testFixture = require('./test/_globals.js'),
             return storage.openDatabase();
         })
         .then(function () {
-            // Delete the projects to be imported
-            function deleteProject(projectInfo) {
-                return testFixture.forceDeleteProject(storage, gmeAuth, projectInfo.name);
-            }
-
-            return Q.all(PROJECTS_TO_IMPORT.map(deleteProject));
-        })
-        .then(function () {
             // Import all the projects.
             function importProject(projectInfo) {
                 var branchName = projectInfo.hasOwnProperty('branches') ?

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -174,22 +174,19 @@ function GMEAuth(session, gmeConfig) {
             })
             .then(function (collection_) {
                 collectionDeferred.resolve(collection_);
-                return _prepareGuestAccount();
-            })
-            .then(function () {
-                //    return Q.ninvoke(db, 'collection', _organizationCollectionName);
-                //})
-                //.then(function (organizationCollection_) {
-                //    organizationCollectionDeferred.resolve(organizationCollection_);
                 return Q.ninvoke(db, 'collection', _projectCollectionName);
             })
             .then(function (projectCollection_) {
                 projectCollectionDeferred.resolve(projectCollection_);
+                return _prepareGuestAccount();
+            })
+            .then(function () {
                 return self;
             })
             .catch(function (err) {
                 logger.error(err);
                 collectionDeferred.reject(err);
+                projectCollectionDeferred.reject(err);
                 throw err;
             })
             .nodeify(callback);
@@ -201,7 +198,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function unload(callback) {
-        return collection
+        return Q.all([collection, projectCollection])
             .finally(function () {
                 return Q.ninvoke(db, 'close');
             })
@@ -934,7 +931,7 @@ function GMEAuth(session, gmeConfig) {
                 }
             })
             .then(function () {
-                collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$pull: {orgs: orgId}});
+                return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$pull: {orgs: orgId}});
             })
             .nodeify(callback);
     }

--- a/test/common/storage/project.spec.js
+++ b/test/common/storage/project.spec.js
@@ -54,11 +54,6 @@ describe('storage project', function () {
                 })
                 .then(function () {
                     return Q.allDone([
-                        safeStorage.deleteProject({projectId: projectName2Id(projectName)})
-                    ]);
-                })
-                .then(function () {
-                    return Q.allDone([
                         testFixture.importProject(safeStorage, {
                             projectSeed: 'seeds/EmptyProject.json',
                             projectName: projectName,

--- a/test/common/storage/socketio/websocket.spec.js
+++ b/test/common/storage/socketio/websocket.spec.js
@@ -55,13 +55,6 @@ describe('storage socketio websocket', function () {
                 })
                 .then(function () {
                     return Q.allDone([
-                        safeStorage.deleteProject({projectId: projectName2Id(projectName)}),
-                        safeStorage.deleteProject({projectId: projectName2Id(projectNameCreate)}),
-                        safeStorage.deleteProject({projectId: projectName2Id(projectNameDelete)})
-                    ]);
-                })
-                .then(function () {
-                    return Q.allDone([
                         testFixture.importProject(safeStorage, {
                             projectSeed: 'seeds/EmptyProject.json',
                             projectName: projectName,

--- a/test/server/logger.spec.js
+++ b/test/server/logger.spec.js
@@ -1,5 +1,4 @@
-/*globals */
-/*jshint node:true, newcap:false*/
+/*jshint node:true, newcap:false, mocha:true*/
 /**
  * @author lattmann / https://github.com/lattmann
  */
@@ -10,8 +9,7 @@ var testFixture = require('../_globals.js');
 describe('server logger', function () {
     'use strict';
 
-    var gmeConfig = testFixture.getGmeConfig(),
-        expect = testFixture.expect,
+    var expect = testFixture.expect,
         Logger = require('../../src/server/logger');
 
     it('should instantiate a logger', function () {

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -407,11 +407,9 @@ describe('standalone server', function () {
 
     describe('http server with authentication turned on', function () {
 
-        var db,
-            collection,
-            safeStorage,
+        var safeStorage,
 
-            gmeauth = require('../../src/server/middleware/auth/gmeauth'),
+            gmeAuth,
             gmeConfig = testFixture.getGmeConfig(),
             logIn = function (callback) {
                 agent.post(serverBaseUrl + '/login?redirect=%2F')
@@ -472,18 +470,12 @@ describe('standalone server', function () {
             gmeConfig.authentication.enable = true;
             gmeConfig.authentication.allowGuests = false;
 
-            dbConn = testFixture.clearDBAndGetGMEAuth(gmeConfig, [project, unauthorizedProject])
+            dbConn = testFixture.clearDBAndGetGMEAuth(gmeConfig)
                 .then(function (gmeAuth_) {
-                    gmeauth = gmeAuth_;
-                    safeStorage = testFixture.getMongoStorage(logger, gmeConfig, gmeauth);
+                    gmeAuth = gmeAuth_;
+                    safeStorage = testFixture.getMongoStorage(logger, gmeConfig, gmeAuth);
                     return safeStorage.openDatabase();
 
-                })
-                .then(function () {
-                    return Q.allDone([
-                        safeStorage.deleteProject({projectId: testFixture.projectName2Id(project)}),
-                        safeStorage.deleteProject({projectId: testFixture.projectName2Id(unauthorizedProject)})
-                    ]);
                 })
                 .then(function () {
                     return Q.allDone([
@@ -500,18 +492,6 @@ describe('standalone server', function () {
                             logger: logger
                         })
                     ]);
-                })
-                .then(function () {
-                    return Q.ninvoke(mongodb.MongoClient, 'connect', gmeConfig.mongo.uri, gmeConfig.mongo.options);
-                })
-                .then(function (db_) {
-                    db = db_;
-                    return Q.allDone([
-                        Q.ninvoke(db, 'collection', testFixture.projectName2Id('ClientCreateProject', 'user'))
-                            .then(function (createdProject) {
-                                return Q.ninvoke(createdProject, 'remove');
-                            })
-                    ]);
                 });
 
             server = WebGME.standaloneServer(gmeConfig);
@@ -520,10 +500,10 @@ describe('standalone server', function () {
 
             Q.allDone([serverReady, dbConn])
                 .then(function () {
-                    return gmeauth.addUser('user', 'user@example.com', 'plaintext', true, {overwrite: true});
+                    return gmeAuth.addUser('user', 'user@example.com', 'plaintext', true, {overwrite: true});
                 })
                 .then(function () {
-                    return gmeauth.authorizeByUserId('user', testFixture.projectName2Id('project'),
+                    return gmeAuth.authorizeByUserId('user', testFixture.projectName2Id('project'),
                         'create', {
                             read: true,
                             write: true,
@@ -532,7 +512,7 @@ describe('standalone server', function () {
                     );
                 })
                 .then(function () {
-                    return gmeauth.authorizeByUserId('user', testFixture.projectName2Id('unauthorized_project'),
+                    return gmeAuth.authorizeByUserId('user', testFixture.projectName2Id('unauthorized_project'),
                         'create', {
                             read: false,
                             write: false,
@@ -544,15 +524,12 @@ describe('standalone server', function () {
         });
 
         after(function (done) {
-            db.close(true, function (err) {
+            server.stop(function (err) {
                 if (err) {
-                    done(err);
-                    return;
+                    logger.error(err);
                 }
-
-                server.stop(function (err) {
-                    done(err);
-                });
+                gmeAuth.unload()
+                    .nodeify(done);
             });
         });
 
@@ -617,7 +594,7 @@ describe('standalone server', function () {
                             socket.disconnect();
                         });
                 }).then(function () {
-                    return gmeauth.getProjectAuthorizationByUserId('user', projectId);
+                    return gmeAuth.getProjectAuthorizationByUserId('user', projectId);
                 }).then(function (authorized) {
                     authorized.should.deep.equal({read: true, write: true, delete: false});
                 }).nodeify(done);
@@ -632,7 +609,7 @@ describe('standalone server', function () {
                             socket.disconnect();
                         });
                 }).then(function () {
-                    return gmeauth.getProjectAuthorizationByUserId('user', projectId);
+                    return gmeAuth.getProjectAuthorizationByUserId('user', projectId);
                 }).then(function (authorized) {
                     authorized.should.deep.equal({read: true, write: true, delete: true});
                 }).nodeify(function (err) {
@@ -723,7 +700,7 @@ describe('standalone server', function () {
                             socket.disconnect();
                         });
                 }).then(function () {
-                    return gmeauth.getProjectAuthorizationByUserId('user', projectId);
+                    return gmeAuth.getProjectAuthorizationByUserId('user', projectId);
                 }).then(function (authorized) {
                     authorized.should.deep.equal({read: true, write: true, delete: true});
                 }).nodeify(done);
@@ -748,5 +725,4 @@ describe('standalone server', function () {
                 });
         });
     });
-})
-;
+});


### PR DESCRIPTION
Bug fix in `gmeAuth.removeUserFromOrganization` return promise.

Drop collections one by one instead of dropDatabase. Fixes timeouts in tests on my windows machine.

Deal with the projectCollection deferred in the same way as collection deferred in gmeAuth.

Use standard (relatively new) functions in testFixtures in some tests.

Clean up some old stuff in tests.