### PR TITLE
Added teardown functionality for autorouter replayer. Fixes #379

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
+++ b/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
@@ -6,6 +6,7 @@ importScripts('../../../lib/require/require.js');
 var worker = this,
     window = {},  //jshint ignore: line
     WebGMEGlobal = {gmeConfig: {}},
+    respondToAll = false,
     msgQueue = [];
 
 /**
@@ -91,7 +92,7 @@ var startWorker = function() {
             }
 
             response.push(result);
-            if (this.respondTo[action]) {
+            if (respondToAll || this.respondTo[action]) {
                 this.logger.debug('Response:', response);
                 worker.postMessage(response);
             }
@@ -140,5 +141,6 @@ worker.onmessage = function(msg) {
     'use strict';
     
     WebGMEGlobal.gmeConfig.client = msg.data[0];
+    respondToAll = msg.data[1];
     startWorker();
 };

--- a/test-karma/client/js/AutoRouter/autorouter.replay.inc.js
+++ b/test-karma/client/js/AutoRouter/autorouter.replay.inc.js
@@ -111,6 +111,18 @@ define(['js/Widgets/DiagramDesigner/AutoRouter.ActionApplier',
         }.bind(this);
     };
 
+    /**
+     * Clean up resources used for testing (namely the web worker).
+     *
+     * @return {undefined}
+     */
+    AutoRouterBugPlayer.prototype.teardown = function () {
+        if (this._worker) {
+            this._worker.terminate();
+            this._worker = null;
+        }
+    };
+
     AutoRouterBugPlayer.prototype.testWithWebWorker = function (actions, options, callback) {
         var last;
 

--- a/test-karma/client/js/autorouter.spec.js
+++ b/test-karma/client/js/autorouter.spec.js
@@ -42,6 +42,10 @@ describe('AutoRouter', function () {
 
     var replayTests = function () {
 
+        beforeEach(function() {
+            bugPlayer.expectedErrors = [];
+        });
+
         it('basic model with ports', function (done) {
             requirejs(['text!aRtestCases/basic.json'], function (actions) {
                 bugPlayer.test(JSON.parse(actions));
@@ -213,6 +217,7 @@ describe('AutoRouter', function () {
         });
 
         it('should not move box that doesn\'t exist', function (done) {
+            this.timeout(30000);  // Too slow with web worker on my dev box
             requirejs(['text!aRtestCases/finding_correct_buffer_box.json'], function (actions) {
                 bugPlayer.expectedErrors.push(/Box does not exist/);
                 bugPlayer.test(JSON.parse(actions), {}, done);
@@ -983,19 +988,22 @@ describe('AutoRouter', function () {
 
     describe('Replay tests', function() {
         describe('Standard', function () {
-            // Set up the Autorouter as a web worker
+            // Set up the Autorouter on the same thread
             before(function() {
                 bugPlayer.useWebWorker(false);
             });
             describe('Tests', replayTests);
         });
 
-        describe.skip('Web Worker', function () {
+        describe('Web Worker', function () {
             // Set up the Autorouter as a web worker
             before(function() {
                 bugPlayer.useWebWorker(true);
             });
             describe('Tests', replayTests);
+            after(function() {
+                bugPlayer.teardown();
+            });
         });
     });
 


### PR DESCRIPTION
This is needed to terminate the web worker cleanly when running the
karma tests