### PR TITLE
Closes #660 Temporary suppress drop action from decorator

### DIFF
--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
@@ -480,8 +480,8 @@ define([
             this.__onBackgroundDrop($.ui.ddmanager.current.helper);
             this.__onDragOver = false;
 
-            //FIXME This brings up the dropdown menu for the canvas-drop or allow execution of a single drop-command
-            this.hostDesignerItem.canvas._enableDroppable(true);
+            // Temporarily suppress the drop action (i.e. the drop select menu) of the canvas.
+            this.hostDesignerItem.canvas.acceptDropTempDisabled = true;
         }
     };
 
@@ -526,8 +526,8 @@ define([
                 }
 
                 menu = new ContextMenu({
-                    'items': menuItems,
-                    'callback': function (key) {
+                    items: menuItems,
+                    callback: function (key) {
                         self._navigateToPointerTarget(ptrTargets[key]);
                     }
                 });

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Droppable.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Droppable.js
@@ -23,6 +23,10 @@ define([
 
         this._acceptDroppable = false;
 
+        // Used from outside (ModelDecorator) when the default drop handling needs to take place in order to
+        // 'clear' event, keep the droppable enabled, but not bringing up the options for drop.
+        this.acceptDropTempDisabled = false;
+
         this.skinParts.$dropRegion = $('<div/>', {class: DiagramDesignerWidgetConstants.DROP_REGION_CLASS});
 
         this.skinParts.$dropRegion.insertBefore(this.skinParts.$itemsContainer);
@@ -96,7 +100,11 @@ define([
         this.logger.debug('_onBackgroundDrop: ' + JSON.stringify(dragInfo));
 
         if (this._acceptDroppable === true) {
-            this.onBackgroundDrop(event, dragInfo, {x: posX, y: posY});
+            if (this.acceptDropTempDisabled === true) {
+                this.acceptDropTempDisabled = false;
+            } else {
+                this.onBackgroundDrop(event, dragInfo, {x: posX, y: posY});
+            }
         }
 
         this._doAcceptDroppable(false, false);


### PR DESCRIPTION
This fixes the issue that the canvas on drop menu shows up when setting a pointer by dropping on an item using the model-decorator.