### PR TITLE
Fixes #609 False 'base containment' error if relids partially identical

### DIFF
--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -850,6 +850,20 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
 
         corerel.overlayInsert = overlayInsert;
 
+        corerel.isContainerPath = function (path, parentPath) {
+            var pathArray = (path || '').split('/'),
+                parentArray = (parentPath || '').split('/'),
+                i;
+
+            for (i = 0; i < parentArray.length; i += 1) {
+                if (parentArray[i] !== pathArray[i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
         return corerel;
     }
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -197,7 +197,7 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                     if (basePath === null) {
                         node.base = null;
                         return node;
-                    } else if (basePath.indexOf(path) === 0) {
+                    } else if (core.isContainerPath(basePath, path)) {
                         //contained base error
                         logger.error('node [' + path + '] contains its own base!');
                         oldcore.deleteNode(node);

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -397,4 +397,21 @@ describe('coretype', function () {
             }, core.loadByPath(newroot, path));
         }, core.loadRoot(core.getHash(root)));
     });
+
+    it('should not trigger base containment error if paths are only partially identical', function (done) {
+        var typeA = core.createNode({parent: root, relid: '123'}),
+            instA = core.createNode({parent: root, base: typeA, relid: '12'}),
+            path = core.getPath(instA);
+
+        //we have to save and reload otherwise the base is still in the cache so it can be loaded without a problem
+        core.persist(root);
+
+        TASYNC.call(function (newroot) {
+            expect(newroot).not.to.equal(null);
+            TASYNC.call(function (node) {
+                expect(node).not.to.equal(null);
+                done();
+            }, core.loadByPath(newroot, path));
+        }, core.loadRoot(core.getHash(root)));
+    });
 });


### PR DESCRIPTION
To decide if a node really contains its own base, we should do a real path check instead of a simple string comparison.