### PR TITLE
Fixes #909 MetaCache doesn't handle node removal during load

### DIFF
--- a/src/common/core/metacachecore.js
+++ b/src/common/core/metacachecore.js
@@ -6,10 +6,10 @@
  */
 
 define([
-    'common/util/assert',
-    'common/core/tasync',
-    'common/core/constants'
-], function (ASSERT, TASYNC, CONSTANTS) {
+        'common/util/assert',
+        'common/core/tasync',
+        'common/core/constants'
+    ], function (ASSERT, TASYNC, CONSTANTS) {
         'use strict';
 
         var MetaCacheCore = function (innerCore, options) {
@@ -41,6 +41,7 @@ define([
                     return TASYNC.lift(metaNodes);
                 }, self.loadPaths(self.getHash(root), JSON.parse(JSON.stringify(paths))));
             }
+
             //</editor-fold>
 
             //<editor-fold=Modified Methods>
@@ -50,7 +51,10 @@ define([
                         var i = 0;
                         root.metaNodes = {};
                         for (i = 0; i < elements.length; i += 1) {
-                            root.metaNodes[innerCore.getPath(elements[i])] = elements[i];
+                            // It can happen that some elements just been removed during load because of missing base.
+                            if (elements[i]) {
+                                root.metaNodes[innerCore.getPath(elements[i])] = elements[i];
+                            }
                         }
                         return root;
                     }, loadMetaSet(root));

--- a/test/common/core/metacachecore.spec.js
+++ b/test/common/core/metacachecore.spec.js
@@ -193,4 +193,36 @@ describe('meta cache core', function () {
         expect(core.isConnection(nonConnection)).to.equal(false);
     });
 
+    it('should detect if some META element have been deleted during load', function (done) {
+        //core.delMember(rootNode, 'MetaAspectSet', metaPaths.pop());
+        var root = core.createNode({}),
+            itemBase = core.createNode({parent: root}),
+            item = core.createNode({parent: root, base: itemBase}),
+            itemBasePath = core.getPath(itemBase),
+            hash = core.getHash(root);
+
+        core.addMember(root, 'MetaAspectSet', itemBase);
+        core.addMember(root, 'MetaAspectSet', item);
+
+        expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(2);
+        core.persist(root);
+        hash = core.getHash(root);
+
+        core.loadRoot(hash)
+            .then(function (root) {
+                var itemBase;
+                expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(2);
+
+                itemBase = core.getAllMetaNodes(root)[itemBasePath];
+                core.deleteNode(itemBase,true);
+                core.persist(root);
+                hash = core.getHash(root);
+
+                return core.loadRoot(hash);
+            })
+            .then(function (root) {
+                expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(0);
+            })
+            .nodeify(done);
+    });
 });


### PR DESCRIPTION
it can happen that nodes removed during load (missing base), that should be handled by the metaCache as well