### PR TITLE
Fixes #601 Cannot draw connection if connection type is not direct valid children type of parent.

### DIFF
--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -88,9 +88,13 @@ define(['js/logger',
 
         this._nodeEventHandling = function (events) {
             var metaChange = false,
-                metaPaths = Object.keys(self._client.getAllMetaNodes() || {}),
+                metaNodes = self._client.getAllMetaNodes() || [],
+                metaPaths = [],
                 i;
 
+            for (i = 0; i < metaNodes.length; i += 1) {
+                metaPaths.push(metaNodes[i].getId());
+            }
             metaPaths.push(CONSTANTS.PROJECT_ROOT_ID);
 
             for (i = 0; i < events.length; i += 1) {

--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -329,13 +329,13 @@ define(['jquery',
     }
 
     function getMETAAspectMergedValidChildrenTypes(objID) {
-        var metaAspectMembers = Object.keys(client.getAllMetaNodes() || {}),
+        var metaNodes = client.getAllMetaNodes() || [],
             validChildrenTypes = client.getValidChildrenTypes(objID),
-            len = metaAspectMembers.length,
+            len = metaNodes.length,
             id;
 
         while (len--) {
-            id = metaAspectMembers[len];
+            id = metaNodes[len].getId();
             if (validChildrenTypes.indexOf(id) === -1) {
                 if (client.isValidChild(objID, id)) {
                     validChildrenTypes.push(id);


### PR DESCRIPTION
the bad type handling of meta nodes were checked and valid target points now visible again