### PR TITLE
loadPaths function

### DIFF
--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -998,7 +998,9 @@ define([
 
             isValidNode: isValidNode,
 
-            getChildHash: getChildHash
+            getChildHash: getChildHash,
+
+            loadPaths: TASYNC.wrap(storage.loadPaths)
         };
     };
 });

--- a/src/common/core/metacachecore.js
+++ b/src/common/core/metacachecore.js
@@ -26,11 +26,13 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                     i,
                     metaNodes = [];
 
-                for (i = 0; i < paths.length; i += 1) {
-                    metaNodes.push(oldcore.loadByPath(root, paths[i]));
-                }
+                return TASYNC.call(function () {
+                    for (i = 0; i < paths.length; i += 1) {
+                        metaNodes.push(oldcore.loadByPath(root, paths[i]));
+                    }
 
-                return TASYNC.lift(metaNodes);
+                    return TASYNC.lift(metaNodes);
+                }, core.loadPaths(core.getHash(root), paths));
             }
 
             core.loadRoot = function (hash) {

--- a/src/common/core/metacachecore.js
+++ b/src/common/core/metacachecore.js
@@ -32,7 +32,7 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                     }
 
                     return TASYNC.lift(metaNodes);
-                }, core.loadPaths(core.getHash(root), paths));
+                }, core.loadPaths(core.getHash(root), JSON.parse(JSON.stringify(paths))));
             }
 
             core.loadRoot = function (hash) {
@@ -46,6 +46,12 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                         return root;
                     }, loadMetaSet(root));
                 }, oldcore.loadRoot(hash));
+            };
+
+            core.loadByPath = function (node, path) {
+                return TASYNC.call(function () {
+                    return oldcore.loadByPath(node, path);
+                }, core.loadPaths(core.getHash(node), [path]));
             };
 
             //functions where the cache may needs to be updated

--- a/src/common/storage/project/cache.js
+++ b/src/common/storage/project/cache.js
@@ -103,10 +103,10 @@ define(['common/util/assert', 'common/storage/constants'], function (ASSERT, CON
                 var obj = cache[hash],
                     commitId;
 
-                if (typeof obj === undefined) {
+                if (typeof obj === 'undefined') {
                     obj = backup[hash];
 
-                    if (typeof obj === undefined) {
+                    if (typeof obj === 'undefined') {
                         for (commitId in self.queuedPersists) {
                             if (self.queuedPersists.hasOwnProperty(commitId) && self.queuedPersists[commitId][key]) {
                                 obj = self.queuedPersists[commitId][key];
@@ -128,19 +128,22 @@ define(['common/util/assert', 'common/storage/constants'], function (ASSERT, CON
                 key, i = paths.length,
                 j;
 
-            if (typeof rootObj !== undefined) {
+            if (typeof rootObj !== 'undefined') {
                 excludes.push(rootKey);
                 objects[rootKey] = rootObj;
 
                 while (i--) {
                     fullyCovered = true;
                     pathArray = paths[i].split('/');
+                    if(pathArray.length > 1){
+                        pathArray.shift();
+                    }
                     obj = rootObj;
                     for (j = 0; j < pathArray.length; j += 1) {
                         key = obj[pathArray[j]];
                         if (key) {
                             obj = getFromCache(key);
-                            if (typeof obj !== undefined) {
+                            if (typeof obj !== 'undefined') {
                                 excludes.push(key);
                                 objects[key] = obj;
                             } else {
@@ -184,6 +187,8 @@ define(['common/util/assert', 'common/storage/constants'], function (ASSERT, CON
                     }
                     callback(err);
                 });
+            } else {
+                callback(null);
             }
 
         };

--- a/src/common/storage/project/interface.js
+++ b/src/common/storage/project/interface.js
@@ -70,6 +70,18 @@ define([
         this.loadObject = this.projectCache.loadObject;
 
         /**
+         * Collects the objects from the server and pre-loads them into the cache
+         * making the load of multiple objects faster.
+         *
+         * @param {string} rootKey - Hash of the object at the entry point of the paths.
+         * @param {string[]} paths - List of paths that needs to be pre-loaded.
+         * @param {string[]} excludes - List of hashes that the user already have.
+         * @param {function} callback - Invoked when objects have been collected.
+         * @func
+         */
+        this.loadPaths = this.projectCache.loadPaths;
+
+        /**
          * Makes a commit to data base. Based on the root hash and commit message a new
          * {@link module:Storage.CommitObject} (with returned hash)
          * is generated and insert together with the core objects to the database on the server.

--- a/src/common/storage/socketio/websocket.js
+++ b/src/common/storage/socketio/websocket.js
@@ -169,6 +169,10 @@ define([
             self.socket.emit('loadObjects', data, wrapError(callback));
         };
 
+        this.loadPaths = function (data, callback) {
+            self.socket.emit('loadPaths', data, wrapError(callback));
+        };
+
         this.setBranchHash = function (data, callback) {
             self.socket.emit('setBranchHash', data, wrapError(callback));
         };

--- a/src/common/storage/storageclasses/objectloaders.js
+++ b/src/common/storage/storageclasses/objectloaders.js
@@ -55,7 +55,7 @@ define(['common/storage/storageclasses/simpleapi'], function (SimpleAPI) {
                 resetBucketAndLoadObjects();
             }, self.gmeConfig.storage.loadBucketTimer);
         }
-        
+
         if (self.loadBucketSize === self.gmeConfig.storage.loadBucketSize) {
             self.logger.debug('loadBuckSize reached will loadObjects, bucketSize:', self.loadBucketSize);
             clearTimeout(self.loadBucketTimer);
@@ -93,6 +93,17 @@ define(['common/storage/storageclasses/simpleapi'], function (SimpleAPI) {
                 }
             }
         });
+    };
+
+    StorageObjectLoaders.prototype.loadPaths = function (projectId, rootKey, paths, excludes, callback) {
+        var data = {
+            projectId: projectId,
+            paths: paths,
+            excludes: excludes,
+            rootHash: rootKey
+        };
+
+        this.webSocket.loadPaths(data, callback);
     };
 
     return StorageObjectLoaders;

--- a/src/server/storage/memory.js
+++ b/src/server/storage/memory.js
@@ -132,8 +132,8 @@ function Memory(mainLogger, gmeConfig) {
 
                 if(pathArray.length > 1){
                     pathArray.shift();
-                    key = pathArray.shift();
                 }
+                key = pathArray.shift();
 
                 loadNext();
                 return pathDeferred.promise;

--- a/src/server/storage/memory.js
+++ b/src/server/storage/memory.js
@@ -26,6 +26,7 @@ var Q = require('q'),
 function Memory(mainLogger, gmeConfig) {
     var logger = mainLogger.fork('memory'),
         database = 'memory', // is this constant or coming from the GME config?
+        self = this,
         storage = {
             length: 0,
             keys: [],
@@ -97,6 +98,69 @@ function Memory(mainLogger, gmeConfig) {
                 deferred.reject(new Error('object does not exist ' + hash));
             }
 
+            return deferred.promise.nodeify(callback);
+        };
+
+        this.loadPaths = function (rootHash, paths, excludes, callback) {
+            ASSERT(typeof rootHash === 'string' && REGEXP.HASH.test(rootHash));
+            ASSERT(paths instanceof Array && excludes instanceof Array);
+
+            function loadPath(path) {
+                var pathDeferred = Q.defer(),
+                    hashes = {},
+                    pathArray = path.split('/'),
+                    hash = rootHash,
+                    key,
+                    loadNext = function () {
+                        self.loadObject(hash)
+                            .then(function (object) {
+                                hashes[hash] = object;
+                                if (key) {
+                                    hash = object[key];
+                                    key = pathArray.shift();
+                                    loadNext();
+                                } else {
+                                    //if there is no key, than there is no more to do
+                                    pathDeferred.resolve(hashes);
+                                }
+                            })
+                            .catch(function (err) {
+                                //we ignore the errors at this point as we will fall back
+                                pathDeferred.resolve(hashes);
+                            });
+                    };
+
+                if(pathArray.length > 1){
+                    pathArray.shift();
+                    key = pathArray.shift();
+                }
+
+                loadNext();
+                return pathDeferred.promise;
+            }
+
+            var deferred = Q.defer(),
+                objects = {},
+                keys, i, j;
+
+            Q.allSettled(paths.map(loadPath))
+                .then(function (results) {
+                    for (i = 0; i < results.length; i += 1) {
+                        if (results[i].state === 'fulfilled') {
+                            keys = Object.keys(results[i].value);
+                            for (j = 0; j < keys.length; j += 1) {
+                                if (excludes.indexOf(keys[j]) === -1 && !objects[keys[j]]) {
+                                    objects[keys[j]] = results[i].value[keys[j]];
+                                }
+                            }
+                        }
+                    }
+                    return deferred.resolve(objects);
+                })
+                .catch(function (err) {
+                    logger.warn('loading paths failed:', err);
+                    return deferred.resolve(objects);
+                });
             return deferred.promise.nodeify(callback);
         };
 

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -187,8 +187,8 @@ SafeStorage.prototype.deleteProject = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId);
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -239,8 +239,8 @@ SafeStorage.prototype.createProject = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectName === 'string', deferred, 'data.projectName is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectName), deferred, 'data.projectName failed regexp: ' + data.projectName);
+        check(typeof data.projectName === 'string', deferred, 'data.projectName is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectName), deferred, 'data.projectName failed regexp: ' + data.projectName);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -386,8 +386,8 @@ SafeStorage.prototype.getBranches = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId);
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -435,15 +435,15 @@ SafeStorage.prototype.getCommits = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
-    check(typeof data.before === 'number' || typeof data.before === 'string', deferred,
-        'data.before is not a number nor string') ||
-    check(typeof data.number === 'number', deferred, 'data.number is not a number');
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.before === 'number' || typeof data.before === 'string', deferred,
+            'data.before is not a number nor string') ||
+        check(typeof data.number === 'number', deferred, 'data.number is not a number');
 
     if (typeof data.before === 'string') {
         rejected = rejected || check(REGEXP.HASH.test(data.before), deferred,
-            'data.before is not a number nor a valid hash.');
+                'data.before is not a number nor a valid hash.');
     }
 
     if (data.hasOwnProperty('username')) {
@@ -506,10 +506,10 @@ SafeStorage.prototype.getLatestCommitData = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
-    check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-    check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
+        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -550,30 +550,30 @@ SafeStorage.prototype.makeCommit = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(data.commitObject !== null && typeof data.commitObject === 'object', deferred,
-        'data.commitObject not an object.') ||
-    check(data.coreObjects !== null && typeof data.coreObjects === 'object', deferred,
-        'data.coreObjects not an object.');
+        check(data.commitObject !== null && typeof data.commitObject === 'object', deferred,
+            'data.commitObject not an object.') ||
+        check(data.coreObjects !== null && typeof data.coreObjects === 'object', deferred,
+            'data.coreObjects not an object.');
 
     // Checks when branchName is given and the branch will be updated
     if (rejected === false && typeof data.branchName !== 'undefined') {
         rejected = check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
-        check(typeof data.commitObject._id === 'string', deferred, 'data.commitObject._id is not a string.') ||
-        check(typeof data.commitObject.root === 'string', deferred, 'data.commitObject.root is not a string.') ||
-        check(REGEXP.HASH.test(data.commitObject._id), deferred,
-            'data.commitObject._id is not a valid hash: ' + data.commitObject._id) ||
-        check(data.commitObject.parents instanceof Array, deferred,
-            'data.commitObject.parents is not an array.') ||
-        check(typeof data.commitObject.parents[0] === 'string', deferred,
-            'data.commitObject.parents[0] is not a string.') ||
-        check(data.commitObject.parents[0] === '' || REGEXP.HASH.test(data.commitObject.parents[0]), deferred,
-            'data.commitObject.parents[0] is not a valid hash: ' + data.commitObject.parents[0]) ||
-        check(REGEXP.HASH.test(data.commitObject.root), deferred,
-            'data.commitObject.root is not a valid hash: ' + data.commitObject.root);
+            check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
+            check(typeof data.commitObject._id === 'string', deferred, 'data.commitObject._id is not a string.') ||
+            check(typeof data.commitObject.root === 'string', deferred, 'data.commitObject.root is not a string.') ||
+            check(REGEXP.HASH.test(data.commitObject._id), deferred,
+                'data.commitObject._id is not a valid hash: ' + data.commitObject._id) ||
+            check(data.commitObject.parents instanceof Array, deferred,
+                'data.commitObject.parents is not an array.') ||
+            check(typeof data.commitObject.parents[0] === 'string', deferred,
+                'data.commitObject.parents[0] is not a string.') ||
+            check(data.commitObject.parents[0] === '' || REGEXP.HASH.test(data.commitObject.parents[0]), deferred,
+                'data.commitObject.parents[0] is not a valid hash: ' + data.commitObject.parents[0]) ||
+            check(REGEXP.HASH.test(data.commitObject.root), deferred,
+                'data.commitObject.root is not a valid hash: ' + data.commitObject.root);
         // Commits without coreObjects is valid now (the assumption is that the rootObject does exist.
         //check(typeof data.coreObjects[data.commitObject.root] === 'object', deferred,
         //    'data.coreObjects[data.commitObject.root] is not an object');
@@ -625,11 +625,11 @@ SafeStorage.prototype.getBranchHash = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-    check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
+        check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
+        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -670,18 +670,18 @@ SafeStorage.prototype.setBranchHash = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-    check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
+        check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
+        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
 
-    check(typeof data.oldHash === 'string', deferred, 'data.oldHash is not a string.') ||
-    check(data.oldHash === '' || REGEXP.HASH.test(data.oldHash), deferred,
-        'data.oldHash is not a valid hash: ' + data.oldHash) ||
-    check(typeof data.newHash === 'string', deferred, 'data.newHash is not a string.') ||
-    check(data.newHash === '' || REGEXP.HASH.test(data.newHash), deferred,
-        'data.newHash is not a valid hash: ' + data.newHash);
+        check(typeof data.oldHash === 'string', deferred, 'data.oldHash is not a string.') ||
+        check(data.oldHash === '' || REGEXP.HASH.test(data.oldHash), deferred,
+            'data.oldHash is not a valid hash: ' + data.oldHash) ||
+        check(typeof data.newHash === 'string', deferred, 'data.newHash is not a string.') ||
+        check(data.newHash === '' || REGEXP.HASH.test(data.newHash), deferred,
+            'data.newHash is not a valid hash: ' + data.newHash);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -722,15 +722,15 @@ SafeStorage.prototype.getCommonAncestorCommit = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(typeof data.commitA === 'string', deferred, 'data.commitA is not a string.') ||
-    check(data.commitA === '' || REGEXP.HASH.test(data.commitA), deferred,
-        'data.commitA is not a valid hash: ' + data.commitA) ||
-    check(typeof data.commitB === 'string', deferred, 'data.commitB is not a string.') ||
-    check(data.commitB === '' || REGEXP.HASH.test(data.commitB), deferred,
-        'data.commitB is not a valid hash: ' + data.commitB);
+        check(typeof data.commitA === 'string', deferred, 'data.commitA is not a string.') ||
+        check(data.commitA === '' || REGEXP.HASH.test(data.commitA), deferred,
+            'data.commitA is not a valid hash: ' + data.commitA) ||
+        check(typeof data.commitB === 'string', deferred, 'data.commitB is not a string.') ||
+        check(data.commitB === '' || REGEXP.HASH.test(data.commitB), deferred,
+            'data.commitB is not a valid hash: ' + data.commitB);
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -771,15 +771,15 @@ SafeStorage.prototype.createBranch = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-    check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
+        check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
+        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName) ||
 
-    check(typeof data.hash === 'string', deferred, 'data.hash is not a string.') ||
-    check(data.hash === '' || REGEXP.HASH.test(data.hash), deferred,
-        'data.hash is not a valid hash: ' + data.hash);
+        check(typeof data.hash === 'string', deferred, 'data.hash is not a string.') ||
+        check(data.hash === '' || REGEXP.HASH.test(data.hash), deferred,
+            'data.hash is not a valid hash: ' + data.hash);
 
     data.oldHash = '';
     data.newHash = data.hash;
@@ -823,11 +823,11 @@ SafeStorage.prototype.deleteBranch = function (data, callback) {
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
 
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
-    check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
-    check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
+        check(typeof data.branchName === 'string', deferred, 'data.branchName is not a string.') ||
+        check(REGEXP.BRANCH.test(data.branchName), deferred, 'data.branchName failed regexp: ' + data.branchName);
 
 
     if (data.hasOwnProperty('username')) {
@@ -937,9 +937,9 @@ SafeStorage.prototype.loadObjects = function (data, callback) {
         self = this;
 
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
-    check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
-    check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
-    check(data.hashes instanceof Array, deferred, 'data.hashes is not an array: ' + JSON.stringify(data.hashes));
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(data.hashes instanceof Array, deferred, 'data.hashes is not an array: ' + JSON.stringify(data.hashes));
 
     if (data.hasOwnProperty('username')) {
         rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
@@ -967,5 +967,60 @@ SafeStorage.prototype.loadObjects = function (data, callback) {
 
     return deferred.promise.nodeify(callback);
 };
+
+/**
+ * Returns a dictionary with all the hashes needed to load the containment of the input pathes.
+ *
+ * Authorization level: read access for project
+ *
+ * @param {object} data - input parameters
+ * @param {string} data.projectId - identifier for project.
+ * @param {string} [data.username=gmeConfig.authentication.guestAccount]
+ * @param {string} data.rootHash - hash of the starting object of the load
+ * @param {string[]} data.paths - list of required paths
+ * @param {string[]} data.excludes - list of keys that already known by the user
+ * @param {function} [callback]
+ * @returns {promise} //TODO: jsdocify this
+ */
+SafeStorage.prototype.loadPaths = function (data, callback) {
+    var deferred = Q.defer(),
+        rejected = false,
+        self = this;
+
+    rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
+        check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
+        check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
+        check(typeof data.rootHash === 'string', deferred, 'data.rootHash os not a string.') ||
+        check(data.excludes instanceof Array,
+            deferred, 'data.excludes is not an array: ' + JSON.stringify(data.excludes)) ||
+        check(data.paths instanceof Array, deferred, 'data.hashes is not an array: ' + JSON.stringify(data.hashes));
+
+    if (data.hasOwnProperty('username')) {
+        rejected = rejected || check(typeof data.username === 'string', deferred, 'data.username is not a string.');
+    } else {
+        data.username = this.gmeConfig.authentication.guestAccount;
+    }
+
+    self.logger.debug('loadPaths', {metadata: data});
+    if (rejected === false) {
+        this.gmeAuth.getProjectAuthorizationByUserId(data.username, data.projectId)
+            .then(function (projectAccess) {
+                if (projectAccess.read) {
+                    return Storage.prototype.loadPaths.call(self, data);
+                } else {
+                    throw new Error('Not authorized to read project. ' + data.projectId);
+                }
+            })
+            .then(function (project) {
+                deferred.resolve(project);
+            })
+            .catch(function (err) {
+                deferred.reject(new Error(err));
+            });
+    }
+
+    return deferred.promise.nodeify(callback);
+};
+
 
 module.exports = SafeStorage;

--- a/src/server/storage/storage.js
+++ b/src/server/storage/storage.js
@@ -302,6 +302,19 @@ Storage.prototype.loadObjects = function (data, callback) {
     return deferred.promise.nodeify(callback);
 };
 
+Storage.prototype.loadPaths = function (data, callback) {
+    var deferred = Q.defer();
+
+    this.mongo.openProject(data.projectId)
+        .then(function (project) {
+            deferred.resolve(project.loadPaths(data.rootHash,data.paths,data.excludes));
+        })
+        .catch(function(err){
+            deferred.reject(err);
+        });
+    return deferred.promise.nodeify(callback);
+};
+
 Storage.prototype.getCommits = function (data, callback) {
     var self = this,
         deferred = Q.defer(),

--- a/src/server/storage/userproject.js
+++ b/src/server/storage/userproject.js
@@ -27,6 +27,9 @@ function UserProject(dbProject, storage, mainLogger, gmeConfig) {
         objectLoader = {
             loadObject: function (projectId, key, callback) {
                 dbProject.loadObject(key, callback);
+            },
+            loadPaths: function (projectId, rootKey, paths, excludes, callback) {
+                dbProject.loadPaths(rootKey, paths, excludes, callback);
             }
         };
 

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -431,6 +431,25 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                     });
             });
 
+            socket.on('loadPaths', function (data, callback) {
+                getUserIdFromSocket(socket)
+                    .then(function (userId) {
+                        data.username = userId;
+                        return storage.loadPaths(data);
+                    })
+                    .then(function (hashDictionary) {
+                        callback(null, hashDictionary);
+                    })
+                    .catch(function (err) {
+                        if (gmeConfig.debug) {
+                            callback(err.stack);
+                        } else {
+                            callback(err.message);
+                        }
+                    });
+            });
+
+
             socket.on('setBranchHash', function (data, callback) {
                 getUserIdFromSocket(socket)
                     .then(function (userId) {

--- a/test/addon/addonmanager.spec.js
+++ b/test/addon/addonmanager.spec.js
@@ -64,6 +64,7 @@ describe('AddOnManager', function () {
 
                 }, self.closeBranchTimeout);
             };
+
         }
 
         it('should dispatch NO_MONITORS after open branch and closing AFTER the monitor opened the branch',
@@ -74,7 +75,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -108,7 +110,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -138,7 +141,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -184,7 +188,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -233,7 +238,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -267,7 +273,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -301,7 +308,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 
@@ -356,7 +364,8 @@ describe('AddOnManager', function () {
                 manager.project = {
                     ID_NAME: '_id',
                     loadObject: function () {},
-                    insertObject: function () {}
+                    insertObject: function () {},
+                    loadPaths: function () {}
                 };
                 manager.storage = storage;
 


### PR DESCRIPTION
By adding a loadPaths function to the storages we are able to pre-load multiple objects from the server saving many roundtrips.
Right now, this functionality is used when we load the MetaNodes and when we loadByPath.
It also implemented inside the loadCollection function, but that is rarely used, and whenever we will implement the loadMembers, that function could benefit from it as well.
