### PR TITLE
Optimized import project functionality.

### DIFF
--- a/src/common/core/users/serialization.js
+++ b/src/common/core/users/serialization.js
@@ -35,7 +35,7 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
             ongoingTaskCounter = 0,
             timerId,
             root = core.getRoot(libraryRoot);
-            
+
         function getAttributes(node) {
             var names = core.getOwnAttributeNames(node).sort(),
                 i,
@@ -1048,10 +1048,14 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
                 };
 
             //pointers
-            keys = core.getOwnPointerNames(node);
-            for (i = 0; i < keys.length; i++) {
-                core.deletePointer(node, keys[i]);
+            if (toUpdateGuids.indexOf(guid) !== -1) {
+                //delete only if the node is to update
+                keys = core.getOwnPointerNames(node);
+                for (i = 0; i < keys.length; i++) {
+                    core.deletePointer(node, keys[i]);
+                }
             }
+
             keys = Object.keys(jsonNode.pointers);
             for (i = 0; i < keys.length; i++) {
                 target = jsonNode.pointers[keys[i]];
@@ -1068,10 +1072,14 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
             }
 
             //sets
-            keys = core.getSetNames(node);
-            for (i = 0; i < keys.length; i++) {
-                core.deleteSet(node, keys[i]);
+            if (toUpdateGuids.indexOf(guid) !== -1) {
+                //delete only if the node is to update
+                keys = core.getSetNames(node);
+                for (i = 0; i < keys.length; i++) {
+                    core.deleteSet(node, keys[i]);
+                }
             }
+
             keys = Object.keys(jsonNode.sets);
             for (i = 0; i < keys.length; i++) {
                 //for every set we create it, go through its members...
@@ -1170,7 +1178,10 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
         }
 
         function updateMeta(guid) {
-            core.clearMetaRules(nodes[guid]);
+            if (toUpdateGuids.indexOf(guid) !== -1) {
+                //clear only if the node is to update
+                core.clearMetaRules(nodes[guid]);
+            }
 
             updateAttributeMeta(guid);
             updateChildrenMeta(guid);

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -4313,12 +4313,14 @@ describe('GME client', function () {
                         superagent.get(url, function (err, result) {
                             expect(err).to.equal(null);
 
-                            expect(result.body).to.deep.equal(refNodeProj);
                             client.deleteProject(projectId, function (err /*, didExist*/) {
                                 expect(err).to.equal(null, 'deleteProject returned error');
 
                                 done();
                             });
+
+                            expect(result.body).to.deep.equal(refNodeProj);
+
                         });
                     }
                 );


### PR DESCRIPTION
As the import use the same underlying function as the library update, it always cleared out the sets and meta rules and pointers before inserting the new ones. Due to the nature of the deletion process it takes some time even if there is nothing to remove, so to improve the overall speed, we check if the given node is a new one, and in that case we skip the remove.
The bigger a project is the bigger the positive impact of the change (example project was of size 8.7Mb, the import time decreased from 45s to 10s).
It also improves library updates where the number of new items is big.