### PR TITLE
Refactored the rotate button.

### DIFF
--- a/src/client/css/webgme_bootstrap_overrides.css
+++ b/src/client/css/webgme_bootstrap_overrides.css
@@ -32,10 +32,14 @@
     -o-user-select: all;
     user-select: all;
 }
+
 .popover .popover-content.narrow {
     padding: 5px 5px;
 }
 
+.popover.right>.arrow {
+    top: 27%;
+}
 
 /* Modals */
 
@@ -44,11 +48,11 @@
     -moz-box-shadow: none;
     box-shadow: none;
 
-    -moz-user-select:-moz-all;
-    -webkit-user-select:all;
-    -o-user-select:all;
-    user-select:all;
-    -ms-user-select:element;
+    -moz-user-select: -moz-all;
+    -webkit-user-select: all;
+    -o-user-select: all;
+    user-select: all;
+    -ms-user-select: element;
 }
 
 .modal-content .row {
@@ -60,7 +64,7 @@
     max-height: 200px;
 }
 
-@media(min-height:700px) {
+@media (min-height: 700px) {
 
     .modal-body {
         max-height: 400px;
@@ -68,8 +72,7 @@
 
 }
 
-
-@media(min-height:850px) {
+@media (min-height: 850px) {
 
     .modal-body {
         max-height: 600px;
@@ -77,7 +80,7 @@
 
 }
 
-@media(min-height:1200px) {
+@media (min-height: 1200px) {
 
     .modal-body {
         max-height: 900px;
@@ -103,7 +106,7 @@
     line-height: 15px;
 }
 
-.btn-micro > i:empty{
+.btn-micro > i:empty {
     margin-right: .75ex;
 }
 
@@ -135,8 +138,7 @@ input[type="submit"].btn.btn-micro {
     top: 0;
 }
 
-.btn-gray.active
-{
+.btn-gray.active {
     color: rgba(255, 255, 255, 0.75);
 }
 
@@ -219,8 +221,7 @@ input[type="submit"].btn.btn-micro {
     height: 16px;
 }
 
-
-.navbar-fixed-bottom .navbar-inner .iCheckBox .txt  {
+.navbar-fixed-bottom .navbar-inner .iCheckBox .txt {
     height: 16px;
     line-height: 16px;
 }
@@ -234,23 +235,22 @@ input[type="submit"].btn.btn-micro {
     margin-bottom: 1px;
 }
 
-
 .navbar {
     margin-bottom: 0;
 }
 
-.nav-tabs>li>a {
+.nav-tabs > li > a {
     border-radius: 0;
 }
 
-.nav-tabs>li.active>a,
-.nav-tabs>li.active>a:hover,
-.nav-tabs>li.active>a:focus {
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
     border: 1px solid #C0C0C0;
     border-bottom-color: transparent;
 }
 
-.nav-tabs>li>a>i:empty {
+.nav-tabs > li > a > i:empty {
     margin-left: .5ex;
     font-size: 110%;
     position: relative;
@@ -273,7 +273,6 @@ ul.dropdown-menu {
     min-width: 0;
 }
 
-
 .input-append .add-on.add-on-mini,
 .input-prepend .add-on.add-on-mini {
     height: 12px;
@@ -293,11 +292,11 @@ input.no-focus-collapse:not(:focus) {
 }
 
 .flip-vertical {
-    -webkit-transform:scaleX(-1);
-    -moz-transform:scaleX(-1);
-    -ms-transform:scaleX(-1);
-    -o-transform:scaleX(-1);
-    transform:scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    -moz-transform: scaleX(-1);
+    -ms-transform: scaleX(-1);
+    -o-transform: scaleX(-1);
+    transform: scaleX(-1);
 }
 
 .panel-base .drawing-canvas {

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Constants.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Constants.js
@@ -62,8 +62,11 @@ define(['js/Constants'], function (CONSTANTS) {
         PATH_SHADOW_ARROW_END_ID_PREFIX: 'p_e_',
 
         /*
-         * ROTATINO RESET CONSTANTS
+         * ROTATION CONSTANTS
          */
-        ROTATION_RESET: 'reset'
+        ROTATION_RESET: 'reset',
+        ROTATION_TOLEFT: 'toleft',
+        ROTATION_TORIGHT: 'toright',
+        ROTATION_CLEAR: 'clear'
     };
 });

--- a/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
+++ b/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
@@ -104,12 +104,12 @@ define([
 
     SelectionManager.prototype.onSelectionCommandClicked = function (command, selectedIds) {
         this.logger.warn('SelectionManager.prototype.onSelectionCommandClicked IS NOT OVERRIDDEN IN HOST COMPONENT. ' +
-        ' command: "' + command + '", selectedIds: ' + selectedIds);
+            ' command: "' + command + '", selectedIds: ' + selectedIds);
     };
 
     SelectionManager.prototype.onSelectionChanged = function (selectedIDs) {
         this.logger.warn('SelectionManager.prototype.onSelectionChanged IS NOT OVERRIDDEN IN HOST COMPONENT.' +
-        ' selectedIDs: ' + selectedIDs);
+            ' selectedIDs: ' + selectedIDs);
     };
 
 
@@ -250,7 +250,7 @@ define([
         }
 
         this.logger.debug('Select children by rubber band: [' + rbBBox.x + ',' + rbBBox.y + '], [' +
-        rbBBox.x2 + ',' + rbBBox.y2 + ']');
+            rbBBox.x2 + ',' + rbBBox.y2 + ']');
 
         selectionContainsBBox = function (itemBBox) {
             var interSectionRect,
@@ -267,8 +267,8 @@ define([
                     };
 
                     interSectionRatio = (interSectionRect.x2 - interSectionRect.x) *
-                    (interSectionRect.y2 - interSectionRect.y) / ((itemBBox.x2 - itemBBox.x) *
-                    (itemBBox.y2 - itemBBox.y));
+                        (interSectionRect.y2 - interSectionRect.y) / ((itemBBox.x2 - itemBBox.x) *
+                        (itemBBox.y2 - itemBBox.y));
 
                     if (interSectionRatio > SELECTION_OVERLAP_RATIO) {
                         return true;
@@ -644,13 +644,21 @@ define([
         });
 
     ROTATION_BUTTON_BASE.html('' +
-    '<i class="glyphicon glyphicon-repeat"><div class="popover right nowrap rotate-options">' +
-    '<div class="arrow"></div><div class="popover-content narrow"><div class="btn-group">' +
-    '<a class="btn btn-small" id="rotate-left" title="Rotate left">' +
-    '<i class="glyphicon glyphicon-repeat flip-vertical"></i></a>' +
-    '<a class="btn  btn-small" id="rotate-right" title="Rotate right"><i class="glyphicon glyphicon-repeat"></i>' +
-    '</a><a class="btn  btn-small" id="rotate-reset" title="Reset rotation">' +
-    '<i class="glyphicon glyphicon-remove"></i></a></div></div></div></i>');
+        '<i class="glyphicon glyphicon-repeat">' +
+        '<div class="popover right nowrap rotate-options">' +
+        '<div class="arrow"></div><div class="popover-content narrow"><div class="btn-group">' +
+        '<a class="btn btn-small" id="rotate-left" title="Rotate left by 90°">' +
+        '<i class="glyphicon glyphicon-repeat flip-vertical" id="icon-rotate-left"></i></a>' +
+        '<a class="btn  btn-small" id="rotate-right" title="Rotate right by 90°">' +
+        '<i class="glyphicon glyphicon-repeat" id="icon-rotate-right"></i></a>' +
+        '<a class="btn btn-small" id="rotate-toleft" title="Rotate left to the closest multiple of 90°">' +
+        '<i class="glyphicon glyphicon-retweet flip-vertical" id="icon-rotate-toleft"></i></a>' +
+        '<a class="btn  btn-small" id="rotate-toright" title="Rotate right to the closest multiple of 90°">' +
+        '<i class="glyphicon glyphicon-retweet" id="icon-rotate-toright"></i></a>' +
+        '<a class="btn  btn-small" id="rotate-reset" title="Set rotation to 0°">' +
+        '<i class="glyphicon glyphicon-minus" id="icon-rotate-reset"></i></a>' +
+        '<a class="btn  btn-small" id="rotate-clear" title="Clear rotation information - reset to inherited">' +
+        '<i class="glyphicon glyphicon-remove" id="icon-rotate-clear"></i></a></div></div></div></i>');
 
     var ROTATION_DEGREE_BASE = $('<div/>', {
         class: 'rotation-deg'
@@ -672,12 +680,15 @@ define([
             this._diagramDesigner.skinParts.$selectionOutline.on('mousedown.' + MOUSE_EVENT_POSTFIX, '.rotate',
                 function (event) {
                     var rotateBtn = $(this);
-                    self.logger.debug('selection rotate button mousedown');
+                    if ($(event.target).attr('id') === undefined) {
+                        self.logger.debug('selection rotate button mousedown');
 
-                    self._startSelectionRotate(rotateBtn, event);
+                        self._startSelectionRotate(rotateBtn, event);
 
-                    event.stopPropagation();
-                    event.preventDefault();
+                        event.stopPropagation();
+                        event.preventDefault();
+                    }
+
                 }
             );
 
@@ -703,6 +714,15 @@ define([
                         break;
                     case DiagramDesignerWidgetConstants.ROTATION_RESET:
                         deg = DiagramDesignerWidgetConstants.ROTATION_RESET;
+                        break;
+                    case DiagramDesignerWidgetConstants.ROTATION_TOLEFT:
+                        deg = DiagramDesignerWidgetConstants.ROTATION_TOLEFT;
+                        break;
+                    case DiagramDesignerWidgetConstants.ROTATION_TORIGHT:
+                        deg = DiagramDesignerWidgetConstants.ROTATION_TORIGHT;
+                        break;
+                    case DiagramDesignerWidgetConstants.ROTATION_CLEAR:
+                        deg = DiagramDesignerWidgetConstants.ROTATION_CLEAR;
                         break;
                 }
 
@@ -796,7 +816,7 @@ define([
 
     SelectionManager.prototype.onSelectionRotated = function (deg, selectedIds) {
         this.logger.warn('SelectionManager.prototype.onSelectionRotated IS NOT OVERRIDDEN IN HOST COMPONENT. deg: "' +
-        deg + '"deg, selectedIds: ' + selectedIds);
+            deg + '"deg, selectedIds: ' + selectedIds);
     };
 
     SelectionManager.prototype.enableRotation = function (enabled) {

--- a/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
+++ b/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
@@ -104,12 +104,12 @@ define([
 
     SelectionManager.prototype.onSelectionCommandClicked = function (command, selectedIds) {
         this.logger.warn('SelectionManager.prototype.onSelectionCommandClicked IS NOT OVERRIDDEN IN HOST COMPONENT. ' +
-            ' command: "' + command + '", selectedIds: ' + selectedIds);
+        ' command: "' + command + '", selectedIds: ' + selectedIds);
     };
 
     SelectionManager.prototype.onSelectionChanged = function (selectedIDs) {
         this.logger.warn('SelectionManager.prototype.onSelectionChanged IS NOT OVERRIDDEN IN HOST COMPONENT.' +
-            ' selectedIDs: ' + selectedIDs);
+        ' selectedIDs: ' + selectedIDs);
     };
 
 
@@ -250,7 +250,7 @@ define([
         }
 
         this.logger.debug('Select children by rubber band: [' + rbBBox.x + ',' + rbBBox.y + '], [' +
-            rbBBox.x2 + ',' + rbBBox.y2 + ']');
+        rbBBox.x2 + ',' + rbBBox.y2 + ']');
 
         selectionContainsBBox = function (itemBBox) {
             var interSectionRect,
@@ -267,8 +267,8 @@ define([
                     };
 
                     interSectionRatio = (interSectionRect.x2 - interSectionRect.x) *
-                        (interSectionRect.y2 - interSectionRect.y) / ((itemBBox.x2 - itemBBox.x) *
-                        (itemBBox.y2 - itemBBox.y));
+                    (interSectionRect.y2 - interSectionRect.y) / ((itemBBox.x2 - itemBBox.x) *
+                    (itemBBox.y2 - itemBBox.y));
 
                     if (interSectionRatio > SELECTION_OVERLAP_RATIO) {
                         return true;
@@ -644,21 +644,21 @@ define([
         });
 
     ROTATION_BUTTON_BASE.html('' +
-        '<i class="glyphicon glyphicon-repeat">' +
-        '<div class="popover right nowrap rotate-options">' +
-        '<div class="arrow"></div><div class="popover-content narrow"><div class="btn-group">' +
-        '<a class="btn btn-small" id="rotate-left" title="Rotate left by 90°">' +
-        '<i class="glyphicon glyphicon-repeat flip-vertical" id="icon-rotate-left"></i></a>' +
-        '<a class="btn  btn-small" id="rotate-right" title="Rotate right by 90°">' +
-        '<i class="glyphicon glyphicon-repeat" id="icon-rotate-right"></i></a>' +
-        '<a class="btn btn-small" id="rotate-toleft" title="Rotate left to the closest multiple of 90°">' +
-        '<i class="glyphicon glyphicon-retweet flip-vertical" id="icon-rotate-toleft"></i></a>' +
-        '<a class="btn  btn-small" id="rotate-toright" title="Rotate right to the closest multiple of 90°">' +
-        '<i class="glyphicon glyphicon-retweet" id="icon-rotate-toright"></i></a>' +
-        '<a class="btn  btn-small" id="rotate-reset" title="Set rotation to 0°">' +
-        '<i class="glyphicon glyphicon-minus" id="icon-rotate-reset"></i></a>' +
-        '<a class="btn  btn-small" id="rotate-clear" title="Clear rotation information - reset to inherited">' +
-        '<i class="glyphicon glyphicon-remove" id="icon-rotate-clear"></i></a></div></div></div></i>');
+    '<i class="glyphicon glyphicon-repeat">' +
+    '<div class="popover right nowrap rotate-options">' +
+    '<div class="arrow"></div><div class="popover-content narrow"><div class="btn-group">' +
+    '<a class="btn btn-small" id="rotate-left" title="Rotate left by 90°">' +
+    '<i class="glyphicon glyphicon-repeat flip-vertical" id="icon-rotate-left"></i></a>' +
+    '<a class="btn  btn-small" id="rotate-right" title="Rotate right by 90°">' +
+    '<i class="glyphicon glyphicon-repeat" id="icon-rotate-right"></i></a>' +
+    '<a class="btn btn-small" id="rotate-toleft" title="Rotate left to the closest multiple of 90°">' +
+    '<i class="glyphicon glyphicon-retweet flip-vertical" id="icon-rotate-toleft"></i></a>' +
+    '<a class="btn  btn-small" id="rotate-toright" title="Rotate right to the closest multiple of 90°">' +
+    '<i class="glyphicon glyphicon-retweet" id="icon-rotate-toright"></i></a>' +
+    '<a class="btn  btn-small" id="rotate-reset" title="Set rotation to 0°">' +
+    '<i class="glyphicon glyphicon-minus" id="icon-rotate-reset"></i></a>' +
+    '<a class="btn  btn-small" id="rotate-clear" title="Clear rotation information - reset to inherited">' +
+    '<i class="glyphicon glyphicon-remove" id="icon-rotate-clear"></i></a></div></div></div></i>');
 
     var ROTATION_DEGREE_BASE = $('<div/>', {
         class: 'rotation-deg'
@@ -816,7 +816,7 @@ define([
 
     SelectionManager.prototype.onSelectionRotated = function (deg, selectedIds) {
         this.logger.warn('SelectionManager.prototype.onSelectionRotated IS NOT OVERRIDDEN IN HOST COMPONENT. deg: "' +
-            deg + '"deg, selectedIds: ' + selectedIds);
+        deg + '"deg, selectedIds: ' + selectedIds);
     };
 
     SelectionManager.prototype.enableRotation = function (enabled) {


### PR DESCRIPTION
Fixes #663
Introduced new buttons so now we can rotate by dragging on the main button, or we can do one of the followings:
- rotate left by 90 degrees
- rotate right by 90 degrees
- rotate left to the closest multiple of 90 degrees (if it is a multiple of 90 degrees, there will be no change)
- rotate right to the closest multiple of 90 degrees (-||-)
- set rotation to 0 degree
- clear rotation info (so reset to the inherited information)

We also enhanced the tool-tip of buttons.
![image](https://cloud.githubusercontent.com/assets/1371489/11518311/c83f2aa8-9855-11e5-8276-8a1a06bdc10e.png)
