### PR TITLE
Fixes #820 Importing an instance model duplicates the meta-sheets.

### DIFF
--- a/src/common/core/users/serialization.js
+++ b/src/common/core/users/serialization.js
@@ -1216,10 +1216,32 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
                             registry[keys[i]]);
                     }
                 },
+                getCurrentShortSheetInfo = function () {
+                    //we collect all the current sheet info, as they are more appropriate to being updated
+                    var metaNodes = core.getAllMetaNodes(root),
+                        sheets = {},
+                        i,
+                        keys = core.getSetNames(root),
+                        j,
+                        members;
+
+                    for (i = 0; i < keys.length; i += 1) {
+                        if (keys[i].indexOf('MetaAspectSet') === 0) {
+                            members = core.getMemberPaths(root, keys[i]);
+                            for (j = 0; j < members.length; j += 1) {
+                                sheets[keys[i]] = sheets[keys[i]] || {};
+                                sheets[keys[i]][core.getGuid(metaNodes[members[j]])] = {};
+                            }
+                        }
+                    }
+
+                    return sheets;
+                },
                 updateSheet = function (name) {
                     //if some element is extra in the place of import, then it stays untouched
                     var oldMemberGuids = Object.keys(oldSheets[name]),
-                        newMemberGuids = Object.keys(newSheets[name]);
+                        newMemberGuids = Object.keys(newSheets[name]),
+                        i;
 
                     for (i = 0; i < newMemberGuids.length; i += 1) {
                         if (oldMemberGuids.indexOf(newMemberGuids[i]) === -1 && nodes[newMemberGuids[i]]) {
@@ -1260,7 +1282,7 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
                     }
                 },
                 oldSheets = updatedLibraryJson.metaSheets || {},
-                newSheets = jsonExport.metaSheets || {},
+                newSheets = getCurrentShortSheetInfo(),
                 oldSheetNames = Object.keys(oldSheets),
                 newSheetNames = Object.keys(newSheets),
                 i;

--- a/test/common/core/users/serialization.spec.js
+++ b/test/common/core/users/serialization.spec.js
@@ -101,6 +101,8 @@ describe('serialization', function () {
                 //TODO check if really all member of the sheets have been inserted
                 expect(contextTo.core.getChildrenRelids(contextTo.rootNode)).to.have.length(2);
                 expect(contextTo.core.getMemberPaths(contextTo.rootNode, 'MetaAspectSet')).to.have.length.above(1);
+                expect(contextTo.core.getSetNames(contextTo.rootNode))
+                    .to.include.members(Object.keys(libraryJson.metaSheets));
                 done();
             })
             .catch(done);


### PR DESCRIPTION
- now when the import checks for changes in meta sheets it will compare all the meta sheets with the import's sheets and will update instead of adding