### PR TITLE
Fixes error on connection removal from crosscut

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -843,10 +843,9 @@ define(['js/logger',
 
                             //TODO: connection as box
                             //remove the box that represents this connections
-                            this._widget.deleteComponent(this._delayedConnectionsAsItems[
-                                this._delayedConnections[j].ID]);
+                            this._widget.deleteComponent(this._delayedConnectionsAsItems[e.eid]);
 
-                            delete this._delayedConnectionsAsItems[this._delayedConnections[j].ID];
+                            delete this._delayedConnectionsAsItems[e.eid];
                         }
                     }
                 } else if (e.etype === CONSTANTS.TERRITORY_EVENT_UPDATE &&

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -841,8 +841,8 @@ define(['js/logger',
                             this.logger.debug('Removing ' + e.eid + ' from delayed connections...');
                             this._delayedConnections.splice(j, 1);
 
-                            //TODO: connection as box
-                            //remove the box that represents this connections
+                            //TODO: find a better solution for removing connection, if
+                            // visualized as a box
                             this._widget.deleteComponent(this._delayedConnectionsAsItems[e.eid]);
 
                             delete this._delayedConnectionsAsItems[e.eid];


### PR DESCRIPTION
When a connection is displayed as a box on a crosscut it needs special handling during deletion.
That special procedure caused an exception as the id of the connection was removed earlier than the actual removal of the DOM element.