### PR TITLE
Enable downloading error json at ERRORed branch.

### DIFF
--- a/src/client/js/Utils/SaveToDisk.js
+++ b/src/client/js/Utils/SaveToDisk.js
@@ -27,7 +27,7 @@ define(['blob/BlobClient'], function (BlobClient) {
             save.href = fileURL;
             save.target = '_self';
 
-            if(fileName){
+            if (fileName) {
                 save.download = fileName;
             }
 

--- a/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
+++ b/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
@@ -19,7 +19,8 @@ define([
         ITEM_VALUE_FORK = 'fork',
         ITEM_VALUE_FOLLOW = 'follow',
         ITEM_VALUE_MERGE = 'merge',
-        ITEM_VALUE_SELECT_BRANCH = 'select';
+        ITEM_VALUE_SELECT_BRANCH = 'select',
+        ITEM_VALUE_DOWNLOAD_ERROR = 'downloadError';
 
     BranchStatusWidget = function (containerEl, client) {
         this._logger = Logger.create('gme:Widgets:BranchStatusWidget', WebGMEGlobal.gmeConfig.client.log);
@@ -137,6 +138,8 @@ define([
                         self._logger.debug('branch selected: ', branchName);
                     }
                 });
+            } else if (value === ITEM_VALUE_DOWNLOAD_ERROR) {
+                self._client.downloadError();
             }
         };
 
@@ -228,6 +231,10 @@ define([
         this._ddBranchStatus.addItem({
             text: 'Reselect branch',
             value: ITEM_VALUE_SELECT_BRANCH
+        });
+        this._ddBranchStatus.addItem({
+            text: 'Download error data',
+            value: ITEM_VALUE_DOWNLOAD_ERROR
         });
     };
 

--- a/src/common/storage/project/branch.js
+++ b/src/common/storage/project/branch.js
@@ -25,6 +25,11 @@ define(['common/storage/constants'], function (CONSTANTS) {
         this.hashUpdateHandlers = [];
         this.callbackQueue = [];
 
+        /**
+         * @type {Error[]}
+         */
+        this.errorList = [];
+
         this._remoteUpdateHandler = null;
 
         this.cleanUp = function () {
@@ -178,7 +183,7 @@ define(['common/storage/constants'], function (CONSTANTS) {
             return false;
         };
 
-        this.dispatchBranchStatus = function (newStatus) {
+        this.dispatchBranchStatus = function (newStatus, err) {
             var i;
 
             logger.debug('dispatchBranchStatus old, new', branchStatus, newStatus);
@@ -188,6 +193,10 @@ define(['common/storage/constants'], function (CONSTANTS) {
                 newStatus = branchStatus;
             } else {
                 branchStatus = newStatus;
+            }
+
+            if (err) {
+                this.errorList.push(err instanceof Error ? err : new Error(err));
             }
 
             for (i = 0; i < self.branchStatusHandlers.length; i += 1) {


### PR DESCRIPTION
This version of the feature only deals with branch errors and there might be places where more unrecoverable states should report back an error to the branch (which in turn dispatches branch status ERROR used by the BranchStatusWidget).

At current version, the feature can be tried out by naming a new attribute to something containing a . or a $.