### PR TITLE
Add shims for the codemirror css-files.

### DIFF
--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -101,6 +101,10 @@ require.config({
         ],
 
         backbone: ['underscore'],
+        codemirror: [
+            'css!' + document.location.pathname + 'css/codemirror/codemirror.css',
+            'css!' + document.location.pathname + 'css/codemirror/codemirror.bootstrap.css'
+        ],
         'js/util': ['jquery'],
         'js/jquery.WebGME': ['bootstrap'],
         'jquery-dataTables': ['jquery'],

--- a/src/client/lib/codemirror/codemirror.amd.js
+++ b/src/client/lib/codemirror/codemirror.amd.js
@@ -4,8 +4,6 @@
  * Author: Robert Kereskenyi
  */
 
-define(['lib/codemirror/codemirror_javascript.min',
-        'css!/css/codemirror/codemirror.css',
-        'css!/css/codemirror/codemirror.bootstrap.css'], function () {
+define(['lib/codemirror/codemirror_javascript.min'], function () {
     return CodeMirror;
 });


### PR DESCRIPTION
Fixes the following bug:

If webgme is used as a library two resources are failed to get downloaded:

```
2015-07-29T14:44:43.899Z - warn: [gme:server:standalone] expressFileSending failed for: /Users/zsolt/BitBucket/mms-webcyphy/public/apps/mmsApp/css/codemirror/codemirror.css: Error: ENOENT, stat '/Users/zsolt/BitBucket/mms-webcyphy/public/apps/mmsApp/css/codemirror/codemirror.css'
   at Error (native)


2015-07-29T14:44:43.900Z - warn: [gme:server:standalone] expressFileSending failed for: /Users/zsolt/BitBucket/mms-webcyphy/public/apps/mmsApp/css/codemirror/codemirror.bootstrap.css: Error: ENOENT, stat '/Users/zsolt/BitBucket/mms-webcyphy/public/apps/mmsApp/css/codemirror/codemirror.bootstrap.css'
   at Error (native)

```