### PR TITLE
Fix corrupt diff generation

### DIFF
--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -398,6 +398,8 @@ define(['common/util/canon',
                 tDiff = getPathOfDiff(diff, paths[i]);
                 if (tDiff.removed !== true) {
                     tDiff.pointer = tDiff.pointer || {source: {}, target: {}};
+                    tDiff.pointer.source = tDiff.pointer.source || {};
+                    tDiff.pointer.target = tDiff.pointer.target || {};
                     names = Object.keys(oDiff.source[paths[i]]);
                     for (j = 0; j < names.length; j++) {
                         tDiff.pointer.source[names[j]] = oDiff.source[paths[i]][names[j]];
@@ -747,6 +749,7 @@ define(['common/util/canon',
             };
 
             normalize(diff);
+
             return isEmptyNodeDiff(diff) ? null : diff;
         };
 


### PR DESCRIPTION
During difference generation it can happen that the relation information regarding a node is only partial at the time of checking, but it should not cause exception.
The logging during merge was also improved so the server logs would now point to actual place of error.