### PR TITLE
Fix test cases with non-deterministic results.

### DIFF
--- a/test/common/core/corerel.spec.js
+++ b/test/common/core/corerel.spec.js
@@ -112,8 +112,6 @@ describe('corerel', function () {
             core.getRegistry(copies[0], 'position').should.be.eql(core.getRegistry(copyOne, 'position'));
             core.getPointerPath(copies[1], 'parent').should.be.eql(core.getPointerPath(copies[0], 'parent'));
             core.getPointerPath(grandChild, 'parent').should.be.eql(core.getPointerPath(grandCopy, 'parent'));
-            core.getRelid(grandChild).should.not.be.eql(core.getRelid(copyOne));
-            core.getRelid(grandChild).should.not.be.eql(core.getRelid(grandCopy));
             done();
         }, core.loadChildren(root));
     });

--- a/test/common/util/random.spec.js
+++ b/test/common/util/random.spec.js
@@ -85,11 +85,7 @@ describe('random generation', function () {
         }
 
         for (i = 0; i < 100; i += 1) {
-            relid = random.generateRelid(data);
-            expect(relids.indexOf(relid)).to.equal(-1);
-            expect(relid).to.have.length(2);
-            relids.push(relid);
-            data[relid] = {};
+            expect(random.generateRelid(data)).to.have.length(2);
         }
     });
 


### PR DESCRIPTION
- copy of a node do not preserve the relid
- random relid generation should not be tested (only to prove that it always generates a relid)