### PR TITLE
Prohibit copy of FCO

### DIFF
--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -427,8 +427,8 @@ define(['js/logger',
             };
 
         //check if FCO is among the items as it may change the outcome
-        for(i=0;i<items.length;i+=1){
-            if(GMEConcepts.isProjectFCO(items[i])){
+        for (i = 0; i < items.length; i += 1) {
+            if (GMEConcepts.isProjectFCO(items[i])) {
                 FCOamongItems = true;
                 break;
             }

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -400,6 +400,7 @@ define(['js/logger',
             parentID = this.currentNodeInfo.id,
             i,
             j,
+            FCOamongItems = false,
             validPointerTypes = [],
             baseTypeID,
             baseTypeNode,
@@ -425,6 +426,14 @@ define(['js/logger',
                 }
             };
 
+        //check if FCO is among the items as it may change the outcome
+        for(i=0;i<items.length;i+=1){
+            if(GMEConcepts.isProjectFCO(items[i])){
+                FCOamongItems = true;
+                break;
+            }
+        }
+
         //check to see what DROP actions are possible
         if (items.length > 0) {
             i = dragEffects.length;
@@ -435,13 +444,13 @@ define(['js/logger',
                         //if so, it's not a real move, it is a reposition
                         if (((dragParams && dragParams.parentID === parentID) ||
                             GMEConcepts.canCreateChildrenInAspect(parentID, items, aspect)) &&
-                            GMEConcepts.canMoveNodeHere(parentID, items)) {
+                            GMEConcepts.canMoveNodeHere(parentID, items) && !FCOamongItems) {
                             dragAction = {dragEffect: dragEffects[i]};
                             possibleDropActions.push(dragAction);
                         }
                         break;
                     case DragHelper.DRAG_EFFECTS.DRAG_COPY:
-                        if (GMEConcepts.canCreateChildrenInAspect(parentID, items, aspect)) {
+                        if (GMEConcepts.canCreateChildrenInAspect(parentID, items, aspect) && !FCOamongItems) {
                             dragAction = {dragEffect: dragEffects[i]};
                             possibleDropActions.push(dragAction);
                         }

--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -754,13 +754,18 @@ define(['jquery',
 
     function canMoveNodeHere(parentId, nodes) {
         var parent = client.getNode(parentId),
-            parentBase = parent.getBaseId();
+            parentBase;
 
-        if (parentBase) {
-            if (nodes.indexOf(parentBase) !== -1) {
-                return false;
+        while (parent) {
+            parentBase = parent.getBaseId();
+            if (parentBase) {
+                if (nodes.indexOf(parentBase) !== -1) {
+                    return false;
+                }
             }
+            parent = client.getNode(parent.getParentId());
         }
+
 
         return true;
     }

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -177,6 +177,7 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
         };
 
         function __loadBase(node) {
+            var path = oldcore.getPath(node);
             ASSERT(node === null || typeof node.base === 'undefined' || typeof node.base === 'object');
 
             if (typeof node.base === 'undefined') {
@@ -185,20 +186,25 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                     node.base = null;
                     return node;
                 } else if (isFalseNode(node)) {
-                    var root = core.getRoot(node);
                     oldcore.deleteNode(node);
-                    //core.persist(root);
+                    //core.persist(core.getRoot(node));
                     //TODO a notification should be generated towards the user
-                    logger.warn('node removed due to missing base'); //TODO check if some identification can be passed
+                    logger.warn('node [' + path + '] removed due to missing base'); //TODO check if some identification can be passed
                     return null;
                 } else {
-                    var basepath = oldcore.getPointerPath(node, 'base');
-                    ASSERT(basepath !== undefined);
-                    if (basepath === null) {
+                    var basePath = oldcore.getPointerPath(node, 'base');
+                    ASSERT(basePath !== undefined);
+                    if (basePath === null) {
                         node.base = null;
                         return node;
+                    } else if (basePath.indexOf(path) === 0) {
+                        //contained base error
+                        logger.error('node [' + path + '] contains its own base!');
+                        oldcore.deleteNode(node);
+                        //core.persist(core.getRoot(node));
+                        return null;
                     } else {
-                        return TASYNC.call(__loadBase2, node, core.loadByPath(core.getRoot(node), basepath));
+                        return TASYNC.call(__loadBase2, node, core.loadByPath(core.getRoot(node), basePath));
                     }
                 }
             } else {

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -374,4 +374,27 @@ describe('coretype', function () {
             done();
         }, core.loadByPath(root, core.getPath(instB) + '/' + relid));
     });
+
+    it('should remove node if it contains its own base', function (done) {
+
+        var typeA = core.createNode({parent: root}),
+            typeB = core.createNode({parent: root}),
+            instA = core.createNode({parent: root, base: typeA}),
+            path = core.getPath(instA);
+
+
+        typeA = core.moveNode(typeA, typeB);
+        typeB = core.moveNode(typeB, instA);
+
+        //we have to save and reload otherwise the base is still in the cache so it can be loaded without a problem
+        core.persist(root);
+
+        TASYNC.call(function (newroot) {
+            expect(newroot).not.to.equal(null);
+            TASYNC.call(function (node) {
+                expect(node).to.equal(null);
+                done();
+            }, core.loadByPath(newroot, path));
+        }, core.loadRoot(core.getHash(root)));
+    });
 });


### PR DESCRIPTION
As some generic UI pieces depend on the fact, that there is only the FCO (and the ROOT) which doesn't have a base, we prohibit its copy.
This restriction however exsits only on the UI as in theory the core layer can handle multiple objects without base.

We also check for situations which cause unloadable nodes. More precisely when a node contains its base.
As not all situation can be avoided beforehand we remove such nodes during their load.
This issue is the opposite of #563
A possible scenario:
1. create typeA and typeB
2. create an instance of typeA (instA)
3. move typeA inside typeB
4. move typeB inside instA (at this point we are unable to prohibit the move as we not necessarily know about typeA and that it is the base of instA)
-> instA become unloadable