### PR TITLE
Fixes #632 Uncaught Error while loading a branch

### DIFF
--- a/src/common/storage/project/cache.js
+++ b/src/common/storage/project/cache.js
@@ -64,7 +64,7 @@ define(['common/util/assert', 'common/storage/constants'], function (ASSERT, CON
                                     ASSERT(missing[key] === obj);
 
                                     delete missing[key];
-                                    if (!err && obj2) {
+                                    if (!err && obj2 && !cache[key]) {
                                         cacheInsert(key, obj2);
                                     }
 
@@ -135,7 +135,7 @@ define(['common/util/assert', 'common/storage/constants'], function (ASSERT, CON
                 while (i--) {
                     fullyCovered = true;
                     pathArray = paths[i].split('/');
-                    if(pathArray.length > 1){
+                    if (pathArray.length > 1) {
                         pathArray.shift();
                     }
                     obj = rootObj;


### PR DESCRIPTION
with the loadPaths function it is now possible that when the loadObject returns from the server, the object is already placed in the cache by a parallel loadPaths, so we have to check if the object already exists before we really put it into the cache twice.