### PR TITLE
Add gmeConfig.server.extlibExcludes.

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -160,7 +160,8 @@ var path = require('path'),
                 enable: false,
                 certificateFile: path.join(__dirname, '../certificates/sample-cert.pem'),
                 keyFile: path.join(__dirname, '../certificates/sample-key.pem')
-            }
+            },
+            extlibExcludes: ['.\.pem$', 'config\/config\..*\.js$']
         },
 
         socketIO: {

--- a/config/getclientconfig.js
+++ b/config/getclientconfig.js
@@ -12,6 +12,7 @@ function getClientConfig(gmeConfig) {
     delete clientConfig.server.https.certificateFile;
     delete clientConfig.server.https.keyFile;
     delete clientConfig.server.log;
+    delete clientConfig.server.extlibExcludes;
     delete clientConfig.executor.nonce;
     delete clientConfig.mongo;
     delete clientConfig.blob;

--- a/config/validator.js
+++ b/config/validator.js
@@ -194,6 +194,8 @@ function validateConfig(configOrFileName) {
     assertBoolean('config.server.https.enable', config.server.https.enable);
     assertString('config.server.https.certificateFile', config.server.https.certificateFile);
     assertString('config.server.https.keyFile', config.server.https.keyFile);
+    // server extlib
+    assertArray('config.server.extlibExcludes', config.server.extlibExcludes);
 
     // socketIO
     expectedKeys.push('socketIO');

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -172,6 +172,11 @@ describe('standalone server', function () {
             {code: 404, url: '/does_not_exist.js'},
             {code: 404, url: '/asdf'},
 
+            //excluded extlib paths.
+            {code: 200, url: '/extlib/config/index.js'},
+            {code: 403, url: '/extlib/config/config.default.js'},
+            {code: 403, url: '/extlib/someCertificate.pem'},
+
             //{code: 410, url: '/getToken'},
             //{code: 410, url: '/checktoken/does_not_exist'},
 


### PR DESCRIPTION
Array of regexps that will return a 403 when accessed via the extlib routing rule.

By default all .pem files and the configuration files are added.