### PR TITLE
Fixes #371 property browser now reacts to every selection change also in splitview

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -1673,12 +1673,6 @@ define(['js/logger',
             }
         }
 
-        //nobody is selected on the canvas
-        //set the active selection to the opened guy
-        if (gmeIDs.length === 0 && this._memberListContainerID) {
-            gmeIDs.push(this._memberListContainerID);
-        }
-
         WebGMEGlobal.State.registerActiveSelection(gmeIDs);
     };
 

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -586,12 +586,6 @@ define(['js/logger',
         this.diagramDesigner.toolbarItems.ddbtnConnectionLineType.enabled(onlyConnectionTypeSelected);
         this.diagramDesigner.toolbarItems.ddbtnConnectionLineWidth.enabled(onlyConnectionTypeSelected);
 
-        //nobody is selected on the canvas
-        //set the active selection to the opened guy
-        if (gmeIDs.length === 0 && this.metaAspectContainerNodeID) {
-            gmeIDs.push(this.metaAspectContainerNodeID);
-        }
-
         WebGMEGlobal.State.registerActiveSelection(gmeIDs);
     };
 

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -781,12 +781,6 @@ define(['js/logger',
 
         this.$btnConnectionRemoveSegmentPoints.enabled(onlyConnectionSelected);
 
-        //nobody is selected on the canvas
-        //set the active selection to the opened guy
-        if (gmeIDs.length === 0 && (this.currentNodeInfo.id || this.currentNodeInfo.id === CONSTANTS.PROJECT_ROOT_ID)) {
-            gmeIDs.push(this.currentNodeInfo.id);
-        }
-
         this._settingActiveSelection = true;
         WebGMEGlobal.State.registerActiveSelection(gmeIDs);
         this._settingActiveSelection = false;

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -66,19 +66,10 @@ define(['js/logger',
             self._logger.debug('activeSelection changed', activeSelection);
             var activeNodeId = WebGMEGlobal.State.getActiveObject();
             if (activeSelection && activeSelection.length > 0) {
-                if (activeSelection.length === 1) {
-                    //https://github.com/webgme/webgme/issues/326
-                    if (self.startsWith(activeSelection[0], activeNodeId)) {
-                        self._selectedObjectsChanged(activeSelection);
-                    } else {
-                        self._logger.debug('Selected node is not a child or the activeNode', activeNodeId,
-                            activeSelection[0]);
-                    }
-                } else {
-                    self._selectedObjectsChanged(activeSelection);
-                }
+                self._selectedObjectsChanged(activeSelection);
             } else {
                 self._selectObjectsUsingActiveObject(activeNodeId);
+
             }
         });
 
@@ -753,13 +744,6 @@ define(['js/logger',
             }
         }
         this._client.completeTransaction();
-    };
-
-    PropertyEditorController.prototype.startsWith = function (str, start) {
-        if (start === '') {
-            return true;
-        }
-        return start.length > 0 && str.substring(0, start.length) === start;
     };
 
     return PropertyEditorController;


### PR DESCRIPTION
the split view error was introduced with the #326, now we made a clear separation of active selection and active node
the treeBrowser could still follow the active node as in split view it is hard to track it, and can still cause confusion