### PR TITLE
executor: fix FAILED_UNZIP jobs being re-run

### DIFF
--- a/src/common/executor/ExecutorWorker.js
+++ b/src/common/executor/ExecutorWorker.js
@@ -164,6 +164,7 @@ define([
                         function (err, stdout, stderr) {
                             if (err) {
                                 jobInfo.status = 'FAILED_UNZIP';
+                                jobInfo.finishTime = new Date().toISOString();
                                 console.error(stderr);
                                 errorCallback(err);
                                 return;
@@ -178,6 +179,7 @@ define([
                             fs.readFile(path.join(jobDir, self.executorConfigFilename), 'utf8', function (err, data) {
                                 if (err) {
                                     jobInfo.status = 'FAILED_EXECUTOR_CONFIG';
+                                    jobInfo.finishTime = new Date().toISOString();
                                     errorCallback('Could not read ' + self.executorConfigFilename + ' err:' + err);
                                     return;
                                 }
@@ -191,6 +193,7 @@ define([
                                     typeof executorConfig.resultArtifacts !== 'object') {
 
                                     jobInfo.status = 'FAILED_EXECUTOR_CONFIG';
+                                    jobInfo.finishTime = new Date().toISOString();
                                     errorCallback(self.executorConfigFilename + ' is missing or wrong type for cmd and/or resultArtifacts.');
                                     return;
                                 }

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -77,8 +77,7 @@ function initialize(middlewareOpts) {
                 // reset unfinished jobs assigned to worker to CREATED, so they'll be executed by someone else
                 self.logger.debug('worker "' + docs[i].clientId + '" is gone');
                 self.workerList.remove({_id: docs[i]._id});
-                // FIXME: race after assigning finishTime between this and uploading to blob
-                self.jobList.update({worker: docs[i].clientId, finishTime: null}, {
+                self.jobList.update({worker: docs[i].clientId, status: {$nin: JobInfo.finishedStatuses}}, {
                     $set: {
                         worker: null,
                         status: 'CREATED',


### PR DESCRIPTION
Worker: set finishTime on FAILED_UNZIP jobs.
Server: check status instead of finishTime when a worker leaves