### PR TITLE
Disable line-style controls in Meta Editor.

### DIFF
--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -611,11 +611,13 @@ define(['js/logger',
             }
         }
 
-        this.diagramDesigner.toolbarItems.ddbtnConnectionArrowStart.enabled(onlyConnectionTypeSelected);
-        this.diagramDesigner.toolbarItems.ddbtnConnectionPattern.enabled(onlyConnectionTypeSelected);
-        this.diagramDesigner.toolbarItems.ddbtnConnectionArrowEnd.enabled(onlyConnectionTypeSelected);
-        this.diagramDesigner.toolbarItems.ddbtnConnectionLineType.enabled(onlyConnectionTypeSelected);
-        this.diagramDesigner.toolbarItems.ddbtnConnectionLineWidth.enabled(onlyConnectionTypeSelected);
+        // lineStyleControls are disabled in meta-editor.
+
+        //this.diagramDesigner.toolbarItems.ddbtnConnectionArrowStart.enabled(onlyConnectionTypeSelected);
+        //this.diagramDesigner.toolbarItems.ddbtnConnectionPattern.enabled(onlyConnectionTypeSelected);
+        //this.diagramDesigner.toolbarItems.ddbtnConnectionArrowEnd.enabled(onlyConnectionTypeSelected);
+        //this.diagramDesigner.toolbarItems.ddbtnConnectionLineType.enabled(onlyConnectionTypeSelected);
+        //this.diagramDesigner.toolbarItems.ddbtnConnectionLineWidth.enabled(onlyConnectionTypeSelected);
 
         WebGMEGlobal.State.registerActiveSelection(gmeIDs);
     };

--- a/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
@@ -46,7 +46,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
             this.$panelHeaderTitle.remove();
         }
 
-        this.widget = new MetaEditorWidget(this.$el, {'toolBar': this.toolBar});
+        this.widget = new MetaEditorWidget(this.$el, {toolBar: this.toolBar});
 
         this.widget.setTitle = function (/* title */) {
             //self.setTitle(title);

--- a/src/client/js/Widgets/MetaEditor/MetaEditorWidget.js
+++ b/src/client/js/Widgets/MetaEditor/MetaEditorWidget.js
@@ -32,7 +32,7 @@ define([
         params.loggerName = 'gme:Widgets:MetaEditor:MetaEditorWidget';
 
         //disable line style parameter controls in toolbar
-        params.lineStyleControls = true;
+        params.lineStyleControls = false;
 
         params.tabsEnabled = true;
         params.addTabs = true;


### PR DESCRIPTION
There is currently no action tied to the line style tool-bar buttons in the meta editor.

Until there is a well defined request about what these buttons should edit - they should be removed.