### PR TITLE
Remove TreeBrowserWidget edit on dbl-click and shift-click

### DIFF
--- a/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
+++ b/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
@@ -146,6 +146,11 @@ define(['js/logger',
                         data.node.setFocus(false);
                     }
                 }
+
+                if (data.targetType !== 'expander') {
+                    event.preventDefault();
+                    return;
+                }
             },
 
             collapse: function (event, data) {
@@ -181,16 +186,11 @@ define(['js/logger',
                 self._deselectSelectedNodes();
                 data.node.setSelected(true);
 
-                // Check if the node is already focused and the title is clicked --> edit title.
-                if (data.targetType === 'title' && lastDblClicked === data.node && self.enableEdit === true) {
-                    // Skip the onNodeDoubleClicked behaviour if edit is enabled.
-                } else {
-                    lastDblClicked = data.node;
-                    if ($.isFunction(self.onNodeDoubleClicked)) {
-                        self._logger.debug('default double-click handler: ' + data.node.key);
-                        self.onNodeDoubleClicked.call(self, data.node.key);
-                        event.preventDefault();
-                    }
+                lastDblClicked = data.node;
+                if ($.isFunction(self.onNodeDoubleClicked)) {
+                    self._logger.debug('default double-click handler: ' + data.node.key);
+                    self.onNodeDoubleClicked.call(self, data.node.key);
+                    event.preventDefault();
                 }
             },
 
@@ -208,7 +208,7 @@ define(['js/logger',
                 allowEmpty: true,
                 inputCss: {minWidth: '3em'},
                 triggerCancel: ['enter'],
-                triggerStart: ['dblclick'],
+                triggerStart: [],
                 beforeEdit: function (event, data) {
                     self._logger.debug('beforeEdit', event, data);
                     if (data.node.extraClasses === NODE_PROGRESS_CLASS || self.enableEdit === false) {


### PR DESCRIPTION
With this change the options to edit the name from the tree-widget are:

1) Press F2
2) Right-click and select edit in context menu.

W.r.t. Editing folder/files from a file-tree this is the same options as in windows.

This should be cherry-picked to v1.5.x too.