### PR TITLE
Add button for opening node on the canvas.

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -918,6 +918,9 @@ define([
             case 'align':
                 this.onSelectionAlignMenu(selectedIds, this.getAdjustedMousePos(event));
                 break;
+            case 'open':
+                this.onDesignerItemDoubleClick(selectedIds[0]);
+                break;
         }
     };
 
@@ -1237,6 +1240,10 @@ define([
 
     DiagramDesignerWidget.prototype.enableAlign = function (enabled) {
         this.selectionManager.enableAlign(enabled);
+    };
+
+    DiagramDesignerWidget.prototype.enableOpenButton = function (enabled) {
+        this.selectionManager.enableOpenButton(enabled);
     };
 
     /*************** SELECTION API ******************************************/

--- a/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
+++ b/src/client/js/Widgets/DiagramDesigner/SelectionManager.js
@@ -34,6 +34,7 @@ define([
         this._selectedElements = [];
         this._rotationEnabled = true;
         this._alignEnabled = true;
+        this._openEnabled = true;
 
         this.logger.debug('SelectionManager ctor finished');
     };
@@ -592,13 +593,13 @@ define([
         class: 's-btn delete',
         command: 'delete'
     });
-    DELETE_BUTTON_BASE.html('<i class="glyphicon glyphicon-remove"></i>');
+    DELETE_BUTTON_BASE.html('<i class="glyphicon glyphicon-remove" title="Delete"></i>');
 
     var CONTEXT_MENU_BUTTON_BASE = $('<div/>', {
         class: 's-btn contextmenu',
         command: 'contextmenu'
     });
-    CONTEXT_MENU_BUTTON_BASE.html('<i class="glyphicon glyphicon-list"></i>');
+    CONTEXT_MENU_BUTTON_BASE.html('<i class="glyphicon glyphicon-list" title="Action Menu"></i>');
 
     var MOVE_BUTTON_BASE = $('<div/>', {
         class: 's-btn move',
@@ -606,15 +607,22 @@ define([
     });
     MOVE_BUTTON_BASE.html('<i class="glyphicon glyphicon-move"></i>');
 
+    var OPEN_BUTTON_BASE = $('<div/>', {
+        class: 's-btn open',
+        command: 'open'
+    });
+    OPEN_BUTTON_BASE.html('<i class="glyphicon glyphicon-circle-arrow-down" title="Open"></i>');
+
     var ALIGN_BUTTON_BASE = $('<div/>', {
         class: 's-btn align',
         command: 'align'
     });
-    ALIGN_BUTTON_BASE.html('<i class="glyphicon glyphicon-th"></i>');
+    ALIGN_BUTTON_BASE.html('<i class="glyphicon glyphicon-th" title="Align Menu"></i>');
 
     SelectionManager.prototype._renderSelectionActions = function () {
         var self = this,
             deleteBtn,
+            openBtn,
             contextMenuBtn,
             alignBtn;
 
@@ -630,6 +638,11 @@ define([
                 alignBtn = ALIGN_BUTTON_BASE.clone();
                 this._diagramDesigner.skinParts.$selectionOutline.append(alignBtn);
             }
+        }
+
+        if (this._openBtnEnabled === true && this._selectedElements.length === 1) {
+            openBtn = OPEN_BUTTON_BASE.clone();
+            this._diagramDesigner.skinParts.$selectionOutline.append(openBtn);
         }
 
         //context menu
@@ -843,6 +856,12 @@ define([
     SelectionManager.prototype.enableAlign = function (enabled) {
         if (this._alignEnabled !== enabled) {
             this._alignEnabled = enabled;
+        }
+    };
+
+    SelectionManager.prototype.enableOpenButton = function (enabled) {
+        if (this._openBtnEnabled !== enabled) {
+            this._openBtnEnabled = enabled;
         }
     };
 

--- a/src/client/js/Widgets/DiagramDesigner/styles/DiagramDesignerWidget.css
+++ b/src/client/js/Widgets/DiagramDesigner/styles/DiagramDesignerWidget.css
@@ -48,8 +48,11 @@
           left: -13px; }
         .diagram-designer .items .selection-outline .s-btn.move {
           top: -13px;
-          left: 50%;
+          left: -13px;
           margin-left: -13px; }
+        .diagram-designer .items .selection-outline .s-btn.open {
+          top: -13px;
+          left: -13px; }
         .diagram-designer .items .selection-outline .s-btn:hover {
           background-color: #428bca; }
       .diagram-designer .items .selection-outline .rotation-deg {

--- a/src/client/js/Widgets/DiagramDesigner/styles/DiagramDesignerWidget.scss
+++ b/src/client/js/Widgets/DiagramDesigner/styles/DiagramDesignerWidget.scss
@@ -104,8 +104,13 @@ $tabs-container-height: 26px;
 
         &.move {
           top: -13px;
-          left: 50%;
+          left: -13px;
           margin-left: -13px;
+        }
+
+        &.open {
+          top: -13px;
+          left: -13px;
         }
 
         &:hover {

--- a/src/client/js/Widgets/ModelEditor/ModelEditorWidget.js
+++ b/src/client/js/Widgets/ModelEditor/ModelEditorWidget.js
@@ -30,6 +30,10 @@ define([
 
     _.extend(ModelEditorWidget.prototype, DiagramDesignerWidget.prototype);
 
+    ModelEditorWidget.prototype._afterManagersInitialized = function () {
+        //turn on open btn
+        this.enableOpenButton(true);
+    };
 
     ModelEditorWidget.prototype.getDragEffects = function (selectedElements, event) {
         var ctrlKey = event.ctrlKey || event.metaKey,


### PR DESCRIPTION
The button is need when trying to open a node on a mobile device (plus it gives a path for not accidentally triggering name editing.)

The button is only displayed in the ModelEditor and when there's only one node selected.