### PR TITLE
Support svg-icons in object (tree) browsers.

### DIFF
--- a/src/client/js/Panels/ObjectBrowser/CrosscutBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/CrosscutBrowserControl.js
@@ -8,11 +8,13 @@
 define(['js/logger',
     'js/Utils/GMEConcepts',
     'js/NodePropertyNames',
-    'js/Constants'
+    'js/Constants',
+    './ObjectBrowserControlBase',
 ], function (Logger,
              GMEConcepts,
              nodePropertyNames,
-             CONSTANTS) {
+             CONSTANTS,
+             ObjectBrowserControlBase) {
     'use strict';
 
     var NODE_PROGRESS_CLASS = 'node-progress',
@@ -25,8 +27,8 @@ define(['js/logger',
     var CrosscutBrowserControl = function (client, treeBrowser) {
         var self = this;
 
-        this._client = client;
-        this._treeBrowser = treeBrowser;
+        ObjectBrowserControlBase.call(this, client, treeBrowser);
+
         this._logger = Logger.create('gme:Panels:ObjectBrowser:CrosscutBrowserControl',
             WebGMEGlobal.gmeConfig.client.log);
 
@@ -34,6 +36,10 @@ define(['js/logger',
             self._initialize();
         }, 250);
     };
+
+    // Prototypical inheritance
+    CrosscutBrowserControl.prototype = Object.create(ObjectBrowserControlBase.prototype);
+    CrosscutBrowserControl.prototype.constructor = CrosscutBrowserControl;
 
     CrosscutBrowserControl.prototype.destroy = function () {
     };
@@ -187,11 +193,13 @@ define(['js/logger',
             class: GME_MODEL_CLASS
         };
 
-        //update the node's representation in the tree
-        this._treeBrowser.updateNode(this._treeNodes[nodeId], nodeDescriptor);
-
         if (this._treeNodes[nodeId].isExpanded()) {
+            nodeDescriptor.icon = this.getIcon(nodeId, true);
+            this._treeBrowser.updateNode(this._treeNodes[nodeId], nodeDescriptor);
             this._updateExpandedTreeNode(nodeId);
+        } else {
+            nodeDescriptor.icon = this.getIcon(nodeId);
+            this._treeBrowser.updateNode(this._treeNodes[nodeId], nodeDescriptor);
         }
     };
 
@@ -298,7 +306,7 @@ define(['js/logger',
             _.each(GMEConcepts.getCrosscuts(nodeId), function (crosscut) {
                 self._createXCutTreeNode(nodeId, crosscut, true);
             });
-
+            this._treeBrowser.updateNode(this._treeNodes[nodeId], {icon: this.getIcon(nodeObj, true)});
             //this._treeBrowser.enableUpdate(true);
         }
 
@@ -381,6 +389,7 @@ define(['js/logger',
         deleteNodeAndChildrenFromLocalHash(nodeId, false);
         this._nodes[nodeId].crosscuts = [];
         this._nodes[nodeId].children = [];
+        this._treeBrowser.updateNode(this._treeNodes[nodeId], {icon: this.getIcon(nodeId)});
 
         //if there is anything to remove from the territory, do it
         if (removeFromTerritory.length > 0) {

--- a/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
+++ b/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
@@ -1,4 +1,4 @@
-/*globals define*/
+/*globals define, WebGMEGlobal*/
 /*jshint browser: true*/
 
 /**
@@ -11,6 +11,8 @@ define(['js/RegistryKeys'], function (REGISTRY_KEYS) {
     function ObjectBrowserControlBase(client, treeBrowser) {
         this._client = client;
         this._treeBrowser = treeBrowser;
+
+        this._treeBrowser.onMakeNodeSelected = this._makeNodeSelected;
     }
 
     ObjectBrowserControlBase.prototype.getIcon = function (nodeOrId, expanded) {
@@ -34,6 +36,10 @@ define(['js/RegistryKeys'], function (REGISTRY_KEYS) {
         }
 
         return iconName ?  '/assets/DecoratorSVG/' + iconName : null;
+    };
+
+    ObjectBrowserControlBase.prototype._makeNodeSelected = function (nodeId) {
+        WebGMEGlobal.State.registerActiveSelection([nodeId]);
     };
 
 

--- a/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
+++ b/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
@@ -1,0 +1,41 @@
+/*globals define*/
+/*jshint browser: true*/
+
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+define(['js/RegistryKeys'], function (REGISTRY_KEYS) {
+    'use strict';
+
+    function ObjectBrowserControlBase(client, treeBrowser) {
+        this._client = client;
+        this._treeBrowser = treeBrowser;
+    }
+
+    ObjectBrowserControlBase.prototype.getIcon = function (nodeOrId, expanded) {
+        var node,
+            iconName;
+
+        if (typeof nodeOrId === 'string') {
+            node = this._client.getNode(nodeOrId);
+        } else {
+            node = nodeOrId;
+        }
+
+        if (node) {
+            if (expanded) {
+                iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON) ||
+                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON);
+            } else {
+                iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON) ||
+                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON);
+            }
+        }
+
+        return iconName ?  '/assets/DecoratorSVG/' + iconName : null;
+    };
+
+
+    return ObjectBrowserControlBase;
+});

--- a/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
@@ -11,13 +11,15 @@ define(['js/logger',
     'js/Utils/ImportManager',
     'js/Constants',
     'js/RegistryKeys',
+    './ObjectBrowserControlBase',
     'css!./styles/TreeBrowserControl.css'
 ], function (Logger,
              nodePropertyNames,
              ExportManager,
              ImportManager,
              CONSTANTS,
-             REGISTRY_KEYS) {
+             REGISTRY_KEYS,
+             ObjectBrowserControlBase) {
     'use strict';
 
 
@@ -51,7 +53,7 @@ define(['js/logger',
         logger = Logger.create('gme:Panels:ObjectBrowser:TreeBrowserControl', WebGMEGlobal.gmeConfig.client.log);
         this._logger = logger;
 
-        this._client = client;
+        ObjectBrowserControlBase.call(this, client, treeBrowser);
 
         this._treeRootId = TREE_ROOT;
 
@@ -728,6 +730,10 @@ define(['js/logger',
         setTimeout(initialize, 250);
     }
 
+    // Prototypical inheritance
+    TreeBrowserControl.prototype = Object.create(ObjectBrowserControlBase.prototype);
+    TreeBrowserControl.prototype.constructor = TreeBrowserControl;
+
     TreeBrowserControl.getDefaultConfig = function () {
         return {
             treeRoot: '',
@@ -751,29 +757,6 @@ define(['js/logger',
 
     TreeBrowserControl.getComponentId = function () {
         return 'GenericUITreeBrowserControl';
-    };
-
-    TreeBrowserControl.prototype.getIcon = function (nodeOrId, expanded) {
-        var node,
-            iconName;
-
-        if (typeof nodeOrId === 'string') {
-            node = this._client.getNode(nodeOrId);
-        } else {
-            node = nodeOrId;
-        }
-
-        if (node) {
-            if (expanded) {
-                iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON) ||
-                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON);
-            } else {
-                iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON) ||
-                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON);
-            }
-        }
-
-        return iconName ?  '/assets/DecoratorSVG/' + iconName : null;
     };
 
     TreeBrowserControl.prototype._getValidChildrenTypes = function (nodeId) {

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -38,6 +38,9 @@ define(['js/logger',
         PREFERENCES_REGISTRY_KEYS = [REGISTRY_KEYS.DECORATOR,
             REGISTRY_KEYS.DISPLAY_FORMAT,
             REGISTRY_KEYS.SVG_ICON,
+            REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON,
+            REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON,
+            REGISTRY_KEYS.SVG_ICON,
             REGISTRY_KEYS.PORT_SVG_ICON],
         NON_INVALID_PTRS = [CONSTANTS.POINTER_BASE];
 
@@ -364,9 +367,22 @@ define(['js/logger',
                             //dstList[extKey].valueType = "option";
                             //FIXME: only the decorators for DiagramDesigner are listed so far
                             dst[extKey].valueItems = decoratorNames;
-                        } else if (key === REGISTRY_KEYS.SVG_ICON || key === REGISTRY_KEYS.PORT_SVG_ICON) {
+                        } else if (key === REGISTRY_KEYS.SVG_ICON || key === REGISTRY_KEYS.PORT_SVG_ICON ||
+                            key === REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON ||
+                            key === REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON) {
+
                             dst[extKey].widget = PROPERTY_GRID_WIDGETS.DIALOG_WIDGET;
                             dst[extKey].dialog = DecoratorSVGExplorerDialog;
+                            dst[extKey].value = dst[extKey].value === undefined ?
+                                '' : dst[extKey].value;
+                        }
+                    } else {
+                        if (key === REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON ||
+                            key === REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON) {
+                            dst[extKey].widget = PROPERTY_GRID_WIDGETS.DIALOG_WIDGET;
+                            dst[extKey].dialog = DecoratorSVGExplorerDialog;
+                            dst[extKey].value = dst[extKey].value === undefined ?
+                                '' : dst[extKey].value;
                         }
                     }
                 } else if (prefix === CONSTANTS.PROPERTY_GROUP_META + '.') {

--- a/src/client/js/RegistryKeys.js
+++ b/src/client/js/RegistryKeys.js
@@ -38,6 +38,8 @@ define([], function () {
         DISPLAY_FORMAT: 'DisplayFormat',
         SVG_ICON: 'SVGIcon',
         PORT_SVG_ICON: 'PortSVGIcon',
+        TREE_ITEM_COLLAPSED_ICON: 'TreeItemCollapsedIcon',
+        TREE_ITEM_EXPANDED_ICON: 'TreeItemExpandedIcon',
 
         /*
          * META_SHEETS_METADATA (title, order, setID, etc)

--- a/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
+++ b/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
@@ -406,7 +406,7 @@ define(['js/logger',
         }
 
         //set new text value (if any)
-        if (node.title !== objDescriptor.name) {
+        if (objDescriptor.hasOwnProperty('name') && node.title !== objDescriptor.name) {
 
 
             nodeName = objDescriptor.name;
@@ -474,7 +474,7 @@ define(['js/logger',
 
         //if there were any change related to this node
         if (nodeDataChanged === true) {
-            node.render();
+            node.render(true);
 
             //log
             this._logger.debug('Node updated: ' + node.key);
@@ -1094,16 +1094,18 @@ define(['js/logger',
     TreeBrowserWidget.prototype.sortChildren = function (node, rec) {
         var compareFn = function (nodeA, nodeB) {
             // Move connections to bottom
-            if (nodeA.data.isConnection === nodeB.data.isConnection) {
-                if (nodeA.title.toLowerCase() >= nodeB.title.toLowerCase()) {
-                    return 1;
-                } else {
-                    return -1;
-                }
-            } else if (nodeA.data.isConnection > nodeB.data.isConnection) {
+            if (nodeA.data.isConnection === true && !nodeB.data.isConnection) {
                 return 1;
-            } else {
+            } else if (nodeB.data.isConnection === true && !nodeA.data.isConnection) {
                 return -1;
+            } else {
+                if (nodeA.title.toLowerCase() > nodeB.title.toLowerCase()) {
+                    return 1;
+                } else if (nodeA.title.toLowerCase() < nodeB.title.toLowerCase()) {
+                    return -1;
+                } else {
+                    return 0;
+                }
             }
         };
 

--- a/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
+++ b/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
@@ -735,6 +735,13 @@ define(['js/logger',
                         self.onNodeDoubleClicked.call(self, node.key);
                     },
                     icon: false
+                },
+                selectNode: { // The "select (aka double-click)" menu item
+                    name: 'Select node',
+                    callback: function (/*key, options*/) {
+                        self.onMakeNodeSelected.call(self, node.key);
+                    },
+                    icon: false
                 }
             };
 

--- a/src/client/js/Widgets/TreeBrowser/styles/TreeBrowserWidget.css
+++ b/src/client/js/Widgets/TreeBrowser/styles/TreeBrowserWidget.css
@@ -20,7 +20,7 @@
       border: 1px solid transparent; }
   .tree-browser .fancytree-has-children span.fancytree-icon {
     background-position: 0px -16px; }
-  .tree-browser span.fancytree-icon {
+  .tree-browser .fancytree-icon {
     margin-top: 1px;
     cursor: pointer; }
   .tree-browser .fancytree-loading span.fancytree-expander {

--- a/src/client/js/Widgets/TreeBrowser/styles/TreeBrowserWidget.scss
+++ b/src/client/js/Widgets/TreeBrowser/styles/TreeBrowserWidget.scss
@@ -34,7 +34,7 @@ $node-progress-font-color: #AAAAAA;
     background-position: 0px -16px;
   }
 
-  span.fancytree-icon /* Default icon */
+  .fancytree-icon /* Default icon */
    {
     margin-top: 1px;
     cursor: pointer;


### PR DESCRIPTION
The icons are set in the PropertyEditor under Preferences.

The values are stored under the registry keys: `TreeItemCollapsedIcon` and `TreeItemExpandedIcon`.

If only one is defined, the tree will fall back onto that value.

