### PR TITLE
Sort getCommits by time field.

### DIFF
--- a/src/server/storage/mongo.js
+++ b/src/server/storage/mongo.js
@@ -242,7 +242,7 @@ function Mongo(mainLogger, gmeConfig) {
                     $lt: before
                 }
             }).limit(number).sort({
-                $natural: -1
+                time: -1
             });
 
             return Q.ninvoke(mongoFind, 'toArray')


### PR DESCRIPTION
Using $natural (i.e. insert to disk order) for getting commits - doesn't make sense after a mongo dump.
Instead sort explicitly by the time field of the commitObject.