### PR TITLE
Add method isInvalidActiveNode on PluginBase.

### DIFF
--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -454,6 +454,22 @@ define([
         this.logger.debug('newCommit added', newCommit);
     };
 
+    /**
+     * Checks if the activeNode has registered the plugin.
+     *
+     * @param {string} pluginId - Id of plugin
+     * @returns {Error} - returns undefined if valid and an Error if not.
+     */
+    PluginBase.prototype.isInvalidActiveNode = function (pluginId) {
+        var validPlugins = this.core.getRegistry(this.activeNode,  'validPlugins') || '';
+        this.logger.debug('validPlugins for activeNode', validPlugins);
+
+        if (validPlugins.split(' ').indexOf(pluginId) === -1) {
+            return new Error('Plugin not registered as validPlugin for active node, validPlugins "' +
+                validPlugins + '"');
+        }
+    };
+
     //--------------------------------------------------------------------------------------------------------------
     //---------- Methods that are used by the Plugin Manager. Derived classes should not use these methods
 

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -304,32 +304,6 @@ function importProject(storage, parameters, callback) {
     return deferred.promise.nodeify(callback);
 }
 
-function saveChanges(parameters, done) {
-    var persisted,
-        newRootHash;
-    expect(typeof parameters.project).to.equal('object');
-    expect(typeof parameters.core).to.equal('object');
-    expect(typeof parameters.rootNode).to.equal('object');
-
-    persisted = parameters.core.persist(parameters.rootNode);
-
-    newRootHash = parameters.core.getHash(parameters.rootNode);
-    parameters.project.makeCommit([], newRootHash, 'create empty project', function (err, commitHash) {
-        if (err) {
-            done(err);
-            return;
-        }
-
-        parameters.project.setBranchHash(parameters.branchName || 'master', '', commitHash, function (err) {
-            if (err) {
-                done(err);
-                return;
-            }
-            done(null, newRootHash, commitHash);
-        });
-    });
-}
-
 /**
  *
  * @param core
@@ -505,7 +479,6 @@ module.exports = {
 
     loadJsonFile: loadJsonFile,
     importProject: importProject,
-    saveChanges: saveChanges,
     projectName2Id: projectName2Id,
     logIn: logIn,
     openSocketIo: openSocketIo,

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -15,7 +15,6 @@ describe('CorePlugins', function () {
         superagent = testFixture.superagent,
 
         WebGME = testFixture.WebGME,
-        path = require('path'),
 
         logger = testFixture.logger.fork('coreplugins.spec'),
 
@@ -43,8 +42,10 @@ describe('CorePlugins', function () {
             'MultipleMainCallbackCalls',
             'InvalidActiveNode'
         ],
-        projects = [],// N.B.: this is getting populated by the createTests function
-
+        projectNames = pluginNames.map(function (name) {
+            return name + 'TestMain';
+        }),
+        importResults = [],
         gmeAuth,
         safeStorage,
 
@@ -52,9 +53,7 @@ describe('CorePlugins', function () {
         serverBaseUrl,
         server,
 
-        runPlugin = require('../../../src/bin/run_plugin'),
-        filename = path.normalize('../../../src/bin/run_plugin.js'),
-        oldProcessExit = process.exit;
+        PluginCliManager = require('../../../src/plugin/climanager');
 
     before(function (done) {
         var gmeConfigWithAuth = testFixture.getGmeConfig();
@@ -69,7 +68,7 @@ describe('CorePlugins', function () {
                 return;
             }
 
-            testFixture.clearDBAndGetGMEAuth(gmeConfigWithAuth, projects)
+            testFixture.clearDBAndGetGMEAuth(gmeConfigWithAuth, projectNames)
                 .then(function (gmeAuth_) {
                     gmeAuth = gmeAuth_;
                     safeStorage = testFixture.getMongoStorage(logger, gmeConfigWithAuth, gmeAuth);
@@ -84,8 +83,8 @@ describe('CorePlugins', function () {
                         promise,
                         i;
 
-                    for (i = 0; i < projects.length; i += 1) {
-                        projectName = projects[i];
+                    for (i = 0; i < projectNames.length; i += 1) {
+                        projectName = projectNames[i];
                         promise = testFixture.importProject(safeStorage, {
                             projectSeed: './seeds/ActivePanels.json',
                             projectName: projectName,
@@ -95,7 +94,11 @@ describe('CorePlugins', function () {
                         });
                         promises.push(promise);
                     }
+
                     return Q.allDone(promises);
+                })
+                .then(function (results) {
+                    importResults = results;
                 })
                 .nodeify(done);
         });
@@ -114,10 +117,6 @@ describe('CorePlugins', function () {
             ])
                 .nodeify(done);
         });
-    });
-
-    afterEach(function () {
-        process.exit = oldProcessExit;
     });
 
     // get seed designs 'files' and make sure all of them are getting tested
@@ -139,44 +138,43 @@ describe('CorePlugins', function () {
     function createTests() {
         var i;
 
-        function createPluginTest(name) {
-            var projectName = name + 'TestMain';
-
-            projects.push(projectName);
-
+        function createPluginTest(name, cnt) {
             // import seed designs
             it('should run plugin ' + name, function (done) {
-                var numCallback = 0;
+                var pluginManager = new PluginCliManager(importResults[cnt].project, logger, gmeConfig),
+                    pluginContext = {
+                        activeNode: '/1',
+                        branchName: 'master'
+                    },
+                    callbackCnt = 0;
 
-                process.exit = function (code) {
-                    expect(code).to.equal(0);
-                    done();
-                };
-
-                runPlugin.main(['node', filename, name, projectName, '-s', '/1'],
-                    function (err, result) {
-                        numCallback += 1;
-                        if (err) {
-                            if (pluginsShouldFail.indexOf(name) > -1) {
-                                if (name === 'MultipleMainCallbackCalls') {
-                                    // ignore all callback functions, done() is called from process.exit once.
-                                } else {
-                                    done();
-                                }
+                pluginManager.executePlugin(name, null, pluginContext, function (err, result) {
+                    callbackCnt += 1;
+                    try {
+                        if (name === 'MultipleMainCallbackCalls') {
+                            if (callbackCnt === 1) {
+                                expect(result.success).to.equal(true);
                             } else {
-                                done(new Error(err));
+                                expect(result.success).to.equal(false);
+                                done();
                             }
-                            return;
+                        } else if (pluginsShouldFail.indexOf(name) > -1) {
+                            expect(result.success).to.equal(false);
+                            done();
+                        } else {
+                            expect(result.success).to.equal(true);
+                            expect(result.error).to.equal(null);
+                            done();
                         }
-                        expect(result.success).to.equal(true);
-                        expect(result.error).to.equal(null);
+                    } catch (err) {
+                        done(err);
                     }
-                );
+                });
             });
         }
 
         for (i = 0; i < pluginNames.length; i += 1) {
-            createPluginTest(pluginNames[i]);
+            createPluginTest(pluginNames[i], i);
         }
     }
 

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -32,14 +32,16 @@ describe('CorePlugins', function () {
             'VisualizerGenerator',
             'LayoutGenerator',
             'MultipleMainCallbackCalls',
-            'PluginForked'
+            'PluginForked',
+            'InvalidActiveNode'
         ],
 
         pluginsShouldFail = [
             'ExecutorPlugin',
             'MergeExample',
             'MetaGMEParadigmImporter',
-            'MultipleMainCallbackCalls'
+            'MultipleMainCallbackCalls',
+            'InvalidActiveNode'
         ],
         projects = [],// N.B.: this is getting populated by the createTests function
 

--- a/test/plugin/scenarios/plugins/InvalidActiveNode/InvalidActiveNode.js
+++ b/test/plugin/scenarios/plugins/InvalidActiveNode/InvalidActiveNode.js
@@ -1,0 +1,43 @@
+/*globals define*/
+/*jshint node:true, browser:true*/
+
+if (typeof define === 'undefined') {
+
+} else {
+    define([
+        'plugin/PluginConfig',
+        'plugin/PluginBase'
+    ], function (PluginConfig,
+                 PluginBase) {
+        'use strict';
+        var InvalidActiveNode = function () {
+            // Call base class' constructor.
+            PluginBase.call(this);
+        };
+
+        InvalidActiveNode.prototype = Object.create(PluginBase.prototype);
+        InvalidActiveNode.prototype.constructor = InvalidActiveNode;
+
+        InvalidActiveNode.prototype.getName = function () {
+            return 'Invalid Active Node';
+        };
+
+        InvalidActiveNode.prototype.getVersion = function () {
+            return '0.1.0';
+        };
+
+        InvalidActiveNode.prototype.main = function (callback) {
+            var self = this,
+                isInvalidActiveNode = self.isInvalidActiveNode('InvalidActiveNode');
+
+            if (isInvalidActiveNode) {
+                callback(isInvalidActiveNode, self.result);
+            } else {
+                self.result.setSuccess(true);
+                callback(null, self.result);
+            }
+        };
+
+        return InvalidActiveNode;
+    });
+}


### PR DESCRIPTION
This adds a convenience method to check if the plugin is registered for the activeNode.
Although it could be checked by default from the pluginManagers, there are cases where this would be cumbersome. For instance most of our tests would have to be revisited. 