### PR TITLE
Fixed error with async routing queues. Fixes #541

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager3.js
+++ b/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager3.js
@@ -487,10 +487,11 @@ define([
         }
     };
 
-    ConnectionRouteManager3.prototype._updateBoxConnectionAreas = function (objId, boxObject) {
+    ConnectionRouteManager3.prototype._updateBoxConnectionAreas = function (objId) {
         var areas = this.diagramDesigner.items[objId].getConnectionAreas() || [],
             newIds = {},
             connInfo = [],
+            boxObject = this._autorouterBoxes[objId],
             id,
             j;
 


### PR DESCRIPTION
This was introduced when fixing #447 as this required the removal
of q for a promise-like implementation that resolved the callbacks
synchronously rather than simply putting the callbacks on the JS
event queue