### PR TITLE
Fixes #856 Project import fails with exception

### DIFF
--- a/seeds/ActivePanels.json
+++ b/seeds/ActivePanels.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "86236510-f1c7-694f-1c76-9bad3a2aa4e0",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/seeds/ActivePanels.json
+++ b/seeds/ActivePanels.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "86236510-f1c7-694f-1c76-9bad3a2aa4e0",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/seeds/EmptyProject.json
+++ b/seeds/EmptyProject.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "03d36072-9e09-7866-cb4e-d0a36ff825f6",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/seeds/EmptyProject.json
+++ b/seeds/EmptyProject.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "03d36072-9e09-7866-cb4e-d0a36ff825f6",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/seeds/EmptyWithConstraint.json
+++ b/seeds/EmptyWithConstraint.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "03d36072-9e09-7866-cb4e-d0a36ff825f6",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/seeds/EmptyWithConstraint.json
+++ b/seeds/EmptyWithConstraint.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "03d36072-9e09-7866-cb4e-d0a36ff825f6",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/seeds/SignalFlowSystem.json
+++ b/seeds/SignalFlowSystem.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "3e91f583-6d14-2508-5e72-718500bafc21",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/seeds/SignalFlowSystem.json
+++ b/seeds/SignalFlowSystem.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "3e91f583-6d14-2508-5e72-718500bafc21",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
@@ -40,6 +40,8 @@ define([
 
         this.__fileUploadInput = INPUT_FILE_UPLOAD.clone();
 
+        this.__files = [];
+
         this._attachFileDropHandlers();
 
         this.updateDisplay();
@@ -170,6 +172,7 @@ define([
 
         // process all File objects
         if (files && files.length > 0) {
+            this.__files = files;
             this._detachFileDropHandlers(true);
 
             afName = self.propertyName;
@@ -226,6 +229,36 @@ define([
         } while (bytes >= thresh);
 
         return bytes.toFixed(1) + ' ' + units[u];
+    };
+
+    AssetWidget.prototype.getTargetAsJson = function (callback) {
+        var self = this,
+            file,
+            parsedContent = null,
+            reader;
+
+        if (this.__files && this.__files.length > 0) {
+            file = this.__files[0];
+            reader = new FileReader();
+
+            reader.onload = function (e) {
+                if (e.target && e.target.result) {
+                    try {
+                        parsedContent = JSON.parse(e.target.result);
+                    } catch (exp) {
+                        self._logger.error('failed to read asset on the client side', exp);
+                        parsedContent = null;
+                    }
+                }
+
+                callback(parsedContent);
+            };
+
+            reader.readAsText(file);
+
+        } else {
+            callback(null);
+        }
     };
 
     AssetWidget.prototype.destroy = function () {

--- a/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
+++ b/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
@@ -199,7 +199,7 @@ define(['js/Loader/LoaderCircles',
             // TODO: Support exported zip file too.
             self.assetWidget.getTargetAsJson(function (targetJson) {
                 if (targetJson) {
-                    var checkResult = self._client.checkImport(targetJson, CORE_CONSTANTS.EXPORT_TYPE_FULL_PROJECT);
+                    var checkResult = self._client.checkImport(targetJson, CORE_CONSTANTS.EXPORT_TYPE_PROJECT);
 
                     if (checkResult) {
                         alert(checkResult);

--- a/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
+++ b/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
@@ -6,12 +6,13 @@
 
 define(['js/Loader/LoaderCircles',
     'common/storage/util',
+    'common/core/constants',
     'js/Controls/PropertyGrid/Widgets/AssetWidget',
     'blob/BlobClient',
     'text!./templates/CreateProjectDialog.html',
 
     'css!./styles/CreateProjectDialog.css'
-], function (LoaderCircles, StorageUtil, AssetWidget, BlobClient, createProjectDialog) {
+], function (LoaderCircles, StorageUtil, CORE_CONSTANTS, AssetWidget, BlobClient, createProjectDialog) {
 
     'use strict';
 
@@ -195,22 +196,21 @@ define(['js/Loader/LoaderCircles',
         this.assetWidget.onFinishChange(function (data) {
             self._btnCreateBlob.disable(true);
 
-            if (data.newValue) {
-                self.blobClient.getMetadata(data.newValue, function (err, metadata) {
-                    if (err) {
-                        self._logger.error(err);
-                        return;
-                    }
+            // TODO: Support exported zip file too.
+            self.assetWidget.getTargetAsJson(function (targetJson) {
+                if (targetJson) {
+                    var checkResult = self._client.checkImport(targetJson, CORE_CONSTANTS.EXPORT_TYPE_FULL_PROJECT);
 
-                    // TODO: Support exported zip file too.
-                    if (metadata.mime === 'application/json') {
-                        self._btnCreateBlob.disable(false);
+                    if (checkResult) {
+                        alert(checkResult);
                     } else {
-                        //TODO: Better feedback here.
-                        alert('Uploaded file must be a json file (from Export branch)');
+                        self._btnCreateBlob.disable(false);
                     }
-                });
-            }
+                } else {
+                    //TODO: Better feedback here.
+                    alert('Uploaded file must be a json file (from Export branch)');
+                }
+            });
         });
 
         this._btnDuplicate.on('click', function (event) {

--- a/src/client/js/Dialogs/ExportErrors/ExportErrorsDialog.js
+++ b/src/client/js/Dialogs/ExportErrors/ExportErrorsDialog.js
@@ -1,0 +1,77 @@
+/*globals define, $*/
+/*jshint browser: true*/
+
+/**
+ * Dialog for confirmation of project deletion.
+ *
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+define([
+    'text!./templates/ExportErrorsDialog.html',
+    'css!./styles/ExportErrorsDialog.css'
+], function (dialogTemplate) {
+    'use strict';
+
+    function ExportErrorsDialog() {
+        this._dialog = null;
+        this._okBtn = null;
+        this._cancelBtn = null;
+        this._reassignBtn = null;
+    }
+
+    ExportErrorsDialog.prototype.show = function (client, logger, projectId, commitHash, text, onOk) {
+        var self = this;
+
+        this._dialog = $(dialogTemplate);
+
+        this._messageBody = this._dialog.find('#messageContent');
+
+        this._okBtn = this._dialog.find('.btn-ok');
+        this._cancelBtn = this._dialog.find('.btn-cancel');
+        this._reassignBtn = this._dialog.find('.btn-warning');
+
+        this._messageBody.html(text.replace(/\n/g, '<br/>'));
+
+        this._okBtn.on('click', function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            self._dialog.modal('hide');
+
+            onOk();
+        });
+
+        this._cancelBtn.on('click', function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            self._dialog.modal('hide');
+        });
+
+        this._reassignBtn.on('click', function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            client.reassignGuids(projectId, commitHash, function (err) {
+                if (err) {
+                    logger.error('GUID reallocation failed', err);
+                }
+                self._dialog.modal('hide');
+            });
+
+        });
+
+        this._dialog.on('hide.bs.modal', function () {
+            self._dialog.remove();
+            self._dialog.empty();
+            self._dialog = undefined;
+            self.onHide();
+        });
+
+        this._dialog.modal('show');
+    };
+
+    ExportErrorsDialog.prototype.onHide = function () {
+        // Not overridden..
+    };
+
+    return ExportErrorsDialog;
+});

--- a/src/client/js/Dialogs/ExportErrors/styles/ExportErrorsDialog.css
+++ b/src/client/js/Dialogs/ExportErrors/styles/ExportErrorsDialog.css
@@ -1,0 +1,19 @@
+/*
+ * @author pmeijer / https://github.com/pmeijer
+ */
+div.export-errors-dialog div.modal-header .header-icon {
+  font-size: 20px;
+  margin-right: 1ex;
+  display: inline-block;
+  color: #b30404; }
+div.export-errors-dialog div.modal-header span {
+  font-size: 24px; }
+div.export-errors-dialog form .do-not-show {
+  display: none; }
+div.export-errors-dialog form label {
+  font-weight: lighter; }
+div.export-errors-dialog .modal-content .delete-item {
+  text-align: center;
+  font-size: 20px;
+  margin-top: 14px;
+  font-weight: bold; }

--- a/src/client/js/Dialogs/ExportErrors/styles/ExportErrorsDialog.scss
+++ b/src/client/js/Dialogs/ExportErrors/styles/ExportErrorsDialog.scss
@@ -1,0 +1,33 @@
+/*
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+div.export-errors-dialog {
+  div.modal-header {
+    .header-icon {
+      font-size: 20px;
+      margin-right: 1ex;
+      display: inline-block;
+      color: #b30404;
+    }
+    span {
+      font-size: 24px;
+    }
+  }
+  form {
+    .do-not-show {
+      display: none;
+    }
+    label {
+      font-weight: lighter;
+    }
+  }
+  .modal-content {
+    .delete-item {
+      text-align: center;
+      font-size: 20px;
+      margin-top: 14px;
+      font-weight: bold;
+    }
+  }
+}

--- a/src/client/js/Dialogs/ExportErrors/templates/ExportErrorsDialog.html
+++ b/src/client/js/Dialogs/ExportErrors/templates/ExportErrorsDialog.html
@@ -1,0 +1,37 @@
+<div class="export-errors-dialog modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">×</button>
+                <i class="glyphicon glyphicon-trash header-icon"></i><span>Export issues</span>
+            </div>
+            <div class="modal-body">
+                <div id="messageContent"></div>
+                <div>
+                    <i><b>Hints:</b></i>
+                    <ul>
+                        <li>
+                            <i>
+                                If you face a missing node error, you can try to redo the export. If the error
+                                seems to be persistent let the server operator know about it.
+                            </i>
+                        </li>
+                        <li>
+                            <i>
+                                If you have GUID collision alerts, you can try to reassign the GUIDs. A new
+                                branch will be created so you can later merge it back to your branch if you
+                                make sure the changes acceptable. If you had any library imported, you will
+                                no longer be able to detect them based on their GUIDs.
+                            </i>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-danger btn-ok">Save anyway</button>
+                <button class="btn btn-warning">Reassign GUIDs</button>
+                <button class="btn btn-default btn-cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/client/js/Dialogs/Import/ImportDialog.js
+++ b/src/client/js/Dialogs/Import/ImportDialog.js
@@ -6,9 +6,11 @@
  */
 
 define(['js/Loader/LoaderCircles',
+    'common/core/constants',
     'text!./templates/ImportDialog.html',
     'css!./styles/ImportDialog.css'
 ], function (LoaderCircles,
+             CORE_CONSTANTS,
              importDialogTemplate) {
 
     'use strict';
@@ -67,7 +69,6 @@ define(['js/Loader/LoaderCircles',
 
             self._fileInput.click();
         });
-
 
         // file select
         this._fileInput.on('change', function (event) {
@@ -147,11 +148,13 @@ define(['js/Loader/LoaderCircles',
                     self._uploadedFileName.text(file.name);
                     self._uploadedFileName.removeClass('empty');
 
-                    if (parsedJSONFileContent === undefined) {
-                        self._displayMessage('INVALID FILE FORMAT...', true);
+                    var checkResult = WebGMEGlobal.Client.checkImport(parsedJSONFileContent,
+                        CORE_CONSTANTS.EXPORT_TYPE_LIBRARY);
+                    if (checkResult) {
+                        self._displayMessage(checkResult, true);
                     } else {
                         self._displayMessage('File has been parsed successfully, click \'Import...\'' +
-                                             ' to start importing.', false);
+                            ' to start importing.', false);
                         btnImport.disable(false);
                         btnImport.on('click', function (event) {
                             event.preventDefault();

--- a/src/client/js/Panels/Header/ProjectNavigatorController.js
+++ b/src/client/js/Panels/Header/ProjectNavigatorController.js
@@ -16,6 +16,7 @@ define([
     'js/Dialogs/Branches/BranchesDialog',
     'js/Dialogs/ConfirmDelete/ConfirmDeleteDialog',
     'js/Dialogs/ProjectRights/ProjectRightsDialog',
+    'js/Dialogs/ExportErrors/ExportErrorsDialog',
     'common/storage/util',
     'js/Utils/SaveToDisk',
     'q'
@@ -29,15 +30,14 @@ define([
              BranchesDialog,
              ConfirmDeleteDialog,
              ProjectRightsDialog,
+             ExportErrorsDialog,
              StorageUtil,
              saveToDisk,
              Q) {
     'use strict';
 
-
     angular.module('gme.ui.ProjectNavigator', []).run(function () {
     });
-
 
     var ProjectNavigatorController;
 
@@ -349,7 +349,7 @@ define([
                 return;
             }
 
-            function getBranchPromise (projectId, branchId, branchHash) {
+            function getBranchPromise(projectId, branchId, branchHash) {
                 var deferred = Q.defer();
 
                 self.gmeClient.getCommits(projectId, branchHash, 1, function (err, commits) {
@@ -654,13 +654,27 @@ define([
 
         if (self.gmeClient) {
             exportBranch = function (data) {
+                var dialog = new ExportErrorsDialog();
                 self.gmeClient.getExportProjectBranchUrl(data.projectId,
                     data.branchId, data.projectId + '_' + data.branchId, function (err, url) {
-                        if (!err && url) {
-                            saveToDisk.saveUrlToDisk(url);
+                        if (url) {
+                            if (err) {
+                                dialog.show(self.gmeClient, self.logger,
+                                    data.projectId, data.commitHash, err.message, function () {
+                                        saveToDisk.saveUrlToDisk(url);
+                                    }
+                                );
+                            } else {
+                                saveToDisk.saveUrlToDisk(url);
+                            }
                         } else {
-                            self.logger.error('Failed to get project export url for', data);
+                            self.logger.error('Failed to retrieve export url for', data);
                         }
+                        //if (!err && url) {
+                        //    saveToDisk.saveUrlToDisk(url);
+                        //} else {
+                        //    self.logger.error('Failed to get project export url for', data);
+                        //}
                     }
                 );
             };
@@ -742,7 +756,8 @@ define([
                     deleteItem = StorageUtil.getProjectDisplayedNameFromProjectId(data.projectId) +
                         '  -  ' + data.branchId;
 
-                deleteBranchModal.show({deleteItem: deleteItem}, function () {});
+                deleteBranchModal.show({deleteItem: deleteItem}, function () {
+                });
             };
 
             createCommitMessage = function (data) {
@@ -753,7 +768,6 @@ define([
         selectBranch = function (data) {
             self.selectBranch(data);
         };
-
 
         deleteBranchItem = {
             id: 'deleteBranch',
@@ -865,7 +879,8 @@ define([
                             action: exportBranch,
                             actionData: {
                                 projectId: projectId,
-                                branchId: branchId
+                                branchId: branchId,
+                                commitHash: branchInfo.branchHash
                             }
                         }
                     ]

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -2039,45 +2039,7 @@ define([
         };
 
         //checking if the import is in the proper format as its intended usage
-        //TODO extra checkings can be done here - now everything is planned to be synchronous
-        this.checkImport = function (jsonImport, importType) {
-            if (!jsonImport) {
-                return 'Import should always be a valid JSON object!';
-            }
-
-            switch (importType) {
-                case CORE_CONSTANTS.EXPORT_TYPE_FULL_PROJECT:
-                    if (jsonImport._metadata && jsonImport._metdata.type) {
-                        if (jsonImport._metadata.type !== CORE_CONSTANTS.EXPORT_TYPE_FULL_PROJECT) {
-                            return 'Import is of type \'library\' and not of \'full project\'!';
-                        }
-                    } else if (jsonImport.root && typeof jsonImport.root.path === 'string') {
-                        if (jsonImport.root.path !== ROOT_PATH) {
-                            return 'Import is of type \'library\' and not of \'full project\'!';
-                        }
-                    } else {
-                        return 'Import data is probably incomplete and should not be used!';
-                    }
-                    break;
-                case CORE_CONSTANTS.EXPORT_TYPE_LIBRARY:
-                    if (jsonImport._metadata && jsonImport._metdata.type) {
-                        if (jsonImport._metadata.type !== CORE_CONSTANTS.EXPORT_TYPE_LIBRARY) {
-                            return 'Import is of type \'full project\' and not of \'library\'!';
-                        }
-                    } else if (jsonImport.root && typeof jsonImport.root.path === 'string') {
-                        if (jsonImport.root.path === ROOT_PATH) {
-                            return 'Import is of type \'full project\' and not of \'library\'!';
-                        }
-                    } else {
-                        return 'Import data is probably incomplete and should not be used!';
-                    }
-                    break;
-                default:
-                    return 'Invalid type, cannot checked!';
-            }
-
-            return null;
-        };
+        this.checkImport = Serialization.checkImport;
 
         this.gmeConfig = gmeConfig;
     }

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -50,6 +50,9 @@ define([], function () {
             CONSTRAINT_COLLISION: 'constraint collision'
         },
 
+        EXPORT_TYPE_FULL_PROJECT: 'full',
+        EXPORT_TYPE_LIBRARY: 'library',
+
         MAX_AGE: 3,
         MAX_TICKS: 2000,
         MAX_MUTATE: 30000

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -50,7 +50,7 @@ define([], function () {
             CONSTRAINT_COLLISION: 'constraint collision'
         },
 
-        EXPORT_TYPE_FULL_PROJECT: 'full',
+        EXPORT_TYPE_PROJECT: 'project',
         EXPORT_TYPE_LIBRARY: 'library',
 
         MAX_AGE: 3,

--- a/src/common/core/users/serialization.js
+++ b/src/common/core/users/serialization.js
@@ -21,7 +21,7 @@ define(['common/util/assert', 'common/core/constants', 'blob/BlobConfig'], funct
             root = core.getRoot(libraryRoot);
 
         if (root === libraryRoot) {
-            result.type = CONSTANTS.EXPORT_TYPE_FULL_PROJECT;
+            result.type = CONSTANTS.EXPORT_TYPE_PROJECT;
         } else {
             result.type = CONSTANTS.EXPORT_TYPE_LIBRARY;
         }
@@ -1438,9 +1438,54 @@ define(['common/util/assert', 'common/core/constants', 'blob/BlobConfig'], funct
         });
     }
 
+    //TODO extra checkings can be done here - now everything is planned to be synchronous
+    function checkImport(jsonImport, importType) {
+        if (!jsonImport) {
+            return 'Import should always be a valid JSON object!';
+        }
+
+        switch (importType) {
+            case CONSTANTS.EXPORT_TYPE_PROJECT:
+                if (jsonImport._metadata && jsonImport._metdata.type) {
+                    if (jsonImport._metadata.type !== CONSTANTS.EXPORT_TYPE_PROJECT) {
+                        return 'Import is of type \'' + CONSTANTS.EXPORT_TYPE_LIBRARY + '\' and not of \'' +
+                            CONSTANTS.EXPORT_TYPE_PROJECT + '\'!';
+                    }
+                } else if (jsonImport.root && typeof jsonImport.root.path === 'string') {
+                    if (jsonImport.root.path !== ROOT_PATH) {
+                        return 'Import is of type \'' + CONSTANTS.EXPORT_TYPE_LIBRARY + '\' and not of \'' +
+                            CONSTANTS.EXPORT_TYPE_PROJECT + '\'!';
+                    }
+                } else {
+                    return 'Import data is probably incomplete and should not be used!';
+                }
+                break;
+            case CONSTANTS.EXPORT_TYPE_LIBRARY:
+                if (jsonImport._metadata && jsonImport._metdata.type) {
+                    if (jsonImport._metadata.type !== CONSTANTS.EXPORT_TYPE_LIBRARY) {
+                        return 'Import is of type \'' + CONSTANTS.EXPORT_TYPE_PROJECT + '\' and not of \'' +
+                            CONSTANTS.EXPORT_TYPE_LIBRARY + '\'!';
+                    }
+                } else if (jsonImport.root && typeof jsonImport.root.path === 'string') {
+                    if (jsonImport.root.path === ROOT_PATH) {
+                        return 'Import is of type \'' + CONSTANTS.EXPORT_TYPE_PROJECT + '\' and not of \'' +
+                            CONSTANTS.EXPORT_TYPE_LIBRARY + '\'!';
+                    }
+                } else {
+                    return 'Import data is probably incomplete and should not be used!';
+                }
+                break;
+            default:
+                return 'Invalid type, cannot checked!';
+        }
+
+        return null;
+    }
+
     return {
         export: exportLibrary,
         import: importLibrary,
-        exportLibraryWithAssets: exportLibraryWithAssets
+        exportLibraryWithAssets: exportLibraryWithAssets,
+        checkImport: checkImport
     };
 });

--- a/src/server/worker/constants.js
+++ b/src/server/worker/constants.js
@@ -33,6 +33,7 @@ module.exports = {
         autoMerge: 'autoMerge',
         resolve: 'resolve',
         checkConstraints: 'checkConstraints',
+        reassignGuids: 'reassignGuids',
 
         // AddOn related
         connectedWorkerStart: 'connectedWorkerStart',

--- a/src/server/worker/simpleworker.js
+++ b/src/server/worker/simpleworker.js
@@ -133,6 +133,16 @@ process.on('message', function (parameters) {
                 result: result
             });
         });
+    } else if (parameters.command === CONSTANTS.workerCommands.reassignGuids) {
+        wr.reassignGuids(parameters.webGMESessionId, parameters.projectId, parameters.commitHash,
+            function (err, result) {
+                safeSend({
+                    pid: process.pid,
+                    type: CONSTANTS.msgTypes.result,
+                    error: err ? err.message : null,
+                    result: result
+                });
+            });
     } else {
         safeSend({
             pid: process.pid,

--- a/test-karma/client/js/client/basicProject.json
+++ b/test-karma/client/js/client/basicProject.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "e687d284-a04a-7cbc-93ed-ea941752d57a",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/test-karma/client/js/client/basicProject.json
+++ b/test-karma/client/js/client/basicProject.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "e687d284-a04a-7cbc-93ed-ea941752d57a",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/test-karma/client/js/client/clientNodeTestProject.json
+++ b/test-karma/client/js/client/clientNodeTestProject.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "d890afdd-3a8a-13ae-18df-af3cba9fda87",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",

--- a/test-karma/client/js/client/clientNodeTestProject.json
+++ b/test-karma/client/js/client/clientNodeTestProject.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "d890afdd-3a8a-13ae-18df-af3cba9fda87",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/test-karma/client/js/client/metaTestProject.json
+++ b/test-karma/client/js/client/metaTestProject.json
@@ -2,7 +2,7 @@
   "_metadata": {
     "hasAssets": false,
     "rootGuid": "153d06f6-478c-0812-776b-94327a563db9",
-    "type": "full"
+    "type": "project"
   },
   "bases": {},
   "root": {

--- a/test-karma/client/js/client/metaTestProject.json
+++ b/test-karma/client/js/client/metaTestProject.json
@@ -1,4 +1,9 @@
 {
+  "_metadata": {
+    "hasAssets": false,
+    "rootGuid": "153d06f6-478c-0812-776b-94327a563db9",
+    "type": "full"
+  },
   "bases": {},
   "root": {
     "path": "",


### PR DESCRIPTION
- There is an issue of GUID collision (by multiple import of the same library/model), which results in a corrupted export that cannot be imported
- The correction fixes the issue at source, meaning it offers GUID reallocation on export (or simply leaves out the colliding nodes)
- The correction also introduces the _metadata into the export format, so it can be checked if an export is a full project or a library and we can reject the import based on this information.