### PR TITLE
Closes #720 Plugin should be enabled by node type/

### DIFF
--- a/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
+++ b/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
@@ -17,7 +17,7 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
         PLUGIN_DATA_KEY = 'plugin',
         ATTRIBUTE_DATA_KEY = 'attribute',
     //jscs:disable maximumLineLength
-        PLUGIN_CONFIG_SECTION_BASE = $('<div><fieldset><legend></legend><form class="form-horizontal" role="form"></form><fieldset></div>'),
+        PLUGIN_CONFIG_SECTION_BASE = $('<div><fieldset><form class="form-horizontal" role="form"></form><fieldset></div>'),
         ENTRY_BASE = $('<div class="form-group"><div class="row"><label class="col-sm-4 control-label">NAME</label><div class="col-sm-8 controls"></div></div><div class="row description"><div class="col-sm-4"></div></div></div>'),
     //jscs:enable maximumLineLength
         DESCRIPTION_BASE = $('<div class="desc muted col-sm-8"></div>');
@@ -27,9 +27,9 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
         this._propertyGridWidgetManager.registerWidgetForType('boolean', 'iCheckBox');
     };
 
-    PluginConfigDialog.prototype.show = function (pluginConfigs, fnCallback) {
+    PluginConfigDialog.prototype.show = function (pluginConfigs, pluginClass, fnCallback) {
         var self = this;
-
+        this._currentPluginClass = pluginClass;
         this._fnCallback = fnCallback;
 
         this._initDialog(pluginConfigs);
@@ -72,6 +72,8 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
 
         this._divContainer = this._dialog.find('.modal-body');
 
+        this._title = this._dialog.find('.modal-title');
+        this._title.text((new this._currentPluginClass()).getName());
         this._widgets = {};
 
         this._btnSave.on('click', function (event) {
@@ -84,7 +86,6 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
             if (pluginConfigs.hasOwnProperty(p)) {
                 pluginSectionEl = PLUGIN_CONFIG_SECTION_BASE.clone();
                 pluginSectionEl.data(PLUGIN_DATA_KEY, p);
-                pluginSectionEl.find('legend').text('Plugin: ' + p);
                 this._divContainer.append(pluginSectionEl);
                 this._generatePluginSection(p, pluginConfigs[p], pluginSectionEl.find('.form-horizontal'));
             }
@@ -146,6 +147,7 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
                 descEl.css({
                     color: 'grey',
                     'padding-top': '7px',
+                    'padding-left': '0px',
                     'font-style': 'italic'
                 });
                 el.find('.controls').append(descEl);

--- a/src/client/js/Dialogs/PluginConfig/templates/PluginConfigDialog.html
+++ b/src/client/js/Dialogs/PluginConfig/templates/PluginConfigDialog.html
@@ -3,7 +3,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">×</button>
-                <h3>Configure plugin</h3>
+                <h3 class="modal-title"></h3>
             </div>
             <div class="modal-body">
             </div>

--- a/src/client/js/Panels/Header/DefaultToolbar.js
+++ b/src/client/js/Panels/Header/DefaultToolbar.js
@@ -30,7 +30,7 @@ define([
 
     var DefaultToolbar;
 
-    DefaultToolbar = function (client) {
+    DefaultToolbar = function (client, params) {
         this._client = client;
         this._pluginToolBar = null;
         this._metaRulesToolBar = null;
@@ -40,13 +40,39 @@ define([
     };
 
     DefaultToolbar.prototype._initialize = function () {
+        var self = this;
         this._pluginToolBar = new PluginToolbar(this._client);
         this._metaRulesToolBar = new MetaRulesToolbar(this._client);
         //TODO the toolbar also has to be optional, but how???
         if (this._client.gmeConfig.core.enableCustomConstraints === true) {
             this._constraintToolBar = new ConstraintToolBar(this._client);
         }
+
+        function activeNodeChanged() {
+            var activeNodeId = WebGMEGlobal.State.getActiveObject(),
+                allPlugins = WebGMEGlobal.allPlugins,
+                filtered = [];
+
+            if (typeof activeNodeId !== 'undefined') {
+                filtered = self._client.filterPlugins(allPlugins, activeNodeId);
+                if (filtered.length === 0) {
+                    self._pluginToolBar.disableButtons(true);
+                } else {
+                    self._pluginToolBar.disableButtons(false);
+                }
+            } else {
+                self._pluginToolBar.disableButtons(true);
+            }
+        }
+
+        self._pluginToolBar.disableButtons(true);
+
+        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_OBJECT, activeNodeChanged);
+        this._client.addEventListener(this._client.CONSTANTS.PROJECT_OPENED, activeNodeChanged);
+        this._client.addEventListener(this._client.CONSTANTS.BRANCH_CHANGED, activeNodeChanged);
+        this._client.addEventListener(this._client.CONSTANTS.BRANCH_STATUS_CHANGED, activeNodeChanged);
     };
+
 
     DefaultToolbar.prototype._createDummyControls = function () {
         var toolbar = WebGMEGlobal.Toolbar;

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -596,19 +596,17 @@ define(['js/logger',
                                     }
                                 } else if (prefix === CONSTANTS.PROPERTY_GROUP_META + '.') {
                                     if (i === REGISTRY_KEYS.VALID_VISUALIZERS) {
-                                        if (onlyRootSelected) {
-                                            dstList[extKey].value = dstList[extKey].value === undefined ?
+                                        dstList[extKey].value = dstList[extKey].value === undefined ?
                                                 '' : dstList[extKey].value;
-                                        }
                                         dstList[extKey].regex = '/[^\w\W]/';
                                         dstList[extKey].regexMessage = getHintMessage('Visualizers');
+                                    } else if (i === REGISTRY_KEYS.VALID_PLUGINS) {
+                                        dstList[extKey].value = dstList[extKey].value === undefined ?
+                                            '' : dstList[extKey].value;
+                                        dstList[extKey].regex = '/[^\w\W]/';
+                                        dstList[extKey].regexMessage = getHintMessage('Plugins');
                                     } else if (onlyRootSelected) {
-                                        if (i === REGISTRY_KEYS.VALID_PLUGINS) {
-                                            dstList[extKey].value = dstList[extKey].value === undefined ?
-                                                '' : dstList[extKey].value;
-                                            dstList[extKey].regex = '/[^\w\W]/';
-                                            dstList[extKey].regexMessage = getHintMessage('Plugins');
-                                        } else if (i === REGISTRY_KEYS.VALID_DECORATORS) {
+                                        if (i === REGISTRY_KEYS.VALID_DECORATORS) {
                                             dstList[extKey].value = dstList[extKey].value === undefined ?
                                                 '' : dstList[extKey].value;
                                             dstList[extKey].regex = '/[^\w\W]/';

--- a/src/client/js/Utils/InterpreterManager.js
+++ b/src/client/js/Utils/InterpreterManager.js
@@ -268,7 +268,7 @@ define([
                     } else {
                         d = new PluginConfigDialog();
                         silentPluginCfg = {};
-                        d.show(hackedConfig, runWithConfiguration);
+                        d.show(hackedConfig, plugin, runWithConfiguration);
                     }
                 });
             } else {

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -2001,7 +2001,7 @@ define([
                     filteredNames.push(validPlugins[i]);
                 } else {
                     logger.warn('Registered plugin for node at path "' + nodePath +
-                        '" is not amongst avaliable plugins', pluginNames);
+                        '" is not amongst available plugins', pluginNames);
                 }
             }
 


### PR DESCRIPTION
Instead of a global setting on the rootNode, the validPlugins follow inheritance.

This will "break" the UI in that for the current models the FCOs don't have any validPlugins. The quickest fix is to copy the values from the root.validPlugins to the fco.validPlugins.

N.B. If there are no valid plugins for the activeNode - the run plugin btn will be disabled (unless there are stored results).