### PR TITLE
Switching panel triggers visualizer switch to the viz set on the node.

### DIFF
--- a/src/client/js/Constants.js
+++ b/src/client/js/Constants.js
@@ -83,6 +83,7 @@ define([
         STATE_ACTIVE_BRANCH_NAME: 'activeBranchName',
         STATE_ACTIVE_CROSSCUT: 'activeCrosscut',
         STATE_ACTIVE_TAB: 'activeTab',
+        STATE_SUPPRESS_VISUALIZER_FROM_NODE: 'suppressVisualizerFromNode',
 
         /* ASPECTS */
         ASPECT_ALL: 'All',

--- a/src/client/js/Panels/SplitPanel/SplitPanel.js
+++ b/src/client/js/Panels/SplitPanel/SplitPanel.js
@@ -233,6 +233,7 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
 
     SplitPanel.prototype._setActivePanel = function (p) {
         //if (this._panel1 && this._panel2) {
+        WebGMEGlobal.State.registerSuppressVisualizerFromNode(true);
         if (p === 0) {
             WebGMEGlobal.PanelManager.setActivePanel(this._panel1);
         }
@@ -240,6 +241,7 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
         if (p === 1) {
             WebGMEGlobal.PanelManager.setActivePanel(this._panel2);
         }
+        WebGMEGlobal.State.registerSuppressVisualizerFromNode(false);
         //}
     };
 

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -222,7 +222,7 @@ define(['js/logger',
         return panelListName === 'p1' ? this._ul1 : this._ul2;
     };
 
-    VisualizerPanel.prototype._updateListedVisualizers = function () {
+    VisualizerPanel.prototype._updateListedVisualizersAndSelect = function () {
         var self = this,
             ul = this._getActivePanelElem(),
             activeVisualizer;
@@ -264,7 +264,7 @@ define(['js/logger',
             }
         }
 
-        //we set the visualizer only if we were able to select some valid one
+        // Only set the visualizer only if we were able to select some valid one.
         if (activeVisualizer) {
             setTimeout(function () {
                 self._setActiveVisualizer(activeVisualizer, ul);
@@ -375,7 +375,9 @@ define(['js/logger',
     VisualizerPanel.prototype.selectedObjectChanged = function (currentNodeId) {
         this._currentNodeID = currentNodeId;
         this._updateValidVisualizers(currentNodeId);
-        this._updateListedVisualizers();
+        if (!WebGMEGlobal.State.getSuppressVisualizerFromNode()) {
+            this._updateListedVisualizersAndSelect();
+        }
     };
 
     VisualizerPanel.prototype._p2Editor = function (enabled) {

--- a/src/client/js/Utils/StateManager.js
+++ b/src/client/js/Utils/StateManager.js
@@ -83,6 +83,14 @@ define([
 
             getActiveTab: function () {
                 return this.get(CONSTANTS.STATE_ACTIVE_TAB);
+            },
+
+            registerSuppressVisualizerFromNode: function (trueOrFalse) {
+                this.set(CONSTANTS.STATE_SUPPRESS_VISUALIZER_FROM_NODE, trueOrFalse);
+            },
+
+            getSuppressVisualizerFromNode: function () {
+                return this.get(CONSTANTS.STATE_SUPPRESS_VISUALIZER_FROM_NODE);
             }
 
         }),
@@ -92,6 +100,7 @@ define([
                 logger = Logger.create('gme:Utils:StateManager', WebGMEGlobal.gmeConfig.client.log);
                 _WebGMEState = new WebGMEStateModel();
                 _WebGMEState.registerActiveAspect(CONSTANTS.ASPECT_ALL);
+                _WebGMEState.registerSuppressVisualizerFromNode(false);
                 //_WebGMEState.registerActiveTab('0');
                 _WebGMEState.on('change', function (model, options) {
                     logger.debug('', model, options);

--- a/src/client/js/WebGME.js
+++ b/src/client/js/WebGME.js
@@ -291,42 +291,41 @@ define([
                             activeNode = client.getNode(nodePath);
                             if (activeNode) {
                                 // First register the activeObject and let it pick the visualizer.
-                                WebGMEGlobal.State.registerActiveObject(nodePath);
+                                updatedState[CONSTANTS.STATE_ACTIVE_OBJECT] = nodePath;
 
-                                // In the next tick we set the other preferences.
-                                setTimeout(function () {
-                                    //WebGMEGlobal.State.registerActiveVisualizer(vizualizer);
+                                selectionIds = selectionIds || [];
+
+                                if (selectionIds.length > 0) {
+                                    updatedState[CONSTANTS.STATE_ACTIVE_SELECTION] = selectionIds;
+                                }
+
+                                tab = parseInt(tab, 10);
+                                if (tab >= 0 && vizualizer) {
                                     updatedState[CONSTANTS.STATE_ACTIVE_VISUALIZER] = vizualizer;
-                                    //updatedState[CONSTANTS.STATE_ACTIVE_OBJECT] = nodePath;
+                                    updatedState[CONSTANTS.STATE_ACTIVE_TAB] = tab;
 
-                                    selectionIds = selectionIds || [];
+                                    // Suppress the node determining the visualizer.
+                                    updatedState[CONSTANTS.STATE_SUPPRESS_VISUALIZER_FROM_NODE] = true;
 
-                                    if (selectionIds.length > 0) {
-                                        updatedState[CONSTANTS.STATE_ACTIVE_SELECTION] = selectionIds;
+                                    // We also have to set the selected aspect according to the selectedTabIndex,
+                                    //TODO this is not the best solution,
+                                    // but as the node always orders the aspects based on their names, it is fine.
+                                    if (vizualizer === 'ModelEditor') {
+                                        aspectNames = client.getMetaAspectNames(nodePath);
+                                        aspectNames.sort(function (a, b) {
+                                            var an = a.toLowerCase(),
+                                                bn = b.toLowerCase();
+
+                                            return (an < bn) ? -1 : 1;
+                                        });
+                                        aspectNames.unshift('All');
+                                        updatedState[CONSTANTS.STATE_ACTIVE_ASPECT] = aspectNames[tab] || 'All';
                                     }
+                                }
 
-                                    tab = parseInt(tab, 10);
-                                    if (tab >= 0 && vizualizer) {
-                                        updatedState[CONSTANTS.STATE_ACTIVE_TAB] = tab;
-
-                                        //we also have to set the selected aspect according to the selectedTabIndex
-                                        //TODO this is not the best solution,
-                                        // but as the node always orders the aspects based on their names, it is fine
-                                        if (vizualizer === 'ModelEditor') {
-                                            aspectNames = client.getMetaAspectNames(nodePath);
-                                            aspectNames.sort(function (a, b) {
-                                                var an = a.toLowerCase(),
-                                                    bn = b.toLowerCase();
-
-                                                return (an < bn) ? -1 : 1;
-                                            });
-                                            aspectNames.unshift('All');
-                                            updatedState[CONSTANTS.STATE_ACTIVE_ASPECT] = aspectNames[tab] || 'All';
-                                        }
-                                    }
-
-                                    WebGMEGlobal.State.set(updatedState);
-                                });
+                                WebGMEGlobal.State.set(updatedState);
+                                // After the state has been updated, make sure to allow node look-up again.
+                                WebGMEGlobal.State.registerSuppressVisualizerFromNode(false);
                                 break;
                             }
                         }


### PR DESCRIPTION
Add state to suppress viz look-up from node.

This way there no need for an extra timeout when starting the page.


Please cherry pick this to 1.5.1 too.