### PR TITLE
Fix DocumentDecorator DOM leakage and issues with cache.

### DIFF
--- a/src/client/decorators/DocumentDecorator/DiagramDesigner/DocumentDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/DocumentDecorator/DiagramDesigner/DocumentDecorator.DiagramDesignerWidget.js
@@ -38,8 +38,6 @@ define([
 
         this.name = '';
 
-        this.editorDialog = new DocumentEditorDialog();
-
         this._skinParts = {};
 
         this.$doc = this.$el.find('.doc').first();
@@ -70,8 +68,6 @@ define([
         var self = this;
         var client = this._control._client;
         var nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]);
-        // Initialize dialog with EpicEditor.
-        this._initDialog();
         this._renderName();
 
         //render text-editor based META editing UI piece
@@ -82,8 +78,9 @@ define([
         this._skinParts.$EditorBtn.on('click', function (event) {
             if (self.hostDesignerItem.canvas.getIsReadOnlyMode() !== true &&
                 nodeObj.getAttribute('documentation') !== undefined) {
-                self.editorDialog.show();
+                self._showEditorDialog();
             }
+
             event.stopPropagation();
             event.preventDefault();
         });
@@ -154,7 +151,6 @@ define([
                     self._skinParts.$EditorBtn.addClass('not-activated');
                 }
                 this.$doc.append($(marked(newDoc)));
-                this.editorDialog.updateText(newDoc);
             }
 
             if (this.name !== newName) {
@@ -286,17 +282,15 @@ define([
      * Initialize Dialog and Editor creation
      * @return {void}
      */
-    DocumentDecorator.prototype._initDialog = function () {
+    DocumentDecorator.prototype._showEditorDialog = function () {
         var self = this;
         var client = this._control._client;
         var nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]);
         var documentation = nodeObj.getAttribute('documentation') || 'Click to enter documentation.';
-        if (nodeObj.getAttribute('documentation') !== undefined) {
-            this.$doc.append($(marked(documentation)));
-        }
+        var editorDialog = new DocumentEditorDialog();
 
         // Initialize with documentation attribute and save callback function
-        this.editorDialog.initialize(documentation,
+        editorDialog.initialize(documentation,
             function (text) {
                 try {
                     client.setAttributes(self._metaInfo[CONSTANTS.GME_ID], 'documentation', text);
@@ -307,6 +301,8 @@ define([
                 }
             }
         );
+
+        editorDialog.show();
     };
 
     return DocumentDecorator;

--- a/src/client/decorators/DocumentDecorator/DiagramDesigner/DocumentEditorDialog.js
+++ b/src/client/decorators/DocumentDecorator/DiagramDesigner/DocumentEditorDialog.js
@@ -67,12 +67,13 @@ define(['js/util',
 
         // Event listener on click for SAVE button
         this._btnSave.on('click', function (event) {
-            // Close dialog and invoke callback
-            self._dialog.modal('hide');
             // Invoke callback to deal with modified text, like save it in client.
             if (saveCallback) {
-                saveCallback.call(self, self.editor.exportFile());
+                saveCallback.call(null, self.editor.exportFile());
             }
+
+            // Close dialog
+            self._dialog.modal('hide');
             event.stopPropagation();
             event.preventDefault();
         });
@@ -89,7 +90,9 @@ define(['js/util',
 
         // Listener on event when dialog is hidden
         this._dialog.on('hidden.bs.modal', function () {
-            self.text = self.editor.exportFile();
+            self._dialog.empty();
+            self._dialog.remove();
+            self.editor.remove(); // clear the localstorage of the editor
         });
     };
 


### PR DESCRIPTION
Sometimes when switching between models to edit, old text from either that node or another node is saved rather than the text in the editor. This is fixed now.


This should be cherry picked to the master too