### PR TITLE
Move config.client.usedDecorators to config.visualization.decoratorsToPreload

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -48,12 +48,6 @@ var path = require('path'),
             log: {
                 level: 'debug'
             },
-            usedDecorators: ['ModelDecorator',
-                             'CircleDecorator',
-                             'MetaDecorator',
-                             'SVGDecorator',
-                             'UMLStateMachineDecorator',
-                             'DefaultDecorator'],
             // Used in client/WebGME.js to load initial project (if url is specified that has higher priority)
             defaultContext: {
                 project: null,   // This is the projectId, e.g. 'guest+TestProject'
@@ -196,6 +190,7 @@ var path = require('path'),
 
         visualization: {
             decoratorPaths: [path.join(__dirname, '../src/client/decorators')],
+            decoratorsToPreload: null, // array of names (ids)
             svgDirs: [],
             visualizerDescriptors: [path.join(__dirname, '../src/client/js/Visualizers.json')],
 

--- a/src/client/js/WebGME.js
+++ b/src/client/js/WebGME.js
@@ -150,11 +150,12 @@ define([
 
                 client.decoratorManager = new DecoratorManager();
                 populateAvailableExtensionPoints(function (err) {
+                    var decorators = gmeConfig.visualization.decoratorsToPreload || WebGMEGlobal.allDecorators || [];
                     if (err) {
                         logger.error('Failed loading extension points', err);
                     }
 
-                    client.decoratorManager.downloadAll(gmeConfig.client.usedDecorators, function (err) {
+                    client.decoratorManager.downloadAll(decorators, function (err) {
                         if (err) {
                             logger.error(err);
                         }


### PR DESCRIPTION
The behavior is changed to.

config.client.usedDecorators was a list (always) of decorators to load before any panels were loaded. 

config.visualization.decoratorsToPreload can be null (default) and will in that case load all available decorators (i.e. the ones listed by /api/decorators/).

