### PR TITLE
Fixes small findings on core and client

### DIFF
--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -627,9 +627,7 @@ define(['js/logger',
                         };
                     }
 
-                    this._client.startTransaction();
                     this._client.moveMoreNodes(params);
-                    this._client.completeTransaction();
                 }
                 break;
             case DragHelper.DRAG_EFFECTS.DRAG_CREATE_INSTANCE:

--- a/src/client/js/client/gmeNodeSetter.js
+++ b/src/client/js/client/gmeNodeSetter.js
@@ -183,7 +183,7 @@ define([], function () {
             }
         }
 
-        function moveMoreNodes(parameters) {
+        function moveMoreNodes(parameters, msg) {
             var pathsToMove = [],
                 returnParams = {},
                 i,
@@ -231,6 +231,8 @@ define([], function () {
                 }
             }
 
+            msg = msg || 'moveMoreNodes(' + JSON.stringify(returnParams) + ')';
+            saveRoot(msg);
             return returnParams;
         }
 

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -193,8 +193,6 @@ define([
          */
         this.getChild = core.getChild;
 
-        //this.getDescendant = core.getDescendant;
-        //this.getDescendantByPath = core.getDescendantByPath;
         //this.isMutable = core.isMutable;
         //this.isObject = core.isObject;
 
@@ -566,11 +564,6 @@ define([
          */
         this.getPointerPath = core.getPointerPath;
 
-        //TODO check if this could be completely removed - or we have to start using it instead of relying on undefined
-        //this.hasPointer = core.hasPointer;
-
-        //this.getOutsidePointerPath = core.getOutsidePointerPath;
-
         /**
          * Removes the pointer from the node.
          * @param {module:Core~Node} node - the node in question.
@@ -611,8 +604,6 @@ define([
          * @func
          */
         this.getCollectionPaths = core.getCollectionPaths;
-
-        //this.getCoreTree = core.getCoreTree;
 
         /**
          * Collects the data hash values of the children of the node.
@@ -958,10 +949,12 @@ define([
 
         //TODO this is only used in import - export use-cases, probably could be removed...
         /**
-         * Get the GUID of a node. As the Core itself do not checks whether the GUID already exists. The use of
+         * Set the GUID of a node. As the Core itself do not checks whether the GUID already exists. The use of
          * this function is only advised during the creation of the node.
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~GUID} guid - the new globally unique identifier.
+         * @param {function()} callback
+         *
          * @func
          */
         this.setGuid = core.setGuid;
@@ -1341,12 +1334,11 @@ define([
 
         /**
          * Generates a differential tree among the two states of the project that contains the necessary changes
-         * that can modify the source to be identical to the target.
+         * that can modify the source to be identical to the target. The result is in form of a json object.
          * @param {module:Core~Node} sourceRoot - the root node of the source state.
          * @param {module:Core~Node} targetRoot - the root node of the target state.
          *
-         * @return {object} The function returns a tree structured patch, that contains the necessary modification
-         * that would changes the source state to be identical with the target state.
+         * @param {function(string, object)} callback
          *
          * @func
          */
@@ -1358,6 +1350,7 @@ define([
          * Apply changes to the current project.
          * @param {module:Core~Node} root - the root of the containment hierarchy where we wish to apply the changes
          * @param {object} patch - the tree structured collection of changes represented with a special JSON object
+         * @param {function(string)} callback
          *
          * @func
          */

--- a/src/common/core/coreQ.js
+++ b/src/common/core/coreQ.js
@@ -183,6 +183,14 @@ define(['common/core/core', 'q'], function (Core, Q) {
 
             return deferred.promise.nodeify(callback);
         };
+
+        var setGuidOrg = this.setGuid;
+        this.setGuid = function (node, guid, callback) {
+            var deferred = Q.defer();
+            setGuidOrg(node, guid, deferred.resolve);
+
+            return deferred.promise.nodeify(callback);
+        };
     }
 
     CoreQ.prototype = Object.create(Core.prototype);

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -62,12 +62,18 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         function getAttributeNames(node) {
             ASSERT(isValidNode(node));
 
-            node = (coretree.getProperty(node, ATTRIBUTES) || {});
-            var keys = coretree.getRawKeys(node);
-            var i = keys.length;
+            var data,
+                keys,
+                i;
+
+            data = (coretree.getProperty(node, ATTRIBUTES) || {});
+            keys = Object.keys(data);
+            i = keys.length;
             while (--i >= 0) {
                 if (keys[i].charAt(0) === '') {
-                    console.log('***** This happens?');
+                    logger.error('empty named attribute found in node [' + coretree.getPath(node) + ']');
+                    keys.splice(i, 1);
+                } else if (keys[i].charAt(0) === '_') {
                     keys.splice(i, 1);
                 }
             }
@@ -78,12 +84,18 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         function getRegistryNames(node) {
             ASSERT(isValidNode(node));
 
-            node = (coretree.getProperty(node, REGISTRY) || {});
-            var keys = coretree.getRawKeys(node);
-            var i = keys.length;
+            var data,
+                keys,
+                i;
+
+            data = (coretree.getProperty(node, REGISTRY) || {});
+            keys = Object.keys(data);
+            i = keys.length;
             while (--i >= 0) {
                 if (keys[i].charAt(0) === '') {
-                    console.log('***** This happens?');
+                    logger.error('empty named attribute found in node [' + coretree.getPath(node) + ']');
+                    keys.splice(i, 1);
+                } else if (keys[i].charAt(0) === '_') {
                     keys.splice(i, 1);
                 }
             }
@@ -644,78 +656,6 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
             return target;
         }
 
-        function getPointersFrom(node, source) {
-            ASSERT(isValidNode(node) && typeof source === 'string');
-            var ovrInfo,
-                targets = {},
-                keys, i;
-
-            do {
-                ovrInfo = (coretree.getProperty(node, OVERLAYS) || {})[soource];
-                if (ovrInfo) {
-                    keys = Object.keys(ovrInfo);
-                    for (i = 0; i < keys.length; i += 1) {
-                        if (isPointerName(keys[i])) {
-                            targets[keys[i]] = ovrInfo[keys[i]];
-                            if (targets[keys[i]] === undefined) {
-                                delete targets[keys[i]];
-                            }
-                        }
-                    }
-                }
-
-                source = '/' + coretree.getRelid(node) + source;
-                node = coretree.getParent(node);
-            } while (node);
-
-            return targets;
-        }
-
-        function hasPointer(node, name) {
-            ASSERT(isValidNode(node) && typeof name === 'string');
-
-            var source = '';
-
-            do {
-                var child = (coretree.getProperty(node, OVERLAYS) || {})[source];
-                if (child && child[name] !== undefined) {
-                    return true;
-                }
-
-                source = '/' + coretree.getRelid(node) + source;
-                node = coretree.getParent(node);
-            } while (node);
-
-            return false;
-        }
-
-        function getOutsidePointerPath(node, name, source) {
-            ASSERT(isValidNode(node) && typeof name === 'string');
-            ASSERT(typeof source === 'string');
-
-            var target;
-
-            do {
-                var child = (coretree.getProperty(node, OVERLAYS) || {})[source];
-                if (child) {
-                    target = child[name];
-                    if (target !== undefined) {
-                        break;
-                    }
-                }
-
-                source = '/' + coretree.getRelid(node) + source;
-                node = coretree.getParent(node);
-            } while (node);
-
-            if (target !== undefined) {
-                ASSERT(node);
-                target = coretree.joinPaths(coretree.getPath(node), target);
-            }
-
-            return target;
-        }
-
         function loadPointer(node, name) {
             ASSERT(isValidNode(node) && name);
 
@@ -913,19 +853,12 @@ define(['common/util/assert', 'common/core/coretree', 'common/core/tasync'], fun
         corerel.getPointerNamesFrom = getPointerNamesFrom;
         corerel.getPointerPath = getPointerPath;
         corerel.getPointerPathFrom = getPointerPathFrom;
-        corerel.getPointersFrom = getPointersFrom;
-        corerel.hasPointer = hasPointer;
-        corerel.getOutsidePointerPath = getOutsidePointerPath;
         corerel.loadPointer = loadPointer;
         corerel.deletePointer = deletePointer;
         corerel.setPointer = setPointer;
         corerel.getCollectionNames = getCollectionNames;
         corerel.getCollectionPaths = getCollectionPaths;
         corerel.loadCollection = loadCollection;
-
-        corerel.getCoreTree = function () {
-            return coretree;
-        };
 
         corerel.getChildrenHashes = getChildrenHashes;
 

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -383,39 +383,6 @@ define([
             return child;
         };
 
-        var getDescendant = function (node, head, base) {
-            ASSERT(typeof base === 'undefined' || isAncestor(head, base));
-
-            node = normalize(node);
-            head = normalize(head);
-            base = typeof base === 'undefined' ? null : normalize(base.parent);
-
-            var path = [];
-            while (head.parent !== base) {
-                path.push(head.relid);
-                head = head.parent;
-            }
-
-            var i = path.length;
-            while (--i >= 0) {
-                node = getChild(node, path[i]);
-            }
-
-            return node;
-        };
-
-        var getDescendantByPath = function (node, path) {
-            ASSERT(path === '' || path.charAt(0) === '/');
-
-            path = path.split('/');
-
-            for (var i = 1; i < path.length; ++i) {
-                node = getChild(node, path[i]);
-            }
-
-            return node;
-        };
-
         // ------- data manipulation
 
         var __isMutableData = function (data) {
@@ -971,8 +938,6 @@ define([
             createRoot: createRoot,
             createChild: createChild,
             getChild: getChild,
-            getDescendant: getDescendant,
-            getDescendantByPath: getDescendantByPath,
 
             isMutable: isMutable,
             isObject: isObject,

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -324,7 +324,6 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
         function _getInheritedCollectionNames(node) {
             var target = '',
                 names = [],
-                coretree = core.getCoreTree(),
                 startNode = node,
                 endNode = _getInstanceRoot(node),
                 exit;
@@ -343,7 +342,7 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
                     if (core.getPath(node) === core.getPath(endNode)) {
                         exit = true;
                     }
-                    var child = coretree.getProperty(coretree.getChild(node, OVERLAYS), target);
+                    var child = oldcore.getProperty(oldcore.getChild(node, OVERLAYS), target);
                     if (child) {
                         for (var name in child) {
                             if (!isPointerName(name)) {
@@ -355,8 +354,8 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
                         }
                     }
 
-                    target = '/' + coretree.getRelid(node) + target;
-                    node = coretree.getParent(node);
+                    target = '/' + oldcore.getRelid(node) + target;
+                    node = oldcore.getParent(node);
                 } while (!exit);
             } while (_isInheritedChild(startNode));
 
@@ -366,7 +365,6 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
         function _getInheritedCollectionPaths(node, name) {
             var target = '',
                 result = [],
-                coretree = core.getCoreTree(),
                 startNode = node,
                 endNode = _getInstanceRoot(node),
                 prefixStart = startNode,
@@ -379,10 +377,10 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
                         child, target;
 
                     while (core.getPath(tNode) !== core.getPath(eNode)) {
-                        child = coretree.getChild(tNode, OVERLAYS);
-                        child = coretree.getChild(child, source);
+                        child = oldcore.getChild(tNode, OVERLAYS);
+                        child = oldcore.getChild(child, source);
                         if (child) {
-                            target = coretree.getProperty(child, name);
+                            target = oldcore.getProperty(child, name);
                             if (target) {
                                 return false;
                             }
@@ -631,13 +629,12 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
                 return ownPointerPath;
             }
             var target,
-                coretree = core.getCoreTree(),
                 basePath,
                 hasNullTarget = false,
                 getProperty = function (node, name) {
                     var property;
                     while (property === undefined && node !== null) {
-                        property = coretree.getProperty(node, name);
+                        property = oldcore.getProperty(node, name);
                         node = core.getBase(node);
                     }
                     return property;
@@ -708,7 +705,7 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
 
             if (target !== undefined) {
                 ASSERT(node);
-                target = coretree.joinPaths(oldcore.getPath(node), target);
+                target = oldcore.joinPaths(oldcore.getPath(node), target);
             }
 
             if (typeof target === 'string') {

--- a/src/common/core/coreunwrap.js
+++ b/src/common/core/coreunwrap.js
@@ -73,6 +73,8 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
         core.loadOwnSubTree = TASYNC.unwrap(oldcore.loadOwnSubTree);
         core.loadTree = TASYNC.unwrap(oldcore.loadTree);
 
+        core.setGuid = TASYNC.unwrap(oldcore.setGuid);
+
         //core diff async functions
         if (typeof oldcore.generateTreeDiff === 'function') {
             core.generateTreeDiff = TASYNC.unwrap(oldcore.generateTreeDiff);

--- a/test/common/core/corerel.spec.js
+++ b/test/common/core/corerel.spec.js
@@ -11,6 +11,7 @@ describe('corerel', function () {
         logger = testFixture.logger.fork('corerel.spec'),
         Q = testFixture.Q,
         storage,
+        expect = testFixture.expect,
         Rel = testFixture.requirejs('common/core/corerel'),
         Tree = testFixture.requirejs('common/core/coretree'),
         TASYNC = testFixture.requirejs('common/core/tasync'),
@@ -83,9 +84,8 @@ describe('corerel', function () {
     it('child should have pointer and root should not', function (done) {
         TASYNC.call(function (children) {
             var child = children[0];
-            core.hasPointer(child, 'parent').should.be.true;
             core.getPointerPath(child, 'parent').should.be.eql(core.getPath(root));
-            core.hasPointer(root, 'parent').should.be.false;
+            expect(core.getPointerPath(root, 'parent')).to.be.equal(undefined);
             done();
         }, core.loadChildren(root));
     });
@@ -128,19 +128,6 @@ describe('corerel', function () {
                 done();
             }, core.loadPointer(child, 'parent'));
         }, core.loadCollection(root, 'parent'));
-    });
-
-    it('getting outside pointer path', function (done) {
-        TASYNC.call(function (children) {
-            var child = children[0],
-                other = core.createNode({parent: root}),
-                grandChild = core.createNode({parent: child});
-            core.setPointer(grandChild, 'ptr', other);
-            core.getOutsidePointerPath(child, 'ptr', '/' + core.getRelid(grandChild))
-                .should.be.eql(core.getPointerPath(grandChild, 'ptr'));
-
-            done();
-        }, core.loadChildren(root));
     });
 
     it('getting children paths', function (done) {

--- a/test/common/core/coretree.spec.js
+++ b/test/common/core/coretree.spec.js
@@ -72,13 +72,6 @@ describe('CoreTree', function () {
         expect(coreTree.getData(node)).to.deep.equal({});
     });
 
-
-    it('should getDescendant', function () {
-        var node = coreTree.createRoot();
-
-        expect(coreTree.getDescendant(node, node, undefined /* base */)).to.deep.equal(node);
-    });
-
     describe('core.getParent', function () {
 
         it('should return with the parent object reference', function () {


### PR DESCRIPTION
Fixes the following findings:
- description of core.generateTreeDiff and core.applyTreeDiff seemed synchronous though the functions are asynchronous
- removed the  following core functions as they were not used (or was easy to change their usage) and not part of the public API: getDescendant, getRawKeys, getCoreTree, getPointersFrom, hasPointer, getOutsidePath
- client.moveMoreNodes now able to receive a commit msg and saves the state of the model (as all client manipulation should do by default)