### PR TITLE
Refactored crosscut functionality.

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -689,6 +689,7 @@ define(['js/logger',
 
         this._selectedMemberListMembers = [];
         this._delayedConnections = [];
+        this._delayedConnectionsAsItems = {};
 
         //remove current territory patterns
         if (this._selectedMemberListMembersTerritoryId) {
@@ -1868,7 +1869,6 @@ define(['js/logger',
         this._GMEID2ComponentID[gmeID].push(uiComponent.id);
         this._ComponentID2GMEID[uiComponent.id] = gmeID;
 
-        this._delayedConnectionsAsItems = this._delayedConnectionsAsItems || {};
         this._delayedConnectionsAsItems[gmeID] = uiComponent.id;
     };
 

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -786,6 +786,15 @@ define(['js/logger',
         this.logger.debug('_dispatchEvents "' + events.length + '" items: ' + JSON.stringify(events));
 
         this._widget.beginUpdate();
+        //first call the updates of the decorators so they can pu out any port they use
+        j = Object.keys(this._GMEID2ComponentID || {});
+        for (i = 0; i < j.length; i += 1) {
+            if (this._widget.items[this._GMEID2ComponentID[j[i]]] &&
+                this._widget.items[this._GMEID2ComponentID[j[i]]]._decoratorInstance) {
+                this._widget.items[this._GMEID2ComponentID[j[i]]]._decoratorInstance.update();
+            }
+        }
+        //decorators have been updated we can move on
 
         /********** ORDER EVENTS BASED ON DEPENDENCY ************/
         /** 1: items first, no dependency **/
@@ -1148,8 +1157,8 @@ define(['js/logger',
                             objDesc.srcSubCompId = sources[k].subCompId;
                             objDesc.dstObjId = destinations[l].objId;
                             objDesc.dstSubCompId = destinations[l].subCompId;
-                            objDesc.reconnectable = false;
-                            objDesc.editable = false;
+                            objDesc.reconnectable = desc.reconnectable === undefined ? false : desc.reconnectable;
+                            objDesc.editable = desc.editable === undefined ? false : desc.editable;
 
                             delete objDesc.source;
                             delete objDesc.target;
@@ -1252,8 +1261,8 @@ define(['js/logger',
                         objDesc.srcSubCompId = sources[k].subCompId;
                         objDesc.dstObjId = destinations[l].objId;
                         objDesc.dstSubCompId = destinations[l].subCompId;
-                        objDesc.reconnectable = true;
-                        objDesc.editable = true;
+                        objDesc.reconnectable = desc.reconnectable === undefined ? true : desc.reconnectable;
+                        objDesc.editable = desc.editable === undefined ? true : desc.editable;
 
                         delete objDesc.source;
                         delete objDesc.target;
@@ -1282,12 +1291,23 @@ define(['js/logger',
                     len += 1;
                     while (len--) {
                         componentID = this._GMEID2ComponentID[gmeID][len];
-                        this._widget.deleteComponent(componentID);
-                        this._GMEID2ComponentID[gmeID].splice(len, 1);
-                        delete this._ComponentID2GMEID[componentID];
+                        //TODO plain designer items associated with the connection should not be removed
+                        if (componentID.indexOf('C_') === 0) {
+                            this._widget.deleteComponent(componentID);
+                            this._GMEID2ComponentID[gmeID].splice(len, 1);
+                            delete this._ComponentID2GMEID[componentID];
+                        }
                     }
                 }
             }
+        } else if (this._selectedMemberListMembers.indexOf(gmeID) === -1 &&
+            this._GMEID2ComponentID[gmeID]) {
+            //item have been removed from the set but remained in the territory
+            this._onUpdatePortToItem(gmeID, true, desc);
+
+        } else if (this._selectedMemberListMembers.indexOf(gmeID) !== -1 && !this._GMEID2ComponentID[gmeID]) {
+            //the item have been added to the set but was already in the territory
+            this._onUpdatePortToItem(gmeID, false, desc);
         }
 
         //check if one of the decorators' is dependent on this
@@ -1386,6 +1406,45 @@ define(['js/logger',
         return territoryChanged;
     };
 
+    DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._onUpdatePortToItem =
+        function (gmeID, remove, desc) {
+            var members = this._selectedMemberListMembers,
+                i,
+                node, src, dst,
+                connections = [];
+
+            for (i = 0; i < members.length; i += 1) {
+                node = this._client.getNode(members[i]);
+                if (node && node.isConnection()) {
+                    src = node.getPointer(SRC_POINTER_NAME).to;
+                    dst = node.getPointer(DST_POINTER_NAME).to;
+                    if (src === gmeID || dst === gmeID) {
+                        this._onUnload.call(this, members[i]);
+                        connections.push(members[i]);
+                    }
+                }
+            }
+
+            if (remove === true) {
+                this._onUnload(gmeID);
+            } else {
+                this._onLoad(gmeID, desc);
+            }
+
+            for (i = 0; i < connections.length; i += 1) {
+                node = this._client.getNode(connections[i]);
+                src = node.getPointer(SRC_POINTER_NAME).to;
+                dst = node.getPointer(DST_POINTER_NAME).to;
+                this._onLoad.call(this, connections[i], {
+                    isConnection: true,
+                    srcID: src,
+                    dstID: dst,
+                    reconnectable: false,
+                    editable: false
+                });
+            }
+        };
+
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype.registerComponentIDForPartID = function (componentID,
                                                                                                              partId) {
         this._componentIDPartIDMap[componentID] = this._componentIDPartIDMap[componentID] || [];
@@ -1413,6 +1472,7 @@ define(['js/logger',
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._checkComponentDependency = function (gmeID,
                                                                                                           eventType) {
         var len;
+
         if (this._componentIDPartIDMap && this._componentIDPartIDMap[gmeID]) {
             len = this._componentIDPartIDMap[gmeID].length;
             while (len--) {
@@ -1808,6 +1868,7 @@ define(['js/logger',
         this._GMEID2ComponentID[gmeID].push(uiComponent.id);
         this._ComponentID2GMEID[uiComponent.id] = gmeID;
 
+        this._delayedConnectionsAsItems = this._delayedConnectionsAsItems || {};
         this._delayedConnectionsAsItems[gmeID] = uiComponent.id;
     };
 

--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -695,7 +695,7 @@ define(['jquery',
         var result = [],
             EXCLUDED_SETS = [],
             nodeObj = client.getNode(containerId),
-            setNames = _.difference(nodeObj.getSetNames(), EXCLUDED_SETS),
+            setNames = _.difference(nodeObj.getValidSetNames(), EXCLUDED_SETS),
             len = setNames.length;
 
         while (len--) {

--- a/src/client/js/Widgets/Crosscut/styles/CrosscutWidget.css
+++ b/src/client/js/Widgets/Crosscut/styles/CrosscutWidget.css
@@ -1,0 +1,39 @@
+/**
+ * @author rkereskenyi / https://github.com/rkereskenyi
+ */
+div.filterPanel {
+  position: absolute;
+  top: 34px;
+  right: 11px;
+  background-color: white;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding;
+  background-clip: padding-box; }
+  div.filterPanel .header {
+    min-width: 100px;
+    text-align: center;
+    margin: 0 5px; }
+  div.filterPanel .body {
+    display: none;
+    list-style: none;
+    padding: 5px;
+    margin: 0; }
+    div.filterPanel .body li.filterItem {
+      margin: 3px 0; }
+      div.filterPanel .body li.filterItem .iCheckBox {
+        float: right;
+        margin-top: 6px;
+        margin-left: 3px; }
+      div.filterPanel .body li.filterItem div > svg {
+        margin-top: 4px; }
+  div.filterPanel:hover .header {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2); }
+  div.filterPanel:hover .body {
+    display: block; }

--- a/src/client/js/Widgets/Crosscut/styles/CrosscutWidget.scss
+++ b/src/client/js/Widgets/Crosscut/styles/CrosscutWidget.scss
@@ -1,0 +1,67 @@
+/**
+ * @author rkereskenyi / https://github.com/rkereskenyi
+ */
+
+$filterPanel-background-color: #FFFFFF;
+$filterPanel-top: 34px;
+$filterPanel-right: 11px;
+$filterPanel-border: 1px solid rgba(0, 0, 0, 0.2);
+$filterPanel-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+$filterPanel-header-min-width: 100px;
+
+div.filterPanel {
+  position: absolute;
+  top: $filterPanel-top;
+  right: $filterPanel-right;
+
+  background-color: $filterPanel-background-color;
+  border: $filterPanel-border;
+
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+
+  -webkit-box-shadow: $filterPanel-shadow;
+  -moz-box-shadow: $filterPanel-shadow;
+  box-shadow: $filterPanel-shadow;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding;
+  background-clip: padding-box;
+
+  .header {
+    min-width: $filterPanel-header-min-width;
+    text-align: center;
+    margin: 0 5px;
+  }
+
+  .body {
+    display: none;
+    list-style: none;
+    padding: 5px;
+    margin: 0;
+
+    li.filterItem {
+      margin: 3px 0;
+
+      .iCheckBox {
+        float: right;
+        margin-top: 6px;
+        margin-left: 3px;
+      }
+
+      div > svg {
+        margin-top: 4px;
+      }
+    }
+  }
+
+  &:hover {
+    .header {
+      border-bottom: $filterPanel-border;
+    }
+
+    .body {
+      display: block;
+    }
+  }
+}

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
@@ -65,21 +65,21 @@ define([
             this.toolbarItems.radioButtonGroupRouteManager.addButton({
                 title: 'Basic route manager',
                 icon: btnIconBase.clone().addClass('gme icon-gme_diagonal-arrow'),
-                selected: WebGMEGlobal.gmeConfig.client.defaultConnectionRouter === 'basic',
+                selected: this._defaultConnectionRouteManagerType === 'basic',
                 data: {type: 'basic'}
             });
 
             this.toolbarItems.radioButtonGroupRouteManager.addButton({
                 title: 'Basic+ route manager',
                 icon: btnIconBase.clone().addClass('gme icon-gme_broken-arow'),
-                selected: WebGMEGlobal.gmeConfig.client.defaultConnectionRouter === 'basic2',
+                selected: this._defaultConnectionRouteManagerType === 'basic2',
                 data: {type: 'basic2'}
             });
 
             this.toolbarItems.radioButtonGroupRouteManager.addButton({
                 title: 'AutoRouter',
                 icon: btnIconBase.clone().addClass('gme icon-gme_broken-arrow-with-box'),
-                selected: WebGMEGlobal.gmeConfig.client.defaultConnectionRouter === 'basic3',
+                selected: this._defaultConnectionRouteManagerType === 'basic3',
                 data: {type: 'basic3'}
             });
             /************** END OF - ROUTING MANAGER SELECTION **************************/

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -81,7 +81,8 @@ define([
         gridSize: 10,
         droppable: true,
         zoomValues: [0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 5, 10],
-        zoomUIControls: true
+        zoomUIControls: true,
+        defaultConnectionRouteManagerType: WebGMEGlobal.gmeConfig.client.defaultConnectionRouter
     };
 
     DiagramDesignerWidget = function (container, par) {
@@ -204,14 +205,15 @@ define([
         //this.dragManager.initialize(this.skinParts.$itemsContainer);
 
         /*********** CONNECTION DRAWING COMPONENT *************/
+        this._defaultConnectionRouteManagerType = params.defaultConnectionRouteManagerType;
         //initiate Connection Router (if needed)
         if (params.connectionRouteManager) {
             this.connectionRouteManager = params.connectionRouteManager;
-        } else if (this.gmeConfig.client.defaultConnectionRouter === 'basic') {
+        } else if (params.defaultConnectionRouteManagerType === 'basic') {
             this.connectionRouteManager = new ConnectionRouteManagerBasic({diagramDesigner: this});
-        } else if (this.gmeConfig.client.defaultConnectionRouter === 'basic2') {
+        } else if (params.defaultConnectionRouteManagerType === 'basic2') {
             this.connectionRouteManager = new ConnectionRouteManager2({diagramDesigner: this});
-        } else if (this.gmeConfig.client.defaultConnectionRouter === 'basic3') {
+        } else if (params.defaultConnectionRouteManagerType === 'basic3') {
             this.connectionRouteManager = new ConnectionRouteManager3({diagramDesigner: this});
         }
 
@@ -1480,7 +1482,7 @@ define([
 
     /************** END OF - API REGARDING TO MANAGERS ***********************/
 
-    //additional code pieces for DiagramDesignerWidget
+        //additional code pieces for DiagramDesignerWidget
     _.extend(DiagramDesignerWidget.prototype, DiagramDesignerWidgetOperatingModes.prototype);
     _.extend(DiagramDesignerWidget.prototype, DiagramDesignerWidgetDesignerItems.prototype);
     _.extend(DiagramDesignerWidget.prototype, DiagramDesignerWidgetConnections.prototype);


### PR DESCRIPTION
- connections now visualized like in Composition view
- set membership relation is visible
- relations can be filtered on every crosscut
- filter states are saved with the project
- default connection manager is set to CM2
- manual tests have been created and stored on google drive
- if a node is visualized as port and as a separate item as well the preference is at the item (so connections will end there)
- adding a node to the crosscut if it was already visualized as port is now possible (both become be visible)
- removing a node that is also visualized as port is now possible