### PR TITLE
Fixes #647 Title of an object is wrong after inline editor usage

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/templates/AttributeDetailsDialog.html
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/templates/AttributeDetailsDialog.html
@@ -50,7 +50,7 @@
                 <div class="form-group" id="pRegExp">
                     <label class="col-sm-4 control-label">Regular Expression</label>
                     <div class="col-sm-8 controls">
-                        <input type="text" id="inputRegExp" placeholder="/.*/g">
+                        <input type="text" id="inputRegExp" title="No leading and trailing slash needed. Modifiers not allowed!">
                     </div>
                 </div>
                 <div class="form-group" id="pRange">

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
@@ -77,6 +77,10 @@ define([
                     value: self.name,
                     onChange: function (oldValue, newValue) {
                         self.__onNodeTitleChanged(oldValue, newValue);
+                    },
+                    onFinish: function () {
+                        self.skinParts.$name.text(self.formattedName);
+                        self.skinParts.$name.attr('title', self.formattedName);
                     }
                 });
             }
@@ -469,14 +473,15 @@ define([
         }
     };
 
-    ModelDecoratorDiagramDesignerWidget.prototype.__onMouseUp = function (/*event*/) {
+    ModelDecoratorDiagramDesignerWidget.prototype.__onMouseUp = function (event) {
         if (this.__onDragOver) {
             // TODO: this is still questionable if we should hack the jQeuryUI 's
             // TODO: draggable&droppable and use half of it only
             this.__onBackgroundDrop($.ui.ddmanager.current.helper);
             this.__onDragOver = false;
-            // This sometimes brings up the dropdown menu for the canvas-drop (typically near the border of the ref).
-            this.hostDesignerItem.canvas._enableDroppable(true);
+
+            //in rare cases this can cause drop ignoring
+            this.hostDesignerItem.canvas._enableDroppable(false);
         }
     };
 

--- a/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.js
@@ -68,6 +68,10 @@ define([
                     value: self.name,
                     onChange: function (oldValue, newValue) {
                         self.__onNodeTitleChanged(oldValue, newValue);
+                    },
+                    onFinish: function () {
+                        self.$name.text(self.formattedName);
+                        self.$name.attr('title', self.formattedName);
                     }
                 });
             }

--- a/src/client/js/Dialogs/Import/styles/ImportDialog.css
+++ b/src/client/js/Dialogs/Import/styles/ImportDialog.css
@@ -1,5 +1,9 @@
 .uploaded-file-name {
-  padding: 0 1ex; }
+  padding: 0 1ex;
+  width: 90%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden; }
 
 .uploaded-file-name.empty {
   color: #999;

--- a/src/client/js/Dialogs/Import/styles/ImportDialog.scss
+++ b/src/client/js/Dialogs/Import/styles/ImportDialog.scss
@@ -1,5 +1,9 @@
 .uploaded-file-name {
   padding: 0 1ex;
+  width: 90%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .uploaded-file-name.empty {

--- a/src/client/js/Dialogs/Import/templates/ImportDialog.html
+++ b/src/client/js/Dialogs/Import/templates/ImportDialog.html
@@ -24,7 +24,7 @@
                         <div class="col-sm-9 controls">
                             <div class="widget">
                                 <div class="asset-widget file-drop-target">
-                                    <span class="uploaded-file-name empty">No file selected</span>
+                                    <div class="uploaded-file-name empty">No file selected</div>
                                     <a class="btn btn-mini btn-dialog-open">
                                         <i class="glyphicon glyphicon-file"></i>
                                     </a>


### PR DESCRIPTION
When the node has a formatted name, the inplace editor can mess it up (if no editing happened), but with handling the onFinish function, we fixed it and restore its value in those cases.
Fix also the problem of long project file import names (start using the overflow '...')
Fix the double-drop handling (as it became frequent), so if you drop the pointer target, the pop-up menu of the canvas drop will not show.
Fix the 'default hint' on the regular expression of the meta attribute definition.