### PR TITLE
Fixes socket.io transport issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "process": "=0.11.1",
     "q": "=1.4.1",
     "requirejs": "=2.1.18",
-    "socket.io": "lattmann/socket.io#3a824239cbe100225f1721e8a053a85fbd289dce",
-    "socket.io-client": "lattmann/socket.io-client#bb0baf236414e05a3548c1003b3a5f13a8042188",
+    "socket.io": "=1.3.2",
+    "socket.io-client": "=1.3.2",
     "superagent": "=1.2.0",
     "unzip": "=0.1.11",
     "winston": "=1.0.0"


### PR DESCRIPTION
Rollback to socket.io version 1.3.2 as later versions not able to setup websocket transport for communication under Safari and polling has problems with 'attachment' http requests during polling session.