### PR TITLE
Fixes #874 Wrong export format is created if an empty instance functions as base for some nodes

### DIFF
--- a/src/common/core/users/serialization.js
+++ b/src/common/core/users/serialization.js
@@ -213,7 +213,7 @@ define(['common/util/assert', 'blob/BlobConfig'], function (ASSERT, BlobConfig) 
                 bases = {};
 
             for (i = 0; i < keys.length; i += 1) {
-                if (pathToGuid[keys[i]] === undefined) {
+                if (pathToGuid[keys[i]] === undefined && keys[i].indexOf(exportProject.root.path) !== 0) {
                     bases[ancestorPathToGuid[keys[i]]] = keys[i];
                 }
             }

--- a/test/common/core/users/serialization.spec.js
+++ b/test/common/core/users/serialization.spec.js
@@ -324,7 +324,6 @@ describe('serialization', function () {
         core.setAttribute(inst, 'name', 'Instance');
         core.setAttribute(iPrime, 'name', 'IPrime');
 
-        console.log('children', childrenPaths);
         expect(childrenPaths).to.have.length(2);
 
         for (i = 0; i < childrenPaths.length; i += 1) {
@@ -344,7 +343,6 @@ describe('serialization', function () {
                 return Q.nfcall(Serialization.export, core, root);
             })
             .then(function (exportJson) {
-                console.log(exportJson);
                 expect(Object.keys(exportJson.nodes)).to.have.members(guids);
                 expect(exportJson.bases).to.eql({});
             })


### PR DESCRIPTION
because the empty instances are not exported (as they not carry additional information), it may happen that during export these nodes are falsely identified as external bases (though they are not)
so the fix will filter out these nodes from the external bases collection as they will be created on the fly anyhow
test has been also created for the scenario