### PR TITLE
Replaced deepCopy with explicit copy of child array

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/AutoRouter.Utils.js
+++ b/src/client/js/Widgets/DiagramDesigner/AutoRouter.Utils.js
@@ -854,24 +854,6 @@ define([
         return result;
     };
 
-    /**
-     * Perform a deep copy of an object
-     *
-     * @param {Object} obj
-     * @return {undefined}
-     */
-    var deepCopy = function (obj) {
-        var res = obj instanceof Array ? [] : {};
-        for (var k in obj) {
-            if (typeof obj[k] === 'object') {
-                res[k] = deepCopy(obj[k]);
-            } else {
-                res[k] = obj[k];
-            }
-        }
-        return res;
-    };
-
     var pick = function(keys, obj) {
         var res = {};
         for (var i = keys.length; i--;) {
@@ -925,7 +907,6 @@ define([
         stringify: stringify,
         floatEquals: floatEquals,
         roundTrunc: roundTrunc,
-        deepCopy: deepCopy,
         toArray: toArray,
         nop: nop,
         pick: pick 

--- a/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
+++ b/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
@@ -71,25 +71,27 @@ var startWorker = function() {
 
         AutoRouterWorker.prototype._handleMessage = function(msg) {
             var response,
+                action = msg[0],
                 result;
 
-            response = Utils.deepCopy(msg);
+            response = [action, msg[1].slice()];  // Copy the input args
+
             // If routing async, decorate the request
-            if (msg[0] === 'routeAsync') {
+            if (action === 'routeAsync') {
                 // Send getPathPoints response for each path on each update
                 msg[1] = [{callback: this._updatePaths.bind(this),
                            first: this._updatePaths.bind(this)}];
             }
 
             try {
-                result = this._invokeAutoRouterMethodUnsafe.apply(this, msg.slice());
+                result = this._invokeAutoRouterMethodUnsafe.apply(this, msg);
             } catch(e) {
                 // Send error message
                 worker.postMessage(['BugReplayList', this._getActionSequence()]);
             }
 
             response.push(result);
-            if (this.respondTo[msg[0]]) {
+            if (this.respondTo[action]) {
                 this.logger.debug('Response:', response);
                 worker.postMessage(response);
             }

--- a/test-karma/client/js/autorouter.spec.js
+++ b/test-karma/client/js/autorouter.spec.js
@@ -1042,18 +1042,6 @@ describe('AutoRouter', function () {
             });
         });
 
-        describe('deepCopy tests', function () {
-            it('should copy nested arrays', function() {
-                var inner = [0,1],
-                    array = [0, inner],
-                    result = arUtils.deepCopy(array);
-
-                inner.pop();
-                assert(result[1].length === 2, 
-                    'Nested array should have length 2 but has length: '+result[1].length);
-            });
-        });
-
         describe('floatEquals tests', function () {
             it('should return true for 8, 8.09', function() {
                 assert(arUtils.floatEquals(8, 8.09));


### PR DESCRIPTION
There was a nested array that needed to be deep copied wrt the
arrays but the deepCopy was trying to copy the items in the array
(in which there was a circular reference). It now explicitly copies
the child array with `.slice()`