### PR TITLE
Use push and new array in coretree.getKeys.

### DIFF
--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -569,14 +569,15 @@ define([
             }
 
             var keys = Object.keys(node.data),
+                result = [],
                 i = keys.length;
 
             while (--i >= 0) {
-                if (!predicate(keys[i])) {
-                    keys.splice(i, 1);
+                if (predicate(keys[i])) {
+                    result.push(keys[i]);
                 }
             }
-            return keys;
+            return result;
         };
 
         var getRawKeys = function (object, predicate) {


### PR DESCRIPTION

Pictures:

1) Ratio between removing and keeping key (doing random work in model).

Profiles when making a change in the model (with same tree expanded) and same change.
2) The old version using splice.
3) The suggested version using push into a new array.

![splice-vs-push](https://cloud.githubusercontent.com/assets/6518904/12655620/6632dafc-c5bf-11e5-95a3-b4bf2527cd0a.PNG)

![getkeysspliceprofile](https://cloud.githubusercontent.com/assets/6518904/12655659/a37a1ba0-c5bf-11e5-9ab9-f5ca95e9695d.PNG)

![getkeyspushprofile](https://cloud.githubusercontent.com/assets/6518904/12655707/d6d86d76-c5bf-11e5-9cc4-c97a8ca986ba.PNG)
