### PR TITLE
Visualizers redraw themselves at panel switch in split mode.

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -199,7 +199,12 @@ define(['js/logger',
     };
 
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._stateActiveObjectChanged = function (model, activeObjectId) {
-        this.selectedObjectChanged(activeObjectId);
+        if (this._memberListContainerID === activeObjectId) {
+            // [patrik] added this check to avoid redrawing when becoming active in split panel mode.
+            this.logger.debug('Disregarding activeObject changed when it is already the same.');
+        } else {
+            this.selectedObjectChanged(activeObjectId);
+        }
     };
 
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._stateActiveTabChanged = function (model, tabId) {

--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -231,7 +231,12 @@ define(['js/logger',
     };
 
     GraphVizControl.prototype._stateActiveObjectChanged = function (model, activeObjectId) {
-        this.selectedObjectChanged(activeObjectId);
+        if (this._currentNodeId === activeObjectId) {
+            // [patrik] added this check to avoid redrawing when becoming active in split panel mode.
+            this._logger.debug('Disregarding activeObject changed when it is already the same.');
+        } else {
+            this.selectedObjectChanged(activeObjectId);
+        }
     };
 
     GraphVizControl.prototype._attachClientEventListeners = function () {

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.js
@@ -973,7 +973,12 @@ define(['js/logger',
     };
 
     ModelEditorControl.prototype._stateActiveObjectChanged = function (model, activeObjectId) {
-        this.selectedObjectChanged(activeObjectId);
+        if (this.currentNodeInfo && this.currentNodeInfo.id === activeObjectId) {
+            // [patrik] added this check to avoid redrawing when becoming active in split panel mode.
+            this.logger.debug('Disregarding activeObject changed when it is already the same.');
+        } else {
+            this.selectedObjectChanged(activeObjectId);
+        }
     };
 
     ModelEditorControl.prototype._stateActiveSelectionChanged = function (model, activeSelection) {


### PR DESCRIPTION
This should be cherry-picked to v1.5.x