### PR TITLE
Feature/nodeless inquiry

### DIFF
--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -720,6 +720,18 @@ define([
         this.getMemberPaths = core.getMemberPaths;
 
         /**
+         * Returns the list of absolute paths of the members of the given set of the given node that not simply
+         * inherited.
+         * @param {module:Core~Node} node - the set owner.
+         * @param {string} name - the name of the set.
+         *
+         * @return {string[]} Returns an array of absolute path strings of the member nodes of the set that has
+         * information on the node's inharitance level.
+         * @func
+         */
+        this.getOwnMemberPaths = core.getOwnMemberPaths;
+
+        /**
          * Removes a member from the set. The functions doesn't remove the node itself.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
@@ -1419,6 +1431,21 @@ define([
          * @func
          */
         this.isMetaNode = core.isMetaNode;
+
+        /**
+         * Checks if the member is completely overridden in the set of the node.
+         * @param {module:Core~Node} node - the node to test.
+         * @param {string} setName - the name of the set of the node.
+         * @param {string} memberPath - the path of the member in question.
+         *
+         * @return {bool} Returns true if the member exists in the base of the set, but was
+         * added to the given set as well, which means a complete override. If the set do not exist
+         * or the member do not have a 'base' member or just some property was overridden, the function returns
+         * false.
+         *
+         * @func
+         */
+        this.isFullyOverriddenMember = core.isFullyOverriddenMember;
     }
 
     return Core;

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -545,7 +545,30 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         function getPointerNames(node) {
             ASSERT(isValidNode(node));
 
-            var source = '';
+            //var source = '';
+            //var names = [];
+            //
+            //do {
+            //    var child = (coretree.getProperty(node, OVERLAYS) || {})[source];
+            //    if (child) {
+            //        for (var name in child) {
+            //            ASSERT(names.indexOf(name) === -1);
+            //            if (isPointerName(name)) {
+            //                names.push(name);
+            //            }
+            //        }
+            //    }
+            //
+            //    source = '/' + coretree.getRelid(node) + source;
+            //    node = coretree.getParent(node);
+            //} while (node);
+            //
+            //return names;
+
+            return getPointerNamesFrom(node, '');
+        }
+
+        function getPointerNamesFrom(node, source) {
             var names = [];
 
             do {
@@ -569,13 +592,40 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         function getPointerPath(node, name) {
             ASSERT(isValidNode(node) && typeof name === 'string');
 
-            var source = '';
-            var target;
+            //var source = '';
+            //var target;
+            //
+            //do {
+            //    var child = (coretree.getProperty(node, OVERLAYS) || {})[source];
+            //    if (child) {
+            //        target = child[name];
+            //        if (target !== undefined) {
+            //            break;
+            //        }
+            //    }
+            //
+            //    source = '/' + coretree.getRelid(node) + source;
+            //    node = coretree.getParent(node);
+            //} while (node);
+            //
+            //if (target !== undefined) {
+            //    ASSERT(node);
+            //    target = coretree.joinPaths(coretree.getPath(node), target);
+            //}
+            //
+            //return target;
+            return getPointerPathFrom(node, '', name);
+        }
+
+        function getPointerPathFrom(node, source, name) {
+            ASSERT(isValidNode(node) && typeof source === 'string' && typeof name === 'string');
+            var target,
+                ovrInfo;
 
             do {
-                var child = (coretree.getProperty(node, OVERLAYS) || {})[source];
-                if (child) {
-                    target = child[name];
+                ovrInfo = (coretree.getProperty(node, OVERLAYS) || {})[source];
+                if (ovrInfo) {
+                    target = ovrInfo[name];
                     if (target !== undefined) {
                         break;
                     }
@@ -583,6 +633,7 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
 
                 source = '/' + coretree.getRelid(node) + source;
                 node = coretree.getParent(node);
+
             } while (node);
 
             if (target !== undefined) {
@@ -591,6 +642,33 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
             }
 
             return target;
+        }
+
+        function getPointersFrom(node, source) {
+            ASSERT(isValidNode(node) && typeof source === 'string');
+            var ovrInfo,
+                targets = {},
+                keys, i;
+
+            do {
+                ovrInfo = (coretree.getProperty(node, OVERLAYS) || {})[soource];
+                if (ovrInfo) {
+                    keys = Object.keys(ovrInfo);
+                    for (i = 0; i < keys.length; i += 1) {
+                        if (isPointerName(keys[i])) {
+                            targets[keys[i]] = ovrInfo[keys[i]];
+                            if (targets[keys[i]] === undefined) {
+                                delete targets[keys[i]];
+                            }
+                        }
+                    }
+                }
+
+                source = '/' + coretree.getRelid(node) + source;
+                node = coretree.getParent(node);
+            } while (node);
+
+            return targets;
         }
 
         function hasPointer(node, name) {
@@ -832,7 +910,10 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         corerel.delRegistry = delRegistry;
 
         corerel.getPointerNames = getPointerNames;
+        corerel.getPointerNamesFrom = getPointerNamesFrom;
         corerel.getPointerPath = getPointerPath;
+        corerel.getPointerPathFrom = getPointerPathFrom;
+        corerel.getPointersFrom = getPointersFrom;
         corerel.hasPointer = hasPointer;
         corerel.getOutsidePointerPath = getOutsidePointerPath;
         corerel.loadPointer = loadPointer;

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -556,9 +556,27 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
         core.getPointerNames = function (node) {
             ASSERT(isValidNode(node));
 
+            return core.getPointerNamesFrom(node, '');
+            //var merged = {};
+            //do {
+            //    var names = oldcore.getPointerNames(node);
+            //    for (var i = 0; i < names.length; ++i) {
+            //        if (!(names[i] in merged)) {
+            //            merged[names[i]] = true;
+            //        }
+            //    }
+            //
+            //    node = node.base;
+            //} while (node);
+            //
+            //return Object.keys(merged);
+        };
+        core.getPointerNamesFrom = function (node, source) {
+            ASSERT(isValidNode(node));
+
             var merged = {};
             do {
-                var names = oldcore.getPointerNames(node);
+                var names = oldcore.getPointerNamesFrom(node, source);
                 for (var i = 0; i < names.length; ++i) {
                     if (!(names[i] in merged)) {
                         merged[names[i]] = true;
@@ -570,20 +588,24 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
 
             return Object.keys(merged);
         };
+
         core.getOwnPointerNames = function (node) {
             ASSERT(isValidNode(node));
             return oldcore.getPointerNames(node);
         };
 
-        core.getPointerPath = function (node, name) {
+        core.getOwnPointerNamesFrom = function (node, source) {
+            return oldcore.getPointerNamesFrom(node, source);
+        };
+
+        core.getPointerPathFrom = function (node, source, name) {
             ASSERT(isValidNode(node) && typeof name === 'string');
 
-            var ownPointerPath = oldcore.getPointerPath(node, name);
+            var ownPointerPath = oldcore.getPointerPathFrom(node, source, name);
             if (ownPointerPath !== undefined) {
                 return ownPointerPath;
             }
-            var source = '',
-                target,
+            var target,
                 coretree = core.getCoreTree(),
                 basePath,
                 hasNullTarget = false,
@@ -596,7 +618,7 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
                     return property;
                 },
                 getSimpleBasePath = function (node) {
-                    var path = oldcore.getPointerPath(node, name);
+                    var path = oldcore.getPointerPathFrom(node, source, name);
                     if (path === undefined) {
                         if (node.base !== null && node.base !== undefined) {
                             return getSimpleBasePath(node.base);
@@ -676,9 +698,115 @@ define(['common/util/assert', 'common/core/core', 'common/core/tasync'], functio
             return undefined;
 
         };
+        core.getPointerPath = function (node, name) {
+
+            return core.getPointerPathFrom(node, '', name);
+            //ASSERT(isValidNode(node) && typeof name === 'string');
+            //
+            //var ownPointerPath = oldcore.getPointerPath(node, name);
+            //if (ownPointerPath !== undefined) {
+            //    return ownPointerPath;
+            //}
+            //var source = '',
+            //    target,
+            //    coretree = core.getCoreTree(),
+            //    basePath,
+            //    hasNullTarget = false,
+            //    getProperty = function (node, name) {
+            //        var property;
+            //        while (property === undefined && node !== null) {
+            //            property = coretree.getProperty(node, name);
+            //            node = core.getBase(node);
+            //        }
+            //        return property;
+            //    },
+            //    getSimpleBasePath = function (node) {
+            //        var path = oldcore.getPointerPath(node, name);
+            //        if (path === undefined) {
+            //            if (node.base !== null && node.base !== undefined) {
+            //                return getSimpleBasePath(node.base);
+            //            } else {
+            //                return undefined;
+            //            }
+            //        } else {
+            //            return path;
+            //        }
+            //    },
+            //    getParentOfBasePath = function (node) {
+            //        if (node.base) {
+            //            var parent = core.getParent(node.base);
+            //            if (parent) {
+            //                return core.getPath(parent);
+            //            } else {
+            //                return undefined;
+            //            }
+            //        } else {
+            //            return undefined;
+            //        }
+            //    },
+            //    getBaseOfParentPath = function (node) {
+            //        var parent = core.getParent(node);
+            //        if (parent) {
+            //            if (parent.base) {
+            //                return core.getPath(parent.base);
+            //            } else {
+            //                return undefined;
+            //            }
+            //        } else {
+            //            return undefined;
+            //        }
+            //    },
+            //    getTargetRelPath = function (node, relSource, name) {
+            //        var ovr = core.getChild(node, 'ovr');
+            //        var source = core.getChild(ovr, relSource);
+            //        return getProperty(source, name);
+            //    };
+            //
+            //basePath = node.base ? getSimpleBasePath(node.base) : undefined;
+            //
+            //while (node) {
+            //    target = getTargetRelPath(node, source, name);
+            //    if (target !== undefined) {
+            //        if (target.indexOf('_nullptr') !== -1) {
+            //            hasNullTarget = true;
+            //            target = undefined;
+            //        } else {
+            //            break;
+            //        }
+            //    }
+            //
+            //    source = '/' + core.getRelid(node) + source;
+            //    if (getParentOfBasePath(node) === getBaseOfParentPath(node)) {
+            //        node = core.getParent(node);
+            //    } else {
+            //        node = null;
+            //    }
+            //}
+            //
+            //
+            //if (target !== undefined) {
+            //    ASSERT(node);
+            //    target = coretree.joinPaths(oldcore.getPath(node), target);
+            //}
+            //
+            //if (typeof target === 'string') {
+            //    return target;
+            //}
+            //if (typeof basePath === 'string') {
+            //    return basePath;
+            //}
+            //if (hasNullTarget === true) {
+            //    return null;
+            //}
+            //return undefined;
+
+        };
         core.getOwnPointerPath = function (node, name) {
             oldcore.getPointerPath(node, name);
         };
+        core.getOwnPointerPathFrom = function (node, source, name) {
+            oldcore.getPointerPathFrom(node, source, name);
+        }
 
         core.setBase = function (node, base) {
             ASSERT(isValidNode(node) && (base === undefined || base === null || isValidNode(base)));

--- a/test/common/core/core.intrapersist.js
+++ b/test/common/core/core.intrapersist.js
@@ -9,6 +9,7 @@ describe('core.intrapersist', function () {
     var gmeConfig = testFixture.getGmeConfig(),
         logger = testFixture.logger.fork('core.intrapersist'),
         Q = testFixture.Q,
+        expect = testFixture.expect,
         storage,
         CANON = testFixture.requirejs('../src/common/util/canon');
 
@@ -87,7 +88,7 @@ describe('core.intrapersist', function () {
             s1NodePrimePath = '/1710723537/274170516',
             nodes = null;
 
-        before(function(done){
+        before(function (done) {
             core.loadRoot(rootHash, function (err, r) {
                 if (err) {
                     return done(err);
@@ -224,61 +225,40 @@ describe('core.intrapersist', function () {
             }
         });
         it('checks the set harmonization for member registry', function () {
-            var elements, elementsPrime, position;
-            elements = core.getMemberPaths(nodes[e1NodePath], 'mySpecials');
-            elements.sort();
-            elementsPrime = core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials');
-            elementsPrime.sort();
-            if (CANON.stringify(elements) !== CANON.stringify(['/1736622193/1579656591', '/1736622193/274170516']) ||
-                CANON.stringify(elementsPrime) !== CANON.stringify(['/1710723537/1579656591',
-                    '/1710723537/274170516'])) {
 
-                throw new Error('initial set members are wrong');
-            }
+            expect(core.getMemberPaths(nodes[e1NodePath], 'mySpecials'))
+                .to.have.members(['/1736622193/1579656591', '/1736622193/274170516']);
+            expect(core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials'))
+                .to.have.members(['/1710723537/1579656591', '/1710723537/274170516']);
 
             core.delMember(nodes[e1NodePath], 'mySpecials', s1NodePath);
-            elements = core.getMemberPaths(nodes[e1NodePath], 'mySpecials');
-            elements.sort();
-            elementsPrime = core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials');
-            elementsPrime.sort();
-            if (CANON.stringify(elements) !== CANON.stringify(['/1736622193/1579656591']) ||
-                CANON.stringify(elementsPrime) !== CANON.stringify(['/1710723537/1579656591'])) {
-                throw new Error('removed set members are wrong');
-            }
+
+            expect(core.getMemberPaths(nodes[e1NodePath], 'mySpecials'))
+                .to.have.members(['/1736622193/1579656591']);
+            expect(core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials'))
+                .to.have.members(['/1710723537/1579656591','/1710723537/274170516']);
 
             core.addMember(nodes[e1NodePrimePath], 'mySpecials', nodes[s1NodePrimePath]);
             core.setMemberRegistry(nodes[e1NodePrimePath], 'mySpecials', s1NodePrimePath, 'position', {x: 100, y: 200});
-            elements = core.getMemberPaths(nodes[e1NodePath], 'mySpecials');
-            elements.sort();
-            elementsPrime = core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials');
-            elementsPrime.sort();
-            position = core.getMemberRegistry(nodes[e1NodePrimePath], 'mySpecials', s1NodePrimePath, 'position');
-            if (CANON.stringify(elements) !== CANON.stringify(['/1736622193/1579656591']) ||
-                CANON.stringify(elementsPrime) !== CANON.stringify(['/1710723537/1579656591',
-                    '/1710723537/274170516']) ||
-                position.x !== 100 || position.y !== 200) {
 
-                throw new Error('prime set members are wrong');
-            }
+            expect(core.getMemberPaths(nodes[e1NodePath], 'mySpecials'))
+                .to.have.members(['/1736622193/1579656591']);
+            expect(core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials'))
+                .to.have.members(['/1710723537/1579656591', '/1710723537/274170516']);
+            expect(core.getMemberRegistry(nodes[e1NodePrimePath], 'mySpecials', s1NodePrimePath, 'position'))
+                .to.deep.equal({x: 100, y: 200});
 
             core.addMember(nodes[e1NodePath], 'mySpecials', nodes[s1NodePath]);
             core.setMemberRegistry(nodes[e1NodePath], 'mySpecials', s1NodePath, 'position', {x: 200, y: 300});
-            elements = core.getMemberPaths(nodes[e1NodePath], 'mySpecials');
-            elements.sort();
-            elementsPrime = core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials');
-            elementsPrime.sort();
-            position = core.getMemberRegistry(nodes[e1NodePrimePath], 'mySpecials', s1NodePrimePath, 'position');
-            if (CANON.stringify(elements) !== CANON.stringify(['/1736622193/1579656591', '/1736622193/274170516']) ||
-                CANON.stringify(elementsPrime) !== CANON.stringify(['/1710723537/1579656591',
-                    '/1710723537/274170516']) ||
-                position.x !== 100 || position.y !== 200) {
 
-                throw new Error('prime set member registry value are wrong');
-            }
-            position = core.getMemberRegistry(nodes[e1NodePath], 'mySpecials', s1NodePath, 'position');
-            if (position.x !== 200 || position.y !== 300) {
-                throw new Error('member registry value is wrong');
-            }
+            expect(core.getMemberPaths(nodes[e1NodePath], 'mySpecials'))
+                .to.have.members(['/1736622193/1579656591', '/1736622193/274170516']);
+            expect(core.getMemberPaths(nodes[e1NodePrimePath], 'mySpecials'))
+                .to.have.members(['/1710723537/1579656591', '/1710723537/274170516']);
+            expect(core.getMemberRegistry(nodes[e1NodePrimePath], 'mySpecials', s1NodePrimePath, 'position'))
+                .to.deep.equal({x: 100, y: 200});
+            expect(core.getMemberRegistry(nodes[e1NodePath], 'mySpecials', s1NodePath, 'position'))
+                .to.deep.equal({x: 200, y: 300});
 
         });
         it('modified set elements should be visible in already loaded nodes', function () {

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -156,4 +156,94 @@ describe('set core', function () {
 
         expect(core.getMemberPaths(setInstance, 'set')).to.have.members([core.getPath(instanceMember)]);
     });
+
+    it('fully overriden members should remain even after base member is removed', function () {
+        var setType = core.createNode({parent: root}),
+            setInstance = core.createNode({parent: root, base: setType}),
+            member = core.createNode({parent: root});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', member);
+
+        expect(core.getMemberPaths(setType, 'set')).to.have.members([core.getPath(member)]);
+        expect(core.getMemberPaths(setInstance, 'set')).to.have.members([core.getPath(member)]);
+
+        //override the member
+        core.addMember(setInstance, 'set', member);
+
+        expect(core.getMemberPaths(setType, 'set')).to.have.members([core.getPath(member)]);
+        expect(core.getMemberPaths(setInstance, 'set')).to.have.members([core.getPath(member)]);
+
+        //remove from base
+        core.delMember(setType, 'set', core.getPath(member));
+        expect(core.getMemberPaths(setType, 'set')).to.empty;
+        expect(core.getMemberPaths(setInstance, 'set')).to.have.members([core.getPath(member)]);
+    });
+
+    it('overriding a member should get the already overridden properties', function () {
+        var setType = core.createNode({parent: root}),
+            setInstance = core.createNode({parent: root, base: setType}),
+            member = core.createNode({parent: root});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', member);
+
+        expect(core.getMemberPaths(setType, 'set')).to.have.members([core.getPath(member)]);
+        expect(core.getMemberPaths(setInstance, 'set')).to.have.members([core.getPath(member)]);
+
+        //override the member's properties
+        core.setMemberAttribute(setInstance, 'set', core.getPath(member), 'attribute', 'value');
+        core.setMemberRegistry(setInstance, 'set', core.getPath(member), 'registry', 'regValue');
+
+        expect(core.getMemberAttribute(setType, 'set', core.getPath(member), 'attribute')).to.equal(undefined);
+        expect(core.getMemberAttribute(setInstance, 'set', core.getPath(member), 'attribute')).to.equal('value');
+        expect(core.getMemberRegistry(setType, 'set', core.getPath(member), 'registry')).to.equal(undefined);
+        expect(core.getMemberRegistry(setInstance, 'set', core.getPath(member), 'registry')).to.equal('regValue');
+
+        //now override the member
+        core.addMember(setInstance, 'set', member);
+
+        expect(core.getMemberAttribute(setInstance, 'set', core.getPath(member), 'attribute')).to.equal('value');
+        expect(core.getMemberRegistry(setInstance, 'set', core.getPath(member), 'registry')).to.equal('regValue');
+
+
+    });
+
+    it('should return all member as own, that has new information', function () {
+        var setType = core.createNode({parent: root}),
+            setInstance = core.createNode({parent: root, base: setType}),
+            fullyOverriddenMember = core.createNode({parent: root}),
+            propertyOverriddenMember = core.createNode({parent: root}),
+            newMember = core.createNode({parent: root});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', fullyOverriddenMember);
+        core.addMember(setType, 'set', propertyOverriddenMember);
+        core.addMember(setInstance, 'set', newMember);
+
+        expect(core.getOwnMemberPaths(setType, 'set')).to.have.members([
+            core.getPath(fullyOverriddenMember),
+            core.getPath(propertyOverriddenMember)
+        ]);
+        expect(core.getOwnMemberPaths(setInstance, 'set')).to.have.members([
+            core.getPath(newMember)
+        ]);
+
+        //now override the property
+        core.setMemberAttribute(setInstance,'set',core.getPath(propertyOverriddenMember),'myAttr','myValue');
+
+        expect(core.getOwnMemberPaths(setInstance, 'set')).to.have.members([
+            core.getPath(propertyOverriddenMember),
+            core.getPath(newMember)
+        ]);
+
+        //now override the member
+        core.addMember(setInstance, 'set', fullyOverriddenMember);
+
+        expect(core.getOwnMemberPaths(setInstance, 'set')).to.have.members([
+            core.getPath(fullyOverriddenMember),
+            core.getPath(propertyOverriddenMember),
+            core.getPath(newMember)
+        ]);
+    });
 });

--- a/test/common/core/users/serialization.spec.js
+++ b/test/common/core/users/serialization.spec.js
@@ -196,4 +196,25 @@ describe('serialization', function () {
             })
             .nodeify(done);
     });
+
+    it('should export set contents with own flag', function (done) {
+        var core = contextFrom.core,
+            setNodeGuid = '880bcd49-2d97-6074-c4aa-c54e9b638c86',
+            memberGuid = '990bcd49-2d97-6074-c4aa-c54e9b638c86',
+            root = core.createNode({}),
+            setBase = core.createNode({parent: root}),
+            setNode = core.createNode({parent: root, base: setBase, guid: setNodeGuid}),
+            member = core.createNode({parent: root,guid: memberGuid});
+
+        core.addMember(setBase, 'set', member);
+        core.addMember(setNode, 'set', member);
+        Q.nfcall(Serialization.export, core, root)
+            .then(function (result) {
+                expect(result.nodes[setNodeGuid].sets.set[0].overridden).to.equal(true);
+                expect(result.nodes[setNodeGuid].sets.set[0].guid).to.equal(memberGuid);
+                done();
+            })
+            .catch(done);
+
+    });
 });


### PR DESCRIPTION
To speed up inquiries on core we implemented the functions in a manner when no sub-gmeNode objects are created during inquiry (the way of manipulating have not changed).
In the process we reviewed the setcore and make some changes:
- getOwnMemberPaths now available on the core API to get those members of a set, that has some information on the node's level (so not completely inherited)
- isFullyOverriddenMember now available on core API to check if a member have been added to the set of the node, though it was inherited as well
- a new optional flag 'overridden' is now used in the export format when describing the set members, to capture if a member was completely overridden on the node's inheritance level (so added to the set directly on the node)

To measure the speed increase we simply exported a relatively bigger model (189Kb in export size):
- with the current master branch, the speed was varying from 1605ms to 2038ms
- with the nodeless_inquiry addition, the speed was reduced to the range of 756ms to 1033ms
This is roughly a ***50%*** increase or we can say it is ***twice*** as fast as the original one. We have to mention that this increase may not effect (or not effect to this extent) all UI operation.