### PR TITLE
Make the cookieId of JWT configurable.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -57,6 +57,8 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
  - Where clients are redirected after logout.
 - `config.authentication.salts = 10`
  - Strength of the salting of the users' passwords [bcrypt](https://github.com/dcodeIO/bcrypt.js).
+- `config.authentication.jwt.cookieId = 'access_token'`
+ - Id of token used when placed inside of a cookie.
 - `config.authentication.jwt.expiresIn = 3600 * 24 * 7`
  - Lifetime of tokens in seconds.
 - `config.authentication.jwt.renewBeforeExpires = 3600`

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -21,6 +21,7 @@ var path = require('path'),
             jwt: {
                 expiresIn: 3600 * 24 * 7,
                 renewBeforeExpires: 3600,
+                cookieId: 'access_token',
                 // These are just examples and should be overwritten
                 privateKey: path.join(__dirname, '../src/server/middleware/auth/EXAMPLE_PRIVATE_KEY'),
                 publicKey: path.join(__dirname, '../src/server/middleware/auth/EXAMPLE_PUBLIC_KEY')

--- a/config/getclientconfig.js
+++ b/config/getclientconfig.js
@@ -10,8 +10,13 @@ function getClientConfig(gmeConfig) {
 
     delete clientConfig.server.log;
     delete clientConfig.server.extlibExcludes;
-    delete clientConfig.authentication.jwt;
+
+    delete clientConfig.authentication.jwt.expiresIn;
+    delete clientConfig.authentication.jwt.renewBeforeExpires;
+    delete clientConfig.authentication.jwt.privateKey;
+    delete clientConfig.authentication.jwt.publicKey;
     delete clientConfig.authentication.salts;
+
     delete clientConfig.executor.nonce;
     delete clientConfig.mongo;
     delete clientConfig.blob;

--- a/src/common/storage/socketio/browserclient.js
+++ b/src/common/storage/socketio/browserclient.js
@@ -34,8 +34,8 @@ define(['common/util/url'], function (URL) {
 
         this.getToken = function () {
             var cookies = URL.parseCookie(document.cookie);
-            if (cookies.access_token) {
-                return cookies.access_token;
+            if (cookies[gmeConfig.authentication.jwt.cookieId]) {
+                return cookies[gmeConfig.authentication.jwt.cookieId];
             }
         };
     }

--- a/src/common/storage/socketio/nodeclient.js
+++ b/src/common/storage/socketio/nodeclient.js
@@ -21,7 +21,7 @@ define(['socket.io-client'], function (io) {
 
             if (webgmeToken) {
                 socketIoOptions.extraHeaders = {
-                    Cookie: 'access_token=' + webgmeToken
+                    Cookie: gmeConfig.authentication.jwt.cookieId + '=' + webgmeToken
                 };
 
                 logger.debug('webgmeToken was defined adding it as an extra header in the cookie..');

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -304,13 +304,13 @@ function createAPI(app, mountPath, middlewareOpts) {
         if (req.userData.token && req.userData.newToken === true) {
             res.status(200);
             res.json({
-                access_token: req.userData.token
+                webgmeToken: req.userData.token
             });
         } else {
             getNewJWToken(userId)
                 .then(function (token) {
                     res.status(200);
-                    res.json({access_token: token});
+                    res.json({webgmeToken: token});
                 })
                 .catch(function (err) {
                     next(err);

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -28,7 +28,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
         if (handshakeData && handshakeData.headers.cookie) {
             // We try to dig it from the cookie.
-            token = URL.parseCookie(handshakeData.headers.cookie).access_token;
+            token = URL.parseCookie(handshakeData.headers.cookie)[gmeConfig.authentication.jwt.cookieId];
         }
 
         return token;
@@ -811,7 +811,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         data.userId = userId;
                         data.socketId = socket.id;
 
-                        if (data.webgmeToken) {
+                        if (gmeConfig.authentication.enable === true) {
                             return gmeAuth.regenerateJWToken(data.webgmeToken);
                         }
                     })
@@ -839,7 +839,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         data.userId = userId;
                         data.socketId = socket.id;
 
-                        if (data.webgmeToken) {
+                        if (gmeConfig.authentication.enable === true) {
                             return gmeAuth.regenerateJWToken(data.webgmeToken);
                         }
                     })

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -623,7 +623,7 @@ describe('REST API', function () {
                     .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(200, err);
-                        expect(res.body.access_token.split('.').length).equal(3, 'Returned token not correct format');
+                        expect(res.body.webgmeToken.split('.').length).equal(3, 'Returned token not correct format');
                         done();
                     });
             });
@@ -962,9 +962,10 @@ describe('REST API', function () {
                 agent.get(server.getUrl() + '/api/v1/user/token')
                     .end(function (err, res) {
                         expect(res.status).equal(200, err);
-                        expect(res.body.access_token.split('.').length).equal(3, 'Returned token not correct format');
+                        expect(res.body.webgmeToken.split('.').length)
+                            .equal(3, 'Returned token not correct format');
                         agent.get(server.getUrl() + '/api/v1/user')
-                            .set('Authorization', 'Bearer ' + res.body.access_token)
+                            .set('Authorization', 'Bearer ' + res.body.webgmeToken)
                             .end(function (err, res) {
                                 expect(res.status).equal(200, err);
                                 expect(res.body._id).equal('guest', err);
@@ -978,9 +979,9 @@ describe('REST API', function () {
                     .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(200, err);
-                        expect(res.body.access_token.split('.').length).equal(3, 'Returned token not correct format');
+                        expect(res.body.webgmeToken.split('.').length).equal(3, 'Returned token not correct format');
                         agent.get(server.getUrl() + '/api/v1/user')
-                            .set('Authorization', 'Bearer ' + res.body.access_token)
+                            .set('Authorization', 'Bearer ' + res.body.webgmeToken)
                             .end(function (err, res) {
                                 expect(res.status).equal(200, err);
                                 expect(res.body._id).equal('admin', err);
@@ -1730,17 +1731,17 @@ describe('REST API', function () {
                 agent.get(server.getUrl() + '/api/v1/user/token')
                     .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {
-                        var orginaltoken = res.body.access_token;
+                        var orginalToken = res.body.webgmeToken;
                         expect(res.status).equal(200, err);
-                        expect(orginaltoken.split('.').length).equal(3, 'Returned token not correct format');
+                        expect(orginalToken.split('.').length).equal(3, 'Returned token not correct format');
                         setTimeout(function () {
                             agent.get(server.getUrl() + '/api/v1/user')
-                                .set('Authorization', 'Bearer ' + orginaltoken)
+                                .set('Authorization', 'Bearer ' + orginalToken)
                                 .end(function (err, res) {
                                     expect(res.status).equal(200, err);
                                     expect(res.body._id).equal('admin', err);
                                     expect(res.header.access_token.split('.').length).equal(3, 'no token in header');
-                                    expect(res.header.access_token).to.not.equal(orginaltoken, 'no token update');
+                                    expect(res.header.access_token).to.not.equal(orginalToken, 'no token update');
                                     done();
                                 });
                         }, 1000);
@@ -1752,7 +1753,7 @@ describe('REST API', function () {
                 agent.get(server.getUrl() + '/api/v1/user/token')
                     .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {
-                        var orginaltoken = res.body.access_token;
+                        var orginaltoken = res.body.webgmeToken;
                         expect(res.status).equal(200, err);
                         expect(orginaltoken.split('.').length).equal(3, 'Returned token not correct format');
                         setTimeout(function () {


### PR DESCRIPTION
This PR also includes a check if auth is enabled before trying to create a new token for a worker-request from a websocket. (Before it checked it there was a token, but for development old cookies may be present.)

Further requesting a new token returns an object with the token under the key `webgmeToken` and not  `access_token` (which is now the cookieId).