### PR TITLE
Plugin can be invoked on read-only and commit.

### DIFF
--- a/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
+++ b/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
@@ -122,6 +122,7 @@ define(['js/util',
                 } else if (commits[c].status === storageUtil.CONSTANTS.SYNCED) {
                     message = 'updated';
                 } else if (!commits[c].status) {
+                    // When null or undefined there was no branch target for the commit..
                     message = 'made commit';
                 } else {
                     message = 'forked and created';

--- a/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
+++ b/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
@@ -36,7 +36,7 @@ define(['js/util',
     //jscs:disable maximumLineLength
         RESULT_ARTIFACTS_BASE = $('<div class="artifacts collapse"><div class="artifacts-title">Generated artifacts</div><div class="artifacts-body"><ul></ul></div></div>'),
         RESULT_HISTORY_BASE = $('<div class="artifacts history collapse"><div class="artifacts-title history-title">Execution History</div><div class="history-body"><ul></ul></div></div>'),
-        COMMIT_ENTRY = $('<li><span class="btn btn-micro btn-commit"></span><span class="commit-msg"></span><span class="btn btn-micro btn-branch"></span></li>'),
+        COMMIT_ENTRY = $('<li><span class="btn btn-micro btn-commit" title="Select commit"></span><span class="commit-msg"></span><span class="btn btn-micro btn-branch" title="Select branch"></span></li>'),
     //jscs:enable maximumLineLength
         ARTIFACT_ENTRY_BASE = $('<li><a href="#" target="_self">Loading...</a></li>'),
         MESSAGE_PREFIX = 'Message #';

--- a/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
+++ b/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
@@ -121,6 +121,8 @@ define(['js/util',
                     message = 'started from';
                 } else if (commits[c].status === storageUtil.CONSTANTS.SYNCED) {
                     message = 'updated';
+                } else if (!commits[c].status) {
+                    message = 'made commit';
                 } else {
                     message = 'forked and created';
                 }
@@ -270,9 +272,9 @@ define(['js/util',
                 projectId = commitEl.attr('project-id'),
                 branchName = commitEl.attr('branch-name');
             if (client.getProjectObject() && client.getProjectObject().projectId === projectId) {
-                if (client.getActiveBranchName() === branchName) {
-                    return;
-                }
+                //if (client.getActiveBranchName() === branchName) {
+                //    return;
+                //}
                 client.selectBranch(branchName, null, function (err) {
                     if (err) {
                         self.logger.error(err);

--- a/src/client/js/Utils/InterpreterManager.js
+++ b/src/client/js/Utils/InterpreterManager.js
@@ -195,13 +195,10 @@ define([
                         if (configSaveCallback) {
                             configSaveCallback(updatedConfig);
 
-                            if (self._client.getBranchStatus() !== self._client.CONSTANTS.BRANCH_STATUS.SYNC) {
-                                errMessage = 'Not allowed to invoke plugin ';
-                                if (self._client.isProjectReadOnly) {
-                                    errMessage += 'when in readOnly state.';
-                                } else {
-                                    errMessage += 'while local branch is AHEAD or PULLING changes from server.';
-                                }
+                            if (self._client.getBranchStatus() &&
+                                self._client.getBranchStatus() !== self._client.CONSTANTS.BRANCH_STATUS.SYNC) {
+                                errMessage = 'Not allowed to invoke plugin while local branch is AHEAD or ' +
+                                    'PULLING changes from server.';
                                 self.logger.error(errMessage);
                                 callback(getPluginErrorResult(name, errMessage, startTime, projectId));
                                 return;

--- a/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
+++ b/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
@@ -133,6 +133,8 @@ define([
                 self._client.selectBranch(branchName, null, function (err) {
                     if (err) {
                         self._logger.error(err);
+                    } else {
+                        self._logger.debug('branch selected: ', branchName);
                     }
                 });
             }

--- a/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
+++ b/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
@@ -18,7 +18,8 @@ define([
     var BranchStatusWidget,
         ITEM_VALUE_FORK = 'fork',
         ITEM_VALUE_FOLLOW = 'follow',
-        ITEM_VALUE_MERGE = 'merge';
+        ITEM_VALUE_MERGE = 'merge',
+        ITEM_VALUE_SELECT_BRANCH = 'select';
 
     BranchStatusWidget = function (containerEl, client) {
         this._logger = Logger.create('gme:Widgets:BranchStatusWidget', WebGMEGlobal.gmeConfig.client.log);
@@ -128,6 +129,12 @@ define([
                         });
                     }
                 });
+            } else if (value === ITEM_VALUE_SELECT_BRANCH) {
+                self._client.selectBranch(branchName, null, function (err) {
+                    if (err) {
+                        self._logger.error(err);
+                    }
+                });
             }
         };
 
@@ -154,6 +161,9 @@ define([
                 break;
             case CONSTANTS.CLIENT.BRANCH_STATUS.PULLING:
                 this._branchPulling(eventData);
+                break;
+            case CONSTANTS.CLIENT.BRANCH_STATUS.ERROR:
+                this._branchError(eventData);
                 break;
             default:
                 this._noBranch();
@@ -204,6 +214,19 @@ define([
         this._ddBranchStatus.clear();
         this._ddBranchStatus.setTitle('PULLING[' + eventData.updateQueue.length + ']');
         this._ddBranchStatus.setColor(DropDownMenu.prototype.COLORS.GRAY);
+    };
+
+    BranchStatusWidget.prototype._branchError = function (eventData) {
+        this._ddBranchStatus.clear();
+        this._ddBranchStatus.setTitle('ERROR');
+        this._ddBranchStatus.setColor(DropDownMenu.prototype.COLORS.RED);
+        this._popoverBox = this._popoverBox || new PopoverBox(this._ddBranchStatus.getEl());
+        this._popoverBox.show('Critical error - detached from branch.',
+            this._popoverBox.alertLevels.ERROR, true);
+        this._ddBranchStatus.addItem({
+            text: 'Reselect branch',
+            value: ITEM_VALUE_SELECT_BRANCH
+        });
     };
 
     BranchStatusWidget.prototype._noBranch = function () {

--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -76,7 +76,8 @@ define([], function () {
             SYNC: 'SYNC',
             AHEAD_SYNC: 'AHEAD_SYNC',
             AHEAD_NOT_SYNC: 'AHEAD_NOT_SYNC',
-            PULLING: 'PULLING'
+            PULLING: 'PULLING',
+            ERROR: 'ERROR'
         },
 
         // Events

--- a/src/common/storage/project/branch.js
+++ b/src/common/storage/project/branch.js
@@ -182,7 +182,14 @@ define(['common/storage/constants'], function (CONSTANTS) {
             var i;
 
             logger.debug('dispatchBranchStatus old, new', branchStatus, newStatus);
-            branchStatus = newStatus;
+
+            if (branchStatus === CONSTANTS.BRANCH_STATUS.ERROR) {
+                logger.warn('In error state, action from user required');
+                newStatus = branchStatus;
+            } else {
+                branchStatus = newStatus;
+            }
+
             for (i = 0; i < self.branchStatusHandlers.length; i += 1) {
                 self.branchStatusHandlers[i](newStatus, commitQueue, updateQueue);
             }

--- a/src/common/storage/project/branch.js
+++ b/src/common/storage/project/branch.js
@@ -184,7 +184,7 @@ define(['common/storage/constants'], function (CONSTANTS) {
             logger.debug('dispatchBranchStatus old, new', branchStatus, newStatus);
 
             if (branchStatus === CONSTANTS.BRANCH_STATUS.ERROR) {
-                logger.warn('In error state, action from user required');
+                logger.error('In error state, action from user required!');
                 newStatus = branchStatus;
             } else {
                 branchStatus = newStatus;

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -505,6 +505,8 @@ define([
                         } else {
                             logger.error('Unsupported commit status ' + result.status);
                         }
+                    } else {
+                        branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.ERROR);
                     }
                 } else {
                     logger.error('_pushNextQueuedCommit returned from server but the branch was closed, ' +
@@ -547,6 +549,7 @@ define([
                     var originHash = updateData.commitObject[CONSTANTS.MONGO_ID];
                     if (err) {
                         logger.error('Loading of update commit failed with error', err, {metadata: updateData});
+                        branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.ERROR);
                     } else if (proceed === true) {
                         logger.debug('New commit was successfully loaded, updating localHash.');
                         branch.updateHashes(originHash, null);

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -405,6 +405,8 @@ define([
                             self.currentHash = commitResult.hash; // This is needed in case hash is randomly generated.
                             return self._createFork();
                         });
+                } else if (!self.branchName) {
+                    self.addCommitToResult(null);
                 } else {
                     throw new Error('setBranchHash returned unexpected status' + commitResult.status);
                 }

--- a/src/plugin/PluginManagerBase.js
+++ b/src/plugin/PluginManagerBase.js
@@ -249,11 +249,11 @@ define(['plugin/PluginBase', 'plugin/PluginContext', 'common/storage/util'],
                     return;
                 }
                 self.logger.debug(branches);
-                if (branches.hasOwnProperty(managerConfiguration.branchName)) {
+                if (managerConfiguration.branchName && !branches.hasOwnProperty(managerConfiguration.branchName)) {
                     //pluginContext.commitHash = branches[managerConfiguration.branchName];
-                    loadCommitHashAndRun(pluginContext.commitHash);
-                } else {
                     callback('cannot find branch "' + managerConfiguration.branchName + '"', pluginContext);
+                } else {
+                    loadCommitHashAndRun(pluginContext.commitHash);
                 }
             });
             //} else {

--- a/src/plugin/PluginManagerBase.js
+++ b/src/plugin/PluginManagerBase.js
@@ -249,8 +249,9 @@ define(['plugin/PluginBase', 'plugin/PluginContext', 'common/storage/util'],
                     return;
                 }
                 self.logger.debug(branches);
-                if (managerConfiguration.branchName && !branches.hasOwnProperty(managerConfiguration.branchName)) {
-                    //pluginContext.commitHash = branches[managerConfiguration.branchName];
+                if (managerConfiguration.branchName &&
+                    branches.hasOwnProperty(managerConfiguration.branchName) === false) {
+
                     callback('cannot find branch "' + managerConfiguration.branchName + '"', pluginContext);
                 } else {
                     loadCommitHashAndRun(pluginContext.commitHash);

--- a/src/plugin/PluginResult.js
+++ b/src/plugin/PluginResult.js
@@ -216,7 +216,7 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
             pluginName: this.pluginName,
             startTime: this.startTime,
             finishTime: this.finishTime,
-            error: null
+            error: this.error
         },
             i;
 

--- a/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
+++ b/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
@@ -103,29 +103,28 @@ define(['plugin/PluginConfig', 'plugin/PluginBase'], function (PluginConfig, Plu
 
         // This will save the changes. If you don't want to save;
         // exclude self.save and call callback directly from this scope.
-        self.result.setSuccess(true);
         if (currentConfiguration.save === true) {
             self.save('added obj', function (err, status) {
                 if (err) {
-                    self.result.setSuccess(false);
-                    self.result.setError(err);
+                    callback(err, self.result);
+                    return;
                 }
                 self.logger.info('saved returned with status', status);
 
                 if (currentConfiguration.shouldFail) {
-                    self.result.setSuccess(false);
-                    self.result.setError('Failed on purpose.');
+                    //self.result.setError('Failed on purpose.');
                     callback('Failed on purpose.', self.result);
                 } else {
+                    self.result.setSuccess(true);
                     callback(null, self.result);
                 }
             });
         } else {
             if (currentConfiguration.shouldFail) {
-                self.result.setSuccess(false);
                 self.result.setError('Failed on purpose.');
                 callback('Failed on purpose.', self.result);
             } else {
+                self.result.setSuccess(true);
                 callback(null, self.result);
             }
         }

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -271,6 +271,8 @@ function WorkerRequests(mainLogger, gmeConfig) {
                     if (!result) {
                         result = pluginManager.getPluginErrorResult(pluginName, err.message,
                             context && context.managerConfig && context.managerConfig.project);
+                    } else if (!result.error) {
+                        result.error = err.message;
                     }
                 } else {
                     logger.info('plugin [' + pluginName + '] completed');

--- a/test/plugin/nodemanagerbase.spec.js
+++ b/test/plugin/nodemanagerbase.spec.js
@@ -197,6 +197,45 @@ describe('climanager', function () {
         });
     });
 
+    it('should executePlugin without specified branchName', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {
+                save: false
+            },
+            context = {
+                project: project,
+                commitHash: commitHash
+            };
+
+        project.getBranchHash(branchName, function (err, commitHash) {
+            expect(err).to.equal(null);
+
+            manager.executePlugin(pluginName, pluginConfig, context, function (err, pluginResult) {
+                expect(err).to.equal(null);
+
+                expect(pluginResult.success).to.equal(true);
+                expect(pluginResult.commits[0].commitHash).to.equal(commitHash);
+                done();
+            });
+        });
+    });
+
+    it('should fail to executePlugin without specified branchName nor commitHash', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {
+                save: false
+            },
+            context = {
+                project: project
+            };
+
+        manager.executePlugin(pluginName, pluginConfig, context, function (err, pluginResult) {
+            expect(err).to.contain('Neither commitHash nor branchHash from branch was obtained');
+
+            done();
+        });
+    });
+
     it('should fail executePlugin with pluginResult when no default project in manager and no project in context',
         function (done) {
             var manager = new PluginCliManager(null, logger, gmeConfig),


### PR DESCRIPTION
This branch also introduces a new branch status ERROR.

When running a plugin in the client the storage is shared between the plugin and client. When a plugin attempts to make a change into a branch on a read-only project - the client updates its state to include the changes before the server responds with an error. These errors (makeCommit) are now propagated to the users via the ERROR branch-status, which prompts the user to re-select the branch.