### PR TITLE
Expose project authorisation on REST API

### DIFF
--- a/config/config.test.js
+++ b/config/config.test.js
@@ -17,6 +17,8 @@ config.blob.fsDir = './test-tmp/blob-storage';
 config.executor.outputDir = './test-tmp/executor';
 config.executor.workerRefreshInterval = 100;
 
+config.authentication.salts = 1;
+
 //FIXME: Have a common dir for this..
 config.plugin.basePaths.push(path.join(__dirname, '../test/plugin/scenarios/plugins'));
 config.plugin.allowServerExecution = true;

--- a/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
+++ b/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
@@ -109,6 +109,11 @@
       color: grey; }
 .projects-dialog .modal-content .modal-footer button.corner-button {
   margin-top: 0.5ex; }
+.projects-dialog .modal-content .modal-footer ul.dropdown-menu {
+  min-width: 0;
+  text-align: left; }
+  .projects-dialog .modal-content .modal-footer ul.dropdown-menu a {
+    cursor: pointer; }
 
 .txt-project-name {
   width: 50%; }

--- a/src/client/js/Dialogs/Projects/styles/ProjectsDialog.scss
+++ b/src/client/js/Dialogs/Projects/styles/ProjectsDialog.scss
@@ -201,6 +201,13 @@
       button.corner-button {
         margin-top: 0.5ex;
       }
+      ul.dropdown-menu {
+        min-width: 0;
+        text-align: left;
+        a {
+          cursor: pointer;
+        }
+      }
     }
   }
 }

--- a/src/client/js/Dialogs/Projects/templates/ProjectsDialog.html
+++ b/src/client/js/Dialogs/Projects/templates/ProjectsDialog.html
@@ -54,16 +54,11 @@
                 <div class="panel-create-new control-group">
                     <div class="input-group">
                         <div class="input-group-btn">
-                            <button type="button" class="btn btn-default dropdown-toggle disabled" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <span class="username">Username</span>
-                                <!--<span class="caret"></span>-->
+                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="selected-owner-id" title="Owner of New Project">Username</span>
+                                <span class="caret"></span>
                             </button>
-                            <ul class="dropdown-menu">
-                                <!--<li><a href="#">Username</a></li>-->
-                                <!--<li><a href="#">Another action</a></li>-->
-                                <!--<li><a href="#">Something else here</a></li>-->
-                                <!--<li role="separator" class="divider"></li>-->
-                                <!--<li><a href="#">Separated link</a></li>-->
+                            <ul class="dropdown-menu ownerId-list">
                             </ul>
                         </div><!-- /btn-group -->
                         <input type="text" class="input-xlarge txt-project-name form-control"

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -102,6 +102,52 @@ function createAPI(app, mountPath, middlewareOpts) {
         });
     });
 
+    function putUser(receivedData, req, res, next) {
+        var userId = getUserId(req);
+
+        gmeAuth.getUser(userId, function (err, data) {
+            if (err) {
+                res.status(404);
+                res.json({
+                    message: 'Requested resource was not found',
+                    error: err
+                });
+                return;
+            }
+
+            if (!data.siteAdmin) {
+                res.status(403);
+                return next(new Error('site admin role is required for  this operation'));
+            }
+
+            // we may need to check if this user can create other ones.
+            gmeAuth.addUser(receivedData.userId,
+                receivedData.email,
+                receivedData.password,
+                receivedData.canCreate === 'true' || receivedData.canCreate === true,
+                {overwrite: false},
+                function (err/*, updateData*/) {
+                    if (err) {
+                        res.status(400);
+                        return next(new Error(err));
+                    }
+
+                    gmeAuth.getUser(receivedData.userId, function (err, data) {
+                        if (err) {
+                            res.status(404);
+                            res.json({
+                                message: 'Requested resource was not found',
+                                error: err
+                            });
+                            return;
+                        }
+
+                        res.json(data);
+                    });
+                });
+        });
+    }
+
     // AUTHENTICATED
     router.get('/user', ensureAuthenticated, function (req, res) {
         var userId = getUserId(req);
@@ -193,63 +239,12 @@ function createAPI(app, mountPath, middlewareOpts) {
     });
 
     router.put('/users', function (req, res, next) {
+        //"userId"
+        //"email": "user@example.com",
+        //"password": "pass",
+        //"canCreate": null,
 
-        var userId = getUserId(req);
-
-        gmeAuth.getUser(userId, function (err, data) {
-            var receivedData;
-            if (err) {
-                res.status(404);
-                res.json({
-                    message: 'Requested resource was not found',
-                    error: err
-                });
-                return;
-            }
-
-            if (!data.siteAdmin) {
-                res.status(403);
-                return next(new Error('site admin role is required for  this operation'));
-            }
-
-            //try {
-            receivedData = req.body;
-            // TODO: verify request
-            // "userId"
-            //"email": "user@example.com",
-            //"password": "pass",
-            //"canCreate": null,
-            //"siteAdmin": false,
-
-            // we may need to check if this user can create other ones.
-
-            gmeAuth.addUser(receivedData.userId,
-                receivedData.email,
-                receivedData.password,
-                receivedData.canCreate === 'true' || receivedData.canCreate === true,
-                {overwrite: false},
-                function (err/*, updateData*/) {
-                    if (err) {
-                        res.status(400);
-                        return next(new Error(err));
-                    }
-
-                    gmeAuth.getUser(receivedData.userId, function (err, data) {
-                        if (err) {
-                            res.status(404);
-                            res.json({
-                                message: 'Requested resource was not found',
-                                error: err
-                            });
-                            return;
-                        }
-
-                        res.json(data);
-                    });
-                });
-
-        });
-
+        putUser(req.body, req, res, next);
     });
 
     router.get('/users/:username', function (req, res) {
@@ -266,6 +261,17 @@ function createAPI(app, mountPath, middlewareOpts) {
 
             res.json(data);
         });
+    });
+
+    router.put('/users/:username', function (req, res, next) {
+        var receivedData = {
+            userId: req.params.username,
+            email: req.body.email,
+            password: req.body.password,
+            canCreate: req.body.canCreate || false
+        };
+
+        putUser(receivedData, req, res, next);
     });
 
     router.patch('/users/:username', function (req, res, next) {
@@ -430,7 +436,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.json(data);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1) {
                     res.status(404);
                 }
@@ -447,7 +452,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1) {
                     res.status(404);
                 }
@@ -464,7 +468,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1 ||
                     err.message.indexOf('No such user [') > -1) {
                     res.status(404);
@@ -482,7 +485,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1) {
                     res.status(404);
                 }
@@ -499,7 +501,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1 ||
                     err.message.indexOf('No such user [') > -1) {
                     res.status(404);
@@ -517,7 +518,6 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                err = new Error(err);
                 if (err.message.indexOf('No such organization [') > -1 ||
                     err.message.indexOf('No such user [') > -1) {
                     res.status(404);
@@ -566,6 +566,31 @@ function createAPI(app, mountPath, middlewareOpts) {
             });
     }
 
+    function canUserAuthorizeProject(req) {
+        var userId = getUserId(req);
+
+        return gmeAuth.getUser(userId)
+            .then(function (userData) {
+                // Make sure user is authorized (owner, admin in owner Org or siteAdmin).
+                if (userId === req.params.ownerId || userData.siteAdmin === true) {
+                    return true;
+                } else {
+                    return gmeAuth.getOrganization(req.params.ownerId)
+                        .then(function (orgData) {
+                            if (orgData.admins.indexOf(userId) > -1) {
+                                return true;
+                            }
+
+                            return false;
+                        })
+                        .catch(function (err) {
+                            logger.debug(err);
+                            return false;
+                        });
+                }
+            });
+    }
+
     router.get('/projects', ensureAuthenticated, function (req, res, next) {
         var userId = getUserId(req);
         safeStorage.getProjects({username: userId})
@@ -600,6 +625,32 @@ function createAPI(app, mountPath, middlewareOpts) {
             });
     });
 
+    router.patch('/projects/:ownerId/:projectName', ensureAuthenticated, function (req, res, next) {
+        var userId = getUserId(req),
+            projectId =  StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId, req.params.projectName);
+
+        gmeAuth.getProjectAuthorizationByUserId(userId, projectId)
+            .then(function (rights) {
+                if (rights.write !== true) {
+                    return gmeAuth.getUser(userId)
+                        .then(function (userData) {
+                            if (userData.siteAdmin !== true) {
+                                res.status(403);
+                                throw new Error('Not authorized to modify project');
+                            }
+                        });
+                }
+            })
+            .then(function () {
+                return gmeAuth.updateProjectInfo(projectId, req.body);
+            })
+            .then(function (projectData) {
+                res.json(projectData);
+            })
+            .catch(function (err) {
+                next(err);
+            });
+    });
     /**
      * Creating project by seed
      *
@@ -651,6 +702,78 @@ function createAPI(app, mountPath, middlewareOpts) {
             });
     });
 
+    router.put('/projects/:ownerId/:projectName/authorize/:userOrOrgId/:accessLevel', function (req, res, next) {
+        var projectId = StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId, req.params.projectName);
+
+        canUserAuthorizeProject(req)
+            .then(function (isAuthorized) {
+                if (isAuthorized === false) {
+                    res.status(403);
+                    throw new Error('Not allowed to authorize users/organizations for project');
+                }
+                // ensure project exists
+                return gmeAuth.getProject(projectId);
+            })
+            .then(function (/*projectData*/) {
+                var rights = {
+                    read: false,
+                    write: false,
+                    delete: false
+                };
+
+                if (req.params.accessLevel === 'read') {
+                    rights.read = true;
+                } else if (req.params.accessLevel === 'write') {
+                    rights.read = true;
+                    rights.write = true;
+                } else if (req.params.accessLevel === 'delete') {
+                    rights.read = true;
+                    rights.write = true;
+                    rights.delete = true;
+                } else {
+                    throw new Error('Unexpected accessLevel [' + req.params.accessLevel + ']');
+                }
+
+                return gmeAuth.authorizeByUserOrOrgId(req.params.userOrOrgId, projectId, 'set', rights);
+            })
+            .then(function () {
+                res.sendStatus(204);
+            })
+            .catch(function (err) {
+                console.log(err);
+                if (err.message.indexOf('No such user or org') > -1 || err.message.indexOf('no such project') > -1) {
+                    res.status(404);
+                }
+                next(err);
+            });
+    });
+
+    router.delete('/projects/:ownerId/:projectName/authorize/:userOrOrgId', function (req, res, next) {
+        var projectId = StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId, req.params.projectName);
+
+        canUserAuthorizeProject(req)
+            .then(function (isAuthorized) {
+                if (isAuthorized === false) {
+                    res.status(403);
+                    throw new Error('Not allowed to authorize users/organizations for project');
+                }
+                // ensure project exists
+                return gmeAuth.getProject(projectId);
+            })
+            .then(function (/*projectData*/) {
+                return gmeAuth.authorizeByUserOrOrgId(req.params.userOrOrgId, projectId, 'delete');
+            })
+            .then(function () {
+                res.sendStatus(204);
+            })
+            .catch(function (err) {
+                if (err.message.indexOf('No such user or org') > -1 || err.message.indexOf('no such project') > -1) {
+                    res.status(404);
+                }
+                next(err);
+            });
+    });
+
     router.get('/projects/:ownerId/:projectName/commits', ensureAuthenticated, function (req, res, next) {
         var userId = getUserId(req),
             data = {
@@ -658,7 +781,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 projectId: StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
                     req.params.projectName),
                 before: (new Date()).getTime(), // current time
-                number: 100 // asks for the last 100 commits from the time specified above
+                number: req.body.number || 100 // asks for the last 100 commits from the time specified above
             };
 
         safeStorage.getCommits(data)
@@ -783,60 +906,6 @@ function createAPI(app, mountPath, middlewareOpts) {
             });
     });
 
-    router.get('/projects/:ownerId/:projectName/branches/:branchId/commits', ensureAuthenticated,
-        function (req, res, next) {
-            var userId = getUserId(req),
-                data = {
-                    username: userId,
-                    projectId: StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
-                        req.params.projectName),
-                    start: req.params.branchId,
-                    number: 100
-                };
-
-            safeStorage.getHistory(data)
-                .then(function (result) {
-                    res.json(result);
-                })
-                .catch(function (err) {
-                    if (err.message.indexOf('not exist') > -1) {
-                        err.status = 404;
-                    }
-                    next(err);
-                });
-        }
-    );
-
-    router.get('/projects/:ownerId/:projectName/branches/:branchId/tree/*', ensureAuthenticated,
-        function (req, res, next) {
-            var userId = getUserId(req),
-                projectId = StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
-                    req.params.projectName),
-                data = {
-                    username: userId,
-                    projectId: projectId,
-                    branchName: req.params.branchId
-                };
-
-            safeStorage.getBranchHash(data)
-                .then(function (branchHash) {
-                    if (!branchHash) {
-                        throw new Error('Branch does not exist ' + req.params.branchId);
-                    }
-                    return loadNodePathByCommitHash(userId, projectId, branchHash, '/' + req.params[0]);
-                })
-                .then(function (dataObj) {
-                    res.json(dataObj);
-                })
-                .catch(function (err) {
-                    if (err.message.indexOf('not exist') > -1 || err.message.indexOf('Not authorized to read') > -1 ) {
-                        err.status = 404;
-                    }
-                    next(err);
-                });
-        }
-    );
-
     router.patch('/projects/:ownerId/:projectName/branches/:branchId', function (req, res, next) {
         var userId = getUserId(req),
             data = {
@@ -894,6 +963,60 @@ function createAPI(app, mountPath, middlewareOpts) {
             });
     });
 
+    router.get('/projects/:ownerId/:projectName/branches/:branchId/commits', ensureAuthenticated,
+        function (req, res, next) {
+            var userId = getUserId(req),
+                data = {
+                    username: userId,
+                    projectId: StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
+                        req.params.projectName),
+                    start: req.params.branchId,
+                    number: req.body.number || 100
+                };
+
+            safeStorage.getHistory(data)
+                .then(function (result) {
+                    res.json(result);
+                })
+                .catch(function (err) {
+                    if (err.message.indexOf('not exist') > -1) {
+                        err.status = 404;
+                    }
+                    next(err);
+                });
+        }
+    );
+
+    router.get('/projects/:ownerId/:projectName/branches/:branchId/tree/*', ensureAuthenticated,
+        function (req, res, next) {
+            var userId = getUserId(req),
+                projectId = StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
+                    req.params.projectName),
+                data = {
+                    username: userId,
+                    projectId: projectId,
+                    branchName: req.params.branchId
+                };
+
+            safeStorage.getBranchHash(data)
+                .then(function (branchHash) {
+                    if (!branchHash) {
+                        throw new Error('Branch does not exist ' + req.params.branchId);
+                    }
+                    return loadNodePathByCommitHash(userId, projectId, branchHash, '/' + req.params[0]);
+                })
+                .then(function (dataObj) {
+                    res.json(dataObj);
+                })
+                .catch(function (err) {
+                    if (err.message.indexOf('not exist') > -1 || err.message.indexOf('Not authorized to read') > -1 ) {
+                        err.status = 404;
+                    }
+                    next(err);
+                });
+        }
+    );
+
     router.get('/projects/:ownerId/:projectName/tags', ensureAuthenticated, function (req, res, next) {
         var userId = getUserId(req),
             data = {
@@ -944,6 +1067,28 @@ function createAPI(app, mountPath, middlewareOpts) {
         safeStorage.createTag(data)
             .then(function () {
                 res.sendStatus(201);
+            })
+            .catch(function (err) {
+                next(err);
+            });
+    });
+
+    router.patch('/projects/:ownerId/:projectName/tags/:tagId', function (req, res, next) {
+        var userId = getUserId(req),
+            data = {
+                username: userId,
+                projectId: StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
+                    req.params.projectName),
+                tagName: req.params.tagId,
+                commitHash: req.body.hash
+            };
+
+        safeStorage.deleteTag(data)
+            .then(function () {
+                return safeStorage.createTag(data);
+            })
+            .then(function () {
+                res.sendStatus(200);
             })
             .catch(function (err) {
                 next(err);

--- a/src/server/api/webgme-api-commit-retrieve.json
+++ b/src/server/api/webgme-api-commit-retrieve.json
@@ -1,0 +1,13 @@
+{
+  "root": "#20d99ca1c0a2ec8a256d0beda8302d2bc0ddd300",
+  "parents": [
+    "#8b2ce483f807d52d44a9377d08ac5a7573ddb07c"
+  ],
+  "updater": [
+    "pmeijer"
+  ],
+  "time": 1448397167677,
+  "message": "[setRegistry(/1036661779/588886926,,position,[object Object])]",
+  "type": "commit",
+  "_id": "#cdfc41958e056e5faf59ff3059394368204a7bbc"
+}

--- a/src/server/api/webgme-api-commits-retrieve.json
+++ b/src/server/api/webgme-api-commits-retrieve.json
@@ -1,0 +1,28 @@
+[
+  {
+    "_id": "#f2a624d9cfbf883c927b04dd45800ba55537dff5",
+    "root": "#e1721a407ecce45c83b7352a62349cada71056bf",
+    "parents": [
+      "#4ac76d63da6f50cc5baaa5bfb42c86138edc9396"
+    ],
+    "updater": [
+      "guest"
+    ],
+    "time": 1449590037764,
+    "message": "[setRegistry(/1054504320/354493498/496824070/2098980444,,rotation,0)]",
+    "type": "commit"
+  },
+  {
+    "_id": "#4ac76d63da6f50cc5baaa5bfb42c86138edc9396",
+    "root": "#6fc60b12e9b17ebb69231fae3356455365d0f8b9",
+    "parents": [
+      ""
+      ],
+    "updater": [
+      "guest"
+    ],
+    "time": 1449589988631,
+    "message": "project created",
+    "type": "commit"
+  }
+]

--- a/src/server/api/webgme-api-org-new.json
+++ b/src/server/api/webgme-api-org-new.json
@@ -3,7 +3,7 @@
   "projects": {},
   "type": "Organization",
   "admins": [
-    "pmeijer"
+    "pelleBlom"
   ],
   "info": {}
 }

--- a/src/server/api/webgme-api-org-retrieve.json
+++ b/src/server/api/webgme-api-org-retrieve.json
@@ -3,12 +3,11 @@
   "projects": {},
   "type": "Organization",
   "admins": [
-    "pmeijer"
+    "pelleBlom"
   ],
-    "info": {},
-    "users": [
-      "pmeijer",
-      "guest",
-      "pelleBlom"
-    ]
+  "info": {},
+  "users": [
+    "guest",
+    "pelleBlom"
+  ]
 }

--- a/src/server/api/webgme-api-project-new.json
+++ b/src/server/api/webgme-api-project-new.json
@@ -1,5 +1,6 @@
 {
   "type": "db",
   "seedName": "me+myOtherProject",
-  "seedBranch": "release"
+  "seedBranch": "master",
+  "ownerId": "myOrganization"
 }

--- a/src/server/api/webgme-api-project-patch.json
+++ b/src/server/api/webgme-api-project-patch.json
@@ -1,0 +1,8 @@
+{
+  "createdAt": "2015-11-03T22:08:35.706Z",
+  "viewedAt": "2015-12-01T22:42:08.713Z",
+  "viewer": "gurka",
+  "modifiedAt": "2015-12-01T22:42:08.713Z",
+  "modifier": "arnold",
+  "creator": "pelleBlom"
+}

--- a/src/server/api/webgme-api-project-retrieve.json
+++ b/src/server/api/webgme-api-project-retrieve.json
@@ -1,7 +1,17 @@
 {
-   "message":"Not found",
-   "documentation_url":"",
-   "error":{
-
-   }
+  "_id": "demo+FSM",
+  "owner": "demo",
+  "name": "FSM",
+  "info": {
+    "createdAt": "2015-11-03T22:08:35.706Z",
+    "viewedAt": "2015-12-01T22:42:08.713Z",
+    "viewer": "demo",
+    "modifiedAt": "2015-12-01T22:42:08.713Z",
+    "modifier": "demo",
+    "creator": "demo"
+  },
+  "branches": {
+    "important_point": "#48e883fe1fbd1f370a34263218e1572cc885b0bc",
+    "master": "#bd5ea217510a3f6a3f7e98fbdae0d10669ef9c2d"
+  }
 }

--- a/src/server/api/webgme-api-tree-retrieve.json
+++ b/src/server/api/webgme-api-tree-retrieve.json
@@ -1,0 +1,12 @@
+{
+  "_id": "#41d009f2dc852dbbf783f900085b789b2f35d372",
+  "atr": {
+    "_relguid": "fa8d13d9e1b0d3477a1f5541ec1c0d3b"
+  },
+  "reg": {
+    "position": {
+      "x": 158,
+      "y": 229
+    }
+  }
+}

--- a/src/server/api/webgme-api-user-patch.json
+++ b/src/server/api/webgme-api-user-patch.json
@@ -1,5 +1,6 @@
 {
   "password": "demo",
   "email": "a@example.com",
-  "canCreate": true
+  "canCreate": true,
+  "siteAdmin": true
 }

--- a/src/server/api/webgme-api-user-retrieve.json
+++ b/src/server/api/webgme-api-user-retrieve.json
@@ -1,21 +1,21 @@
- {
-      "_id":"demo",
-      "email":"demo",
-      "canCreate":true,
-      "projects":{
-         "guest+aaaaaa":{
-            "read":true,
-            "write":true,
-            "delete":false
-         },
-         "demo+ASDF":{
-            "read":true,
-            "write":true,
-            "delete":true
-         }
-      },
-      "orgs":[
-
-      ],
-      "siteAdmin":false
-   }
+{
+  "_id":"demo",
+  "email":"demo@mail.com",
+  "canCreate":true,
+  "projects":{
+    "guest+aaaaaa":{
+      "read":true,
+      "write":true,
+      "delete":false
+    },
+    "demo+ASDF":{
+      "read":true,
+      "write":true,
+      "delete":true
+    }
+  },
+  "orgs":[
+    "ATeam"
+  ],
+  "siteAdmin":false
+}

--- a/src/server/api/webgme-api-users.json
+++ b/src/server/api/webgme-api-users.json
@@ -9,7 +9,7 @@
       "orgs":[
 
       ],
-      "site_admin":false
+      "siteAdmin":false
    },
    {
       "_id":"anonymous",

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -239,32 +239,34 @@ resourceTypes:
         userOrOrgId:
           example: demoUser
       delete:
-        description: Remove user's or organization's access rights to the project. Requires at least one of the following from initiator;
-         is owner of the project, is admin in the organization that owns the project, or is siteAdmin.
+        description: Remove user's or organization's access rights to the project. Requires at least one of the following from user;
+           is <b>owner</b> of the project, is <b>admin in the organization</b> that owns the project, or is <b>siteAdmin</b>.
         responses:
           204:
           403:
           404:
-      /{accessLevel}:
+      /{rights}:
         uriParameters:
-          accessLevel:
-            description: read, write or delete
-            example: read
+          rights:
+            description: Combination of r-read, w-write, d-delete
+            example: rwd
         put:
-          description: Grants user or organization access to the project. Requires at least one of the following from initiator;
-           is owner of the project, is admin in the organization that owns the project, or is siteAdmin.
+          description: Grants user or organization access to the project. Requires at least one of the following from user;
+           is <b>owner</b> of the project, is <b>admin in the organization</b> that owns the project, or is <b>siteAdmin</b>.
           responses:
             204:
             403:
             404:
     /commits:
       get:
-        description: Retrives an array of latested commits made to the project. The body parameter "number" set the maximum number of commits retrieved (default is 100). Requires <b>read</b> access for project.
-        body:
-          application/json:
-            example: "{
-              \"number\": 2
-            }"
+        description: Retrives an array of latested commits made to the project. Requires <b>read</b> access for project.
+        queryParameters:
+          n:
+            displayName: n
+            type: number
+            description: Maximum number of commits to retrieve (default 100).
+            example: 2
+            required: false
         responses:
           200:
             body:
@@ -319,12 +321,14 @@ resourceTypes:
             deleteDesc: Requires <b>write</b> access for project.
         /commits:
           get:
-            description: Retrives an array of the commit history for the branch. The body parameter "number" set the maximum number of commits retrieved default is 100. Requires <b>read</b> access for project.
-            body:
-              application/json:
-                example: "{
-                  \"number\": 2
-                }"
+            description: Retrives an array of the commit history for the branch. Requires <b>read</b> access for project.
+            queryParameters:
+              n:
+                displayName: n
+                type: number
+                description: Maximum number of commits to retrieve (default 100).
+                example: 2
+                required: false
             responses:
               200:
                 body:

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -18,50 +18,25 @@ securitySchemes:
             description: Authentication required
           403:
             description: Forbidden
-  - orgOrSiteAdmin:
-      description: Admin for the entire site or the organization.
-      type: Basic Authentication
-      describedBy:
-        responses:
-          403:
-            description: Not authorized.
 
 
 resourceTypes:
   - collection:
       description: Collection of available <<resourcePathName>> in WebGME.
       get:
-        description: Get a list of <<resourcePathName>>.
+        description: Get a list of <<resourcePathName>>. <<desc>>
         responses:
           200:
             body:
               application/json:
                 example: |
                   <<exampleCollection>>
-      put:
-        description: |
-          Add a new <<resourcePathName|!singularize>> to WebGME.
-        securedBy: [ basic ]
-        body:
-          application/json:
-            schema: <<resourcePathName|!singularize>>
-            example: |
-              <<exampleItem>>
-        responses:
-          200:
-            body:
-              application/json:
-                example: |
-                  { "message": "The <<resourcePathName|!singularize>> has been properly entered" }
-          400:
           
   - collection-item:
       description: Entity representing a <<resourcePathName|!singularize>>
       get:
         description: |
-          Get the <<resourcePathName|!singularize>>
-          with <<resourcePathName|!singularize>>Id =
-          {<<resourcePathName|!singularize>>Id}
+          Get the <<resourcePathName|!singularize>>. <<getDesc>>
         responses:
           200:
             body:
@@ -74,14 +49,51 @@ resourceTypes:
                 example: |
                   {"message": "<<resourcePathName|!singularize>> not found" }
       put:
-          securedBy: [ basic ]
+        description: |
+          Add a new <<resourcePathName|!singularize>> to WebGME. <<putDesc>>
+        securedBy: [ basic ]
+        body:
+          application/json:
+            schema: See example
+            example: |
+              <<putBody>>
+        responses:
+          204:
+            body:
+              application/json:
+                example: |
+                  { "message": "The <<resourcePathName|!singularize>> has been properly entered" }
+          403:
+          404:
       patch:
-          securedBy: [ basic ]
+        description: Update <<resourcePathName|!singularize>> within WebGME. <<patchDesc>>
+        securedBy: [ basic ]
+        body:
+          application/json:
+            schema: See example
+            example: |
+              <<patchBody>>
+        responses:
+            204:
+            403:
+            404:
       delete:
-          securedBy: [ basic ]
-          responses:
-            204:          
-        
+        description: Delete <<resourcePathName|!singularize>> from WebGME. <<deleteDesc>>
+        securedBy: [ basic ]
+        responses:
+          204:
+          403:
+          404:
+  - project-tree:
+      get:
+        description: Retrieves the raw data object at given path within the project tree. Requires <b>read</b> access for project.
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include webgme-api-tree-retrieve.json
+          403:
+          404:
 
 /:
   get:
@@ -109,6 +121,8 @@ resourceTypes:
           application/json:
             example: !include webgme-api-user-retrieve.json
   delete:
+    description: Remove the current user
+    securedBy: [ basic ]
     responses:
       204:
 
@@ -116,11 +130,17 @@ resourceTypes:
   type:
     collection:
       exampleCollection: !include webgme-api-users.json
-      exampleItem: !include webgme-api-user-new.json  
+      desc: 
   /{username}:
     type:
       collection-item:
-        exampleItem: !include webgme-api-user-retrieve.json   
+        exampleItem: !include webgme-api-user-retrieve.json
+        putBody: !include webgme-api-user-new.json
+        patchBody: !include webgme-api-user-patch.json
+        getDesc:
+        putDesc: Requires <b>user.siteAdmin</b>.
+        patchDesc: Requires <b>user.siteAdmin</b> if setting siteAdmin.
+        deleteDesc: Requires is current user or <b>user.siteAdmin</b>.
 
 /orgs:
   get:
@@ -133,7 +153,7 @@ resourceTypes:
             example: !include webgme-api-orgs.json
   /{orgId}:
     get:
-      description: Entity representing an organization
+      description: Retrives organization data including members.
       securedBy: [ basic ]
       responses:
         200:
@@ -142,58 +162,63 @@ resourceTypes:
               example: !include webgme-api-org-retrieve.json
         404:
     put:
-      description: Create a new organization (requires canCreate).
+      description: Create a new organization. Requires <b>user.canCreate</b> or <b>user.siteAdmin</b>.
       securedBy: [ basic ]
       responses:
         200:
           body:
             application/json:
-              example: !include webgme-api-org-retrieve.json
+              example: !include webgme-api-org-new.json
         403:
         404:
     delete:
-      description: Delete an organization.
-      securedBy: [ basic, orgOrSiteAdmin ]
+      description: Delete an organization. Requires admin in organization or <b>user.siteAdmin</b>.
+      securedBy: [ basic ]
       responses:
-        200:
+        204:
         403:
         404:
     
     /users/{username}:
       put:
-        description: Adds user to the organization.
-        securedBy: [ basic, orgOrSiteAdmin ]
+        description: Adds user to the organization. Requires admin in organization or <b>user.siteAdmin</b>.
+        securedBy: [ basic ]
         responses:
           200:
           403:
           404:
         
       delete:
-        description: Delete user from the organization.
-        securedBy: [ basic, orgOrSiteAdmin ]
+        description: Delete user from the organization. Requires admin in organization or <b>user.siteAdmin</b>.
+        securedBy: [ basic ]
         responses:
           204:
+          403:
           404:
           
     /admins/{username}:
       put:
-        description: Make user admin for the organization.
-        securedBy: [ basic, orgOrSiteAdmin ]
+        description: Make user admin for the organization. Requires admin in organization or <b>user.siteAdmin</b>.
+        securedBy: [ basic ]
         responses:
           200:
+          403:
+          404:
         
       delete:
-        description: Remove user from admins of the organization.
-        securedBy: [ basic, orgOrSiteAdmin ]
+        description: Remove user from admins of the organization. Requires admin in organization or <b>user.siteAdmin</b>.
+        securedBy: [ basic ]
         responses:
           204:
+          403:
+          404:
 
 
 /projects:
   type:
     collection:
       exampleCollection: !include webgme-api-projects.json
-      exampleItem: !include webgme-api-project-new.json
+      desc: Only lists the projects where the user has at least <b>read</b> access.
   /{ownerId}/{projectName}:
     uriParameters:
       ownerId:
@@ -203,19 +228,76 @@ resourceTypes:
     type:
       collection-item:
         exampleItem: !include webgme-api-project-retrieve.json
-    
+        putBody: !include webgme-api-project-new.json
+        patchBody: !include webgme-api-project-patch.json
+        getDesc: Requires <b>read</b> access for project.
+        putDesc: Requires <b>user.canCreate</b>.
+        patchDesc: Requires <b>write</b> access for project.
+        deleteDesc: Requires <b>delete</b> access for project.
+    /authorize/{userOrOrgId}:
+      uriParameters:
+        userOrOrgId:
+          example: demoUser
+      delete:
+        description: Remove user's or organization's access rights to the project. Requires at least one of the following from initiator;
+         is owner of the project, is admin in the organization that owns the project, or is siteAdmin.
+        responses:
+          204:
+          403:
+          404:
+      /{accessLevel}:
+        uriParameters:
+          accessLevel:
+            description: read, write or delete
+            example: read
+        put:
+          description: Grants user or organization access to the project. Requires at least one of the following from initiator;
+           is owner of the project, is admin in the organization that owns the project, or is siteAdmin.
+          responses:
+            204:
+            403:
+            404:
     /commits:
       get:
-    
+        description: Retrives an array of latested commits made to the project. The body parameter "number" set the maximum number of commits retrieved (default is 100). Requires <b>read</b> access for project.
+        body:
+          application/json:
+            example: "{
+              \"number\": 2
+            }"
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include webgme-api-commits-retrieve.json
+          403:
+      /{commitId}:
+        uriParameters:
+          commitId:
+            description: Commit hash, with or without URL-encoded '#'.
+            example: b83ee8d50034fc96f006176bba516e68ce50838a
+        get:
+          description: Retrieves the commit object associated with the commitId. Requires <b>read</b> access for project.
+          responses:
+            200:
+              body:
+                application/json:
+                  example: !include webgme-api-commit-retrieve.json
+            403:
+        /tree/{nodePath}:
+          uriParameters:
+            nodePath:
+              example: 1563412505/5585498754
+          type:
+            project-tree:
+
     /compare/{branchOrCommitA}...{branchOrCommitB}:
       get:
-      
-      
     /branches:
       type:
         collection:
           exampleCollection: !include webgme-api-branches.json
-          exampleItem: !include webgme-api-branch-new.json
+          desc: Requires <b>read</b> access for project.
         
       /{branchId}:
         uriParameters:
@@ -224,7 +306,60 @@ resourceTypes:
         type:
           collection-item:
             exampleItem: !include webgme-api-branch-retrieve.json
-        
+            putBody: "{
+              \"hash\": \"#f2a624d9cfbf883c927b04dd45800ba55537dff5\"
+            }"
+            patchBody: "{
+              \"oldHash\": \"#f2a624d9cfbf883c927b04dd45800ba55537dff5\",
+              \"newHash\": \"#4ac76d63da6f50cc5baaa5bfb42c86138edc9396\"
+            }"
+            getDesc: Requires <b>read</b> access for project.
+            putDesc: Requires <b>write</b> access for project.
+            patchDesc: Requires <b>write</b> access for project.
+            deleteDesc: Requires <b>write</b> access for project.
+        /commits:
+          get:
+            description: Retrives an array of the commit history for the branch. The body parameter "number" set the maximum number of commits retrieved default is 100. Requires <b>read</b> access for project.
+            body:
+              application/json:
+                example: "{
+                  \"number\": 2
+                }"
+            responses:
+              200:
+                body:
+                  application/json:
+                    example: !include webgme-api-commits-retrieve.json
+              403:
+          
+        /tree/{nodePath}:
+          uriParameters:
+            nodePath:
+              example: 1563412505/5585498754
+          type:
+            project-tree:
+    /tags:
+      type:
+        collection:
+          exampleCollection: !include webgme-api-branches.json
+          desc: Requires <b>read</b> access for project.
+      /{tagId}:
+        uriParameters:
+          tagId:
+            example: myTag
+        type:
+          collection-item:
+            exampleItem: !include webgme-api-commit-retrieve.json
+            putBody: "{
+              \"hash\": \"#f2a624d9cfbf883c927b04dd45800ba55537dff5\"
+            }"
+            patchBody: "{
+              \"hash\": \"#f2a624d9cfbf883c927b04dd45800ba55537dff5\"
+            }"
+            getDesc: Requires <b>read</b> access for project.
+            putDesc: Requires <b>write</b> access for project.
+            patchDesc: Requires <b>delete</b> access for project.
+            deleteDesc: Requires <b>delete</b> access for project.
 
 /decorators:
   get:

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -227,7 +227,7 @@ function GMEAuth(session, gmeConfig) {
         collection.findOne(query)
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('no such user [' + userId + ']');
+                    return Q.reject(new Error('no such user [' + userId + ']'));
                 }
                 if (type === 'gmail') {
                     req.session.udmId = userData._id;
@@ -242,11 +242,11 @@ function GMEAuth(session, gmeConfig) {
                                     req.session.authenticated = true;
                                     next();
                                 } else {
-                                    return Q.reject('incorrect password');
+                                    return Q.reject(new Error('incorrect password'));
                                 }
                             });
                     }
-                    return Q.reject('no password given');
+                    return Q.reject(new Error('no password given'));
                 }
             })
             .catch(function (err) {
@@ -320,7 +320,7 @@ function GMEAuth(session, gmeConfig) {
             return collection.update({_id: userOrOrgId}, update)
                 .spread(function (numUpdated) {
                     if (numUpdated !== 1) {
-                        return Q.reject('No such user or org [' + userOrOrgId + ']');
+                        return Q.reject(new Error('No such user or org [' + userOrOrgId + ']'));
                     }
                 })
                 .nodeify(callback);
@@ -334,7 +334,7 @@ function GMEAuth(session, gmeConfig) {
                 })
                 .nodeify(callback);
         } else {
-            return Q.reject('unknown type ' + type)
+            return Q.reject(new Error('unknown type ' + type))
                 .nodeify(callback);
         }
     }
@@ -343,7 +343,7 @@ function GMEAuth(session, gmeConfig) {
         return Q.ninvoke(_session, 'getSessionUser', sessionId)
             .then(function (userId) {
                 if (!userId) {
-                    throw 'invalid session';
+                    throw new Error('invalid session');
                 }
                 return authorizeByUserId(userId, projectName, type, {read: true, write: true, delete: true});
             })
@@ -368,7 +368,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     /**
-     *
+     * This includes authorization from organizations userId is part of.
      * @param userId {string}
      * @param projectId {string}
      * @param callback
@@ -379,7 +379,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userId}, _getProjection('orgs', 'projects.' + projectId))
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('No such user [' + userId + ']');
+                    return Q.reject(new Error('No such user [' + userId + ']'));
                 }
                 userData.orgs = userData.orgs || [];
                 return [userData.projects[projectId] || {},
@@ -414,7 +414,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userId}, _getProjection('orgs', 'projects'))
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('No such user [' + userId + ']');
+                    return Q.reject(new Error('No such user [' + userId + ']'));
                 }
                 userData.orgs = userData.orgs || [];
                 res = userData.projects;
@@ -542,7 +542,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('no such user [' + userId + ']');
+                    return Q.reject(new Error('no such user [' + userId + ']'));
                 }
                 return userData.projects;
             })
@@ -570,7 +570,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('no such user [' + userId + ']');
+                    return Q.reject(new Error('no such user [' + userId + ']'));
                 }
                 delete userData.passwordHash;
                 return userData;
@@ -600,7 +600,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject('no such user [' + userId + ']');
+                    return Q.reject(new Error('no such user [' + userId + ']'));
                 }
 
                 userData.email = data.email || userData.email;
@@ -660,7 +660,7 @@ function GMEAuth(session, gmeConfig) {
         return Q.ninvoke(_session, 'getSessionUser', sessionId)
             .then(function (userId) {
                 if (!userId) {
-                    throw 'invalid session';
+                    throw new Error('invalid session');
                 }
                 return getAllUserAuthInfo(userId);
             })
@@ -872,7 +872,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
                 return [org, collection.find({orgs: orgId, type: {$ne: CONSTANTS.ORGANIZATION}}, {_id: 1})];
             })
@@ -916,7 +916,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.remove({_id: orgId, type: CONSTANTS.ORGANIZATION})
             .then(function (count) {
                 if (count === 0) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
                 return collection.update({orgs: orgId}, {$pull: {orgs: orgId}}, {multi: true});
             })
@@ -934,14 +934,14 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
                 return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$addToSet: {orgs: orgId}})
                     .spread(function (count) {
                         if (count === 0) {
-                            return Q.reject('No such user [' + userId + ']');
+                            return Q.reject(new Error('No such user [' + userId + ']'));
                         }
                     });
             })
@@ -959,7 +959,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
@@ -986,7 +986,7 @@ function GMEAuth(session, gmeConfig) {
             .then(function (user) {
                 if (makeAdmin) {
                     if (!user) {
-                        return Q.reject('No such user [' + userId + ']');
+                        return Q.reject(new Error('No such user [' + userId + ']'));
                     }
                     return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION}, {$addToSet: {admins: userId}});
                 } else {
@@ -1002,7 +1002,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION}, {admins: 1})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
                 return org.admins;
             })
@@ -1036,7 +1036,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION}, projection)
             .then(function (orgData) {
                 if (!orgData) {
-                    return Q.reject('No such organization [' + orgId + ']');
+                    return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
                 return orgData.projects[projectId] || {};
             })
@@ -1053,7 +1053,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: userOrOrgId})
             .then(function (userOrOrgData) {
                 if (!userOrOrgData) {
-                    return Q.reject('no such user or org [' + userOrOrgId + ']');
+                    return Q.reject(new Error('no such user or org [' + userOrOrgId + ']'));
                 }
                 if (!userOrOrgData.type || userOrOrgData.type === CONSTANTS.USER) {
                     delete userOrOrgData.passwordHash;
@@ -1103,6 +1103,8 @@ function GMEAuth(session, gmeConfig) {
         listOrganizations: listOrganizations,
 
         getUserOrOrg: getUserOrOrg,
+
+        authorizeByUserOrOrgId: authorizeByUserOrOrgId,
 
         removeOrganizationByOrgId: removeOrganizationByOrgId,
         addUserToOrganization: addUserToOrganization,

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -277,7 +277,7 @@ SafeStorage.prototype.createProject = function (data, callback) {
             })
             .then(function (projectId) {
                 data.projectId = projectId;
-                return self.gmeAuth.authorizeByUserId(data.username, projectId, 'create', {
+                return self.gmeAuth.authorizeByUserId(data.ownerId, projectId, 'create', {
                     read: true,
                     write: true,
                     delete: true
@@ -1034,7 +1034,11 @@ SafeStorage.prototype.createTag = function (data, callback) {
         check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
 
         check(typeof data.tagName === 'string', deferred, 'data.tagName is not a string.') ||
-        check(REGEXP.TAG.test(data.tagName), deferred, 'data.tagName failed regexp: ' + data.tagName);
+        check(REGEXP.TAG.test(data.tagName), deferred, 'data.tagName failed regexp: ' + data.tagName) ||
+
+        check(typeof data.commitHash === 'string', deferred, 'data.hash is not a string.') ||
+        check(data.commitHash === '' || REGEXP.HASH.test(data.commitHash), deferred,
+            'data.hash is not a valid hash: ' + data.commitHash);
 
 
     if (data.hasOwnProperty('username')) {

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -277,6 +277,7 @@ function importProject(storage, parameters, callback) {
                     return;
                 }
                 persisted = core.persist(rootNode);
+                project.setUser(data.username);
 
                 project.makeCommit(branchName, [''], persisted.rootHash, persisted.objects, 'project imported')
                     .then(function (result) {

--- a/test/bin/usermanager.spec.js
+++ b/test/bin/usermanager.spec.js
@@ -403,7 +403,7 @@ describe('User manager command line interface (CLI)', function () {
                 .then(function () {
                     auth.getUser('user_to_delete', function (err, data) {
                         restoreLogAndExit();
-                        if (err && err.indexOf('no such user') > -1 && !data) {
+                        if (err && err.message.indexOf('no such user') > -1 && !data) {
                             done();
                             return;
                         }

--- a/test/server/api/index.spec.js
+++ b/test/server/api/index.spec.js
@@ -1792,6 +1792,22 @@ describe('REST API', function () {
                     });
             });
 
+            it('should list commits for project /projects/:ownerId/:projectId/commits?n=1', function (done) {
+                agent.get(server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/commits?n=1')
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(res.body.length).to.equal(1);
+                        expect(res.body[0]).to.have.property('message');
+                        expect(res.body[0]).to.have.property('parents');
+                        expect(res.body[0]).to.have.property('root');
+                        expect(res.body[0]).to.have.property('time');
+                        expect(res.body[0]).to.have.property('type');
+                        expect(res.body[0]).to.have.property('updater');
+                        expect(res.body[0]).to.have.property('_id');
+                        done();
+                    });
+            });
+
             it('should return commit for project /projects/:ownerId/:projectId/commits/:commitHash', function (done) {
                 var url = server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/commits/' +
                     importResult.commitHash.substring(1);
@@ -1951,6 +1967,22 @@ describe('REST API', function () {
                 function (done) {
                     var url = server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/branches/' +
                         'master/commits';
+                    agent.get(url)
+                        .end(function (err, res) {
+                            expect(res.status).equal(200, err);
+                            expect(res.body instanceof Array).to.equal(true);
+                            expect(res.body.length).to.equal(1);
+                            expect(res.body[0]._id).to.equal(importResult.commitHash);
+
+                            done();
+                        });
+                }
+            );
+
+            it('should get history for branch /projects/:ownerId/branches/:branchId/commits?n=1',
+                function (done) {
+                    var url = server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/branches/' +
+                        'master/commits?n=1';
                     agent.get(url)
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
@@ -2892,8 +2924,8 @@ describe('REST API', function () {
             agent = superagent.agent();
         });
 
-        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest1/read', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest1/read')
+        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest1/r', function (done) {
+            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest1/rr')
                 .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                 .end(function (err, res) {
                     expect(res.status).equal(204, err);
@@ -2909,8 +2941,8 @@ describe('REST API', function () {
                 });
         });
 
-        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest2/write', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest2/write')
+        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest2/w', function (done) {
+            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest2/w')
                 .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                 .end(function (err, res) {
                     expect(res.status).equal(204, err);
@@ -2926,8 +2958,8 @@ describe('REST API', function () {
                 });
         });
 
-        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest3/delete', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest3/delete')
+        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/userTest3/rwd', function (done) {
+            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest3/rwd')
                 .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                 .end(function (err, res) {
                     expect(res.status).equal(204, err);
@@ -2943,17 +2975,8 @@ describe('REST API', function () {
                 });
         });
 
-        it('500 as owner should not authorize /projects/user/projectOwnedByUser/authorize/userTest3/wrong', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/userTest3/wrong')
-                .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
-                .end(function (err, res) {
-                    expect(res.status).equal(500, err);
-                    done();
-                });
-        });
-
-        it('404 as owner should not authorize /projects/user/projectOwnedByUser/authorize/notExists/read', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/notExists/read')
+        it('404 as owner should not authorize /projects/user/projectOwnedByUser/authorize/notExists/r', function (done) {
+            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/notExists/r')
                 .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                 .end(function (err, res) {
                     expect(res.status).equal(404, err);
@@ -2961,8 +2984,8 @@ describe('REST API', function () {
                 });
         });
 
-        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/orgTest1/read', function (done) {
-            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/orgTest1/read')
+        it('204 as owner should authorize /projects/user/projectOwnedByUser/authorize/orgTest1/r', function (done) {
+            agent.put(server.getUrl() + '/api/v1/projects/user/projectOwnedByUser/authorize/orgTest1/r')
                 .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                 .end(function (err, res) {
                     expect(res.status).equal(204, err);
@@ -2978,9 +3001,9 @@ describe('REST API', function () {
                 });
         });
 
-        it('204 as admin in owner org should authorize /projects/org/projectOwnedByOrg/authorize/userTest4/read',
+        it('204 as admin in owner org should authorize /projects/org/projectOwnedByOrg/authorize/userTest4/r',
             function (done) {
-                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/userTest4/read')
+                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/userTest4/r')
                     .set('Authorization', 'Basic ' + new Buffer('userOrgAdmin:p').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(204, err);
@@ -2997,9 +3020,9 @@ describe('REST API', function () {
             }
         );
 
-        it('204 as siteAdmin should authorize /projects/org/projectOwnedByOrg/authorize/userTest5/read',
+        it('204 as siteAdmin should authorize /projects/org/projectOwnedByOrg/authorize/userTest5/r',
             function (done) {
-                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/userTest5/read')
+                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/userTest5/r')
                     .set('Authorization', 'Basic ' + new Buffer('userSiteAdmin:p').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(204, err);
@@ -3016,9 +3039,9 @@ describe('REST API', function () {
             }
         );
 
-        it('403 should not authorize /projects/' + guestAccount + '/projectOwnedByOtherUser/authorize/userTest6/read',
+        it('403 should not authorize /projects/' + guestAccount + '/projectOwnedByOtherUser/authorize/userTest6/r',
             function (done) {
-                agent.put(server.getUrl() + '/api/v1/projects/' + guestAccount + '/projectOwnedByOtherUser/authorize/userTest6/read')
+                agent.put(server.getUrl() + '/api/v1/projects/' + guestAccount + '/projectOwnedByOtherUser/authorize/userTest6/r')
                     .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(403, err);
@@ -3113,9 +3136,9 @@ describe('REST API', function () {
             }
         );
 
-        it('404 as org admin if project not exist /projects/org/unknown/authorize/userWithRights3/read',
+        it('404 as org admin if project not exist /projects/org/unknown/authorize/userWithRights3/r',
             function (done) {
-                agent.put(server.getUrl() + '/api/v1/projects/org/unknown/authorize/userWithRights3/read')
+                agent.put(server.getUrl() + '/api/v1/projects/org/unknown/authorize/userWithRights3/r')
                     .set('Authorization', 'Basic ' + new Buffer('userOrgAdmin:p').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(404, err);
@@ -3135,9 +3158,9 @@ describe('REST API', function () {
             }
         );
 
-        it('403 as not org admin authorize /projects/org/projectOwnedByOrg/authorize/orgTest2/read',
+        it('403 as not org admin authorize /projects/org/projectOwnedByOrg/authorize/orgTest2/r',
             function (done) {
-                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/orgTest2/read')
+                agent.put(server.getUrl() + '/api/v1/projects/org/projectOwnedByOrg/authorize/orgTest2/r')
                     .set('Authorization', 'Basic ' + new Buffer('user:p').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(403, err);

--- a/test/server/api/index.spec.js
+++ b/test/server/api/index.spec.js
@@ -2949,7 +2949,7 @@ describe('REST API', function () {
                     gmeAuth.getProjectAuthorizationByUserId('userTest2', pr2Id(projectOwnedByUser, 'user'))
                         .then(function (auth) {
                             expect(auth).to.deep.equal({
-                                read: true,
+                                read: false,
                                 write: true,
                                 delete: false
                             });

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -92,7 +92,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('no such user') > -1) {
+                if (err.message.indexOf('no such user') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error ' + err);
@@ -106,7 +106,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('No such user') > -1) {
+                if (err.message.indexOf('No such user') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error ' + err);
@@ -128,7 +128,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('no such user') > -1) {
+                if (err.message.indexOf('no such user') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error ' + err);
@@ -432,7 +432,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('No such organization') > -1) {
+                if (err.message.indexOf('No such organization') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error: ' + err);
@@ -446,7 +446,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('No such organization') > -1) {
+                if (err.message.indexOf('No such organization') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error: ' + err);
@@ -460,7 +460,7 @@ describe('GME authentication', function () {
 
     it('should fail to authorize organization with invalid type', function (done) {
         auth.authorizeOrganization('dummyOrgId', 'dummyProjectName', 'unknown', {}, function (err) {
-            if (err.indexOf('unknown type') > -1) {
+            if (err.message.indexOf('unknown type') > -1) {
                 done();
                 return;
             }
@@ -470,7 +470,7 @@ describe('GME authentication', function () {
 
     it('should fail to authorize by user id with invalid type', function (done) {
         auth.authorizeByUserId('user', 'dummyProjectName', 'unknown', {}, function (err) {
-            if (err.indexOf('unknown type') > -1) {
+            if (err.message.indexOf('unknown type') > -1) {
                 done();
                 return;
             }
@@ -484,7 +484,7 @@ describe('GME authentication', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                if (err.indexOf('No such user or org') > -1) {
+                if (err.message.indexOf('No such user or org') > -1) {
                     return;
                 }
                 throw new Error('Unexpected error: ' + err);
@@ -497,7 +497,7 @@ describe('GME authentication', function () {
             .then(function () {
                 done(new Error('Should have failed'));
             }, function (err) {
-                if (err.indexOf('No such organization') > -1) {
+                if (err.message.indexOf('No such organization') > -1) {
                     done();
                     return;
                 }
@@ -723,10 +723,10 @@ describe('GME authentication', function () {
         var orgId = 'doesNotExist';
         return auth.getAdminsInOrganization(orgId)
             .then(function () {
-                throw 'getAdminsInOrganization should fail with non-existing organization';
+                throw new Error('getAdminsInOrganization should fail with non-existing organization');
             })
             .catch(function (error) {
-                expect(error).to.include('No such organization [' + orgId);
+                expect(error.message).to.include('No such organization [' + orgId);
                 done();
             })
             .done();
@@ -1011,10 +1011,10 @@ describe('GME authentication', function () {
 
         auth.getProjectAuthorizationListByUserId(userId).
             then(function () {
-                throw 'Should have failed';
+                throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err).to.include('No such user [' + userId);
+                expect(err.message).to.include('No such user [' + userId);
                 done();
             })
             .done();


### PR DESCRIPTION
- Adds REST calls for authorizing users/orgs to project.
- Updates the RAML docs.
- Added some new REST methods for consistency.
- Fixes to some methods as tests were added.
- In project creation dialog user can select organization as owner (if admin in it).
- GmeAuth returns Errors instead of strings consistently.
