### PR TITLE
Fixes #563 We should not allow adding instance as descendant

### DIFF
--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -179,6 +179,18 @@ define(['jquery',
         return isProjectRegistryValue(CONSTANTS.PROJECT_FCO_ID, objID);
     }
 
+    // returns with all the contaners of the node plus the node itself up untill the ROOT
+    function getAllContainerIds(nodeId) {
+        var containers = [],
+            node = client.getNode(nodeId);
+
+        while (node !== null) {
+            containers.push(node.getId());
+            node = client.getNode(node.getParentId());
+        }
+        return containers;
+    }
+
     /*
      * Returns true if a new child with the given baseId (instance of base) can be created in parent
      */
@@ -195,18 +207,23 @@ define(['jquery',
             j,
             node,
             validChildrenTypes,
-            validChildrenTypeMap;
+            validChildrenTypeMap,
+            parentIds = getAllContainerIds(parentId);
 
         //TODO: implement real logic based on META and CONSTRAINTS...
         if (typeof parentId === 'string' && baseIdList && baseIdList.length > 0) {
             result = true;
 
-            //make sure that no basIDList is not derived from parentId
+            //make sure that no baseId is derived from any of the containers
             len = baseIdList.length;
             while (len-- && result === true) {
-                if (client.isTypeOf(baseIdList[len], parentId)) {
-                    result = false;
+                i = parentIds.length;
+                while (i-- && result === true) {
+                    if (client.isTypeOf(baseIdList[len], parentIds[i])) {
+                        result = false;
+                    }
                 }
+
             }
 
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -54,6 +54,25 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
 
         core.isValidNode = isValidNode;
 
+        //check of inheritance chain and containment hierarchy collision
+        core.isInheritanceContainmentCollision = function (node, parent) {
+            var parentPath = core.getPath(parent),
+                bases = [];
+
+            while (node) {
+                bases.push(core.getPath(node));
+                node = core.getBase(node);
+            }
+
+            while (parent) {
+                if (bases.indexOf(core.getPath(parent)) !== -1) {
+                    return true;
+                }
+                parent = core.getParent(parent);
+            }
+            return false;
+        };
+
         // ----- navigation
 
         core.getBase = function (node) {
@@ -84,7 +103,7 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
             return node;
         }
 
-        core.loadChild = function (node, relid) {
+        function _loadChild(node, relid) {
             var child = null,
                 base = core.getBase(node),
                 basechild = null;
@@ -114,14 +133,41 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
             }
             //normal child
             return TASYNC.call(__loadBase, oldcore.loadChild(node, relid));
+        }
+
+        core.loadChild = function (node, relid) {
+            return TASYNC.call(function (child) {
+                if (child && core.isInheritanceContainmentCollision(child, core.getParent(child))) {
+                    logger.error('node[' + core.getPath(child) + '] was deleted due to inheritance-containment collision');
+                    core.deleteNode(child);
+                    //core.persist(core.getRoot(child));
+                    return null;
+                } else {
+                    return child;
+                }
+            }, _loadChild(node, relid));
         };
 
-        core.loadByPath = function (node, path) {
+        function _loadByPath(node, path) {
             ASSERT(isValidNode(node));
             ASSERT(path === '' || path.charAt(0) === '/');
             path = path.split('/');
             return loadDescendantByPath(node, path, 1);
+        }
+
+        core.loadByPath = function(node,path){
+            return TASYNC.call(function(nodeAtPath){
+                if (nodeAtPath && core.isInheritanceContainmentCollision(nodeAtPath, core.getParent(nodeAtPath))) {
+                    logger.error('node[' + core.getPath(nodeAtPath) + '] was deleted due to inheritance-containment collision');
+                    core.deleteNode(nodeAtPath);
+                    //core.persist(core.getRoot(nodeAtPath));
+                    return null;
+                } else {
+                    return nodeAtPath;
+                }
+            },_loadByPath(node,path));
         };
+
         var loadDescendantByPath = function (node, pathArray, index) {
             if (node === null || index === pathArray.length) {
                 return node;
@@ -154,7 +200,9 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                 } else if (isFalseNode(node)) {
                     var root = core.getRoot(node);
                     oldcore.deleteNode(node);
-                    core.persist(root);
+                    //core.persist(root);
+                    //TODO a notification should be generated towards the user
+                    logger.warn('node removed due to missing base'); //TODO check if some identification can be passed
                     return null;
                 } else {
                     var basepath = oldcore.getPointerPath(node, 'base');

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -148,24 +148,11 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
             }, _loadChild(node, relid));
         };
 
-        function _loadByPath(node, path) {
+        core.loadByPath = function (node, path) {
             ASSERT(isValidNode(node));
             ASSERT(path === '' || path.charAt(0) === '/');
             path = path.split('/');
             return loadDescendantByPath(node, path, 1);
-        }
-
-        core.loadByPath = function(node,path){
-            return TASYNC.call(function(nodeAtPath){
-                if (nodeAtPath && core.isInheritanceContainmentCollision(nodeAtPath, core.getParent(nodeAtPath))) {
-                    logger.error('node[' + core.getPath(nodeAtPath) + '] was deleted due to inheritance-containment collision');
-                    core.deleteNode(nodeAtPath);
-                    //core.persist(core.getRoot(nodeAtPath));
-                    return null;
-                } else {
-                    return nodeAtPath;
-                }
-            },_loadByPath(node,path));
         };
 
         var loadDescendantByPath = function (node, pathArray, index) {

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -342,4 +342,36 @@ describe('coretype', function () {
             expect(e).not.to.equal(null);
         }
     });
+
+    it('should remove if node has inheritance-containment collision found during loadChildren', function (done) {
+        var typeA = core.createNode({parent: root}),
+            typeB = core.createNode({parent: root}),
+            instA = core.createNode({parent: root, base: typeA}),
+            instB = core.createNode({parent: root, base: typeB});
+
+        instA = core.moveNode(instA, instB);
+        instB = core.moveNode(instB, typeA);
+
+        TASYNC.call(function (children) {
+            expect(children).to.have.length(0);
+            done();
+        }, core.loadChildren(instB));
+    });
+
+    it('should remove if node has inheritance-containment collision found during loadByPath', function (done) {
+        var typeA = core.createNode({parent: root}),
+            typeB = core.createNode({parent: root}),
+            instA = core.createNode({parent: root, base: typeA}),
+            instB = core.createNode({parent: root, base: typeB}),
+            relid = core.getRelid(instA);
+
+
+        instA = core.moveNode(instA, instB);
+        instB = core.moveNode(instB, typeA);
+
+        TASYNC.call(function (node) {
+            expect(node).to.equal(null);
+            done();
+        }, core.loadByPath(root, core.getPath(instB) + '/' + relid));
+    });
 });


### PR DESCRIPTION
Now we detect if a node has inheritance-containment collision (meaning that one of its container nodes as also its ancestor) and remove it from the project.
