### PR TITLE
Custom test config must start with 'test'

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,6 +9,7 @@ var env = process.env.NODE_ENV || 'default',
     config = require(configFilename),
     validateConfig = require(__dirname + '/validator');
 
+console.info('Using configuration from ' + configFilename);
 validateConfig(configFilename);
 
 module.exports = config;

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -3,13 +3,16 @@
 
 /**
  * @author kecso / https://github.com/kecso
+ * @author lattmann / https://github.com/lattmann
+ * @author pmeijer / https://github.com/pmeijer
  */
 'use strict';
 
 global.TESTING = true;
 global.WebGMEGlobal = {};
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.NODE_ENV = (process.env.NODE_ENV && process.env.NODE_ENV.indexOf('test') === 0) ?
+    process.env.NODE_ENV : 'test';
 
 //adding a local storage class to the global Namespace
 var WebGME = require('../webgme'),


### PR DESCRIPTION
This in order to reduce the risk of clearing a database when running tests if using the same command window for running the app with a custom configuration.
