### PR TITLE
Fix the selection of the default visualizer

### DIFF
--- a/src/client/js/Constants.js
+++ b/src/client/js/Constants.js
@@ -91,7 +91,10 @@ define([
         PROPERTY_GROUP_META: 'META',
         PROPERTY_GROUP_PREFERENCES: 'Preferences',
         PROPERTY_GROUP_ATTRIBUTES: 'Attributes',
-        PROPERTY_GROUP_POINTERS: 'Pointers'
+        PROPERTY_GROUP_POINTERS: 'Pointers',
+
+        /* Visualizer */
+        DEFAULT_VISUALIZER: 'ModelEditor'
     });
 
     clientConstants.CLIENT = CLIENT_CONSTANTS;

--- a/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
@@ -27,7 +27,6 @@ define(['js/logger',
         GME_CONNECTION_CLASS = 'gme-connection',
         GME_ROOT_ICON = 'gme-root',
         GME_ASPECT_ICON = 'gme-aspect',
-        DEFAULT_VISUALIZER = 'ModelEditor',
         CROSSCUT_VISUALIZER = 'Crosscut',
         SET_VISUALIZER = 'SetEditor',
         TREE_ROOT = CONSTANTS.PROJECT_ROOT_ID,
@@ -272,9 +271,7 @@ define(['js/logger',
             treeBrowser.onNodeDoubleClicked = function (nodeId) {
                 logger.debug('Firing onNodeDoubleClicked with nodeId: ' + nodeId);
                 var settings = {};
-                settings[CONSTANTS.STATE_ACTIVE_OBJECT] = nodeId;
-                settings[CONSTANTS.STATE_ACTIVE_VISUALIZER] = DEFAULT_VISUALIZER;
-                WebGMEGlobal.State.set(settings);
+                WebGMEGlobal.State.registerActiveObject(nodeId);
             };
 
             treeBrowser.onExtendMenuItems = function (nodeId, menuItems) {

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -58,6 +58,17 @@ define(['js/logger',
     //inherit from PanelBaseWithHeader
     _.extend(VisualizerPanel.prototype, PanelBaseWithHeader.prototype);
 
+    VisualizerPanel.prototype._isAvailableVisualizer = function (visualizerId) {
+        var i;
+
+        for (i = 0; i < VisualizersJSON.length; i += 1) {
+            if (visualizerId === VisualizersJSON[i].id) {
+                return true;
+            }
+        }
+        return false;
+    };
+
     VisualizerPanel.prototype._initialize = function () {
         var self = this,
             toolbar = WebGMEGlobal.Toolbar,
@@ -116,7 +127,7 @@ define(['js/logger',
 
         WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_VISUALIZER, function (model, activeVisualizer) {
             if (self._settingVisualizer !== true) {
-                self._setActiveVisualizer(activeVisualizer,self._ul1);
+                self._setActiveVisualizer(activeVisualizer, self._ul1);
             }
         });
 
@@ -148,8 +159,8 @@ define(['js/logger',
 
         if (this._activeVisualizer[panel] !== visualizer && this._visualizers.hasOwnProperty(visualizer)) {
             //we should change the selected tab to 0 in case of visualizer change to get the 'default' behaviour
-            WebGMEGlobal.State.set(CONSTANTS.STATE_ACTIVE_TAB,0);
-            WebGMEGlobal.State.set(CONSTANTS.STATE_ACTIVE_ASPECT,'All');
+            WebGMEGlobal.State.set(CONSTANTS.STATE_ACTIVE_TAB, 0);
+            WebGMEGlobal.State.set(CONSTANTS.STATE_ACTIVE_ASPECT, 'All');
 
 
             //destroy current visualizer
@@ -232,12 +243,29 @@ define(['js/logger',
         });
 
         this.updateContainerSize();
+
         if (self._validVisualizers) {
+            activeVisualizer = self._validVisualizers[0];
+            if (!self._isAvailableVisualizer(activeVisualizer)) {
+                //fallback to the global default
+                activeVisualizer = self.defaultVisualizer.id;
+            }
+        } else {
             // Set this to the global default if it is valid for the project
             activeVisualizer = self.defaultVisualizer.id;
-            if (self._validVisualizers.indexOf(activeVisualizer) === -1) {
-                activeVisualizer = self._validVisualizers[0];
+        }
+
+        if (!self._isAvailableVisualizer(activeVisualizer)) {
+            if (self._isAvailableVisualizer(CONSTANTS.DEFAULT_VISUALIZER)) {
+                //fall back to model editor if nothing else works
+                activeVisualizer = CONSTANTS.DEFAULT_VISUALIZER;
+            } else {
+                activeVisualizer = null;
             }
+        }
+
+        //we set the visualizer only if we were able to select some valid one
+        if (activeVisualizer) {
             setTimeout(function () {
                 self._setActiveVisualizer(activeVisualizer, ul);
             }, 0);


### PR DESCRIPTION
The order of selection is the following:
- If the 'validVisualizers' have a value, then the first element is the default one
- If no node level value available (or it is not an available visualizer) we fall back to the global default (set by the visualizers.json)
- If no 'server-global' visualizer is available we fall back to 'ModelEditor' as a default
- If for some reason the 'ModelEditor' is not available, we simply ignore to modify the visualizer on active node change