### PR TITLE
Revert "Fixes #378 create pointer after mouse over an object"

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Droppable.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Droppable.js
@@ -76,7 +76,6 @@ define([
 
         if (dragInfo) {
             this._doAcceptDroppable(this.onBackgroundDroppableAccept(event, dragInfo), true);
-            this._savedAcceptDroppable = this._acceptDroppable;
         } else {
             this._doAcceptDroppable(false, false);
         }
@@ -140,9 +139,11 @@ define([
                 dropTarget.enableDroppable(this.skinParts.$dropRegion, true);
                 if (this._savedAcceptDroppable !== undefined) {
                     this._doAcceptDroppable(this._savedAcceptDroppable, true);
+                    this._savedAcceptDroppable = undefined;
                 }
             } else {
                 dropTarget.enableDroppable(this.skinParts.$dropRegion, false);
+                this._savedAcceptDroppable = this._acceptDroppable;
                 this._doAcceptDroppable(false, false);
             }
         }


### PR DESCRIPTION
Reverts webgme/webgme#572

Just noticed that with these changes you can no longer click-and-drag an object on the canvas. Instead you need to click-drop-click-and-drag. If you click-and-drag the canvas will turn red.