### PR TITLE
Removed crossbar from highlighted elements

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
+++ b/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
@@ -611,9 +611,10 @@ define([
             deleteBtn = DELETE_BUTTON_BASE.clone();
             this._diagramDesigner.skinParts.$selectionOutline.append(deleteBtn);
 
-            moveBtn = MOVE_BUTTON_BASE.clone();
-            this._diagramDesigner.skinParts.$selectionOutline.append(moveBtn);
-            this._diagramDesigner._makeDraggable({$el: moveBtn});
+            // FIXME: There is an issue with the x and y offset, try it with zoom and scroll, too.
+            // moveBtn = MOVE_BUTTON_BASE.clone();
+            // this._diagramDesigner.skinParts.$selectionOutline.append(moveBtn);
+            // this._diagramDesigner._makeDraggable({$el: moveBtn});
         }
 
         //context menu


### PR DESCRIPTION
Move objects by grabbing any object from the selection.

Please see my inline comments to the code if you attempt to fix this issue.