### PR TITLE
Add tabs in the svg selector and display short names

### DIFF
--- a/src/client/decorators/SVGDecorator/Core/SVGDecorator.Core.js
+++ b/src/client/decorators/SVGDecorator/Core/SVGDecorator.Core.js
@@ -12,14 +12,16 @@ define([
     'js/Utils/DisplayFormat',
     'js/Decorators/DecoratorWithPorts.Base',
     'js/Widgets/DiagramDesigner/DiagramDesignerWidget.Constants',
-    'text!./default.svg'
+    'text!./default.svg',
+    'common/regexp'
 ], function (CONSTANTS,
              nodePropertyNames,
              REGISTRY_KEYS,
              displayFormat,
              DecoratorBase,
              DiagramDesignerWidgetConstants,
-             DefaultSvgTemplate) {
+             DefaultSvgTemplate,
+             REGEXP) {
 
     'use strict';
 
@@ -233,6 +235,9 @@ define([
         var svgIcon;
         //set new content
         this.$svgContent.empty();
+        this.$svgContent.removeClass();
+        this.$svgContent.addClass('svg-content');
+        this.$svgContent.addClass(svg.replace(REGEXP.INVALID_CSS_CHARS, '__'));
 
         //remove existing connectors (if any)
         this.$el.find('> .' + DiagramDesignerWidgetConstants.CONNECTOR_CLASS).remove();

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
@@ -3,6 +3,7 @@
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
  * @author nabana / https://github.com/nabana
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 define(['js/Constants',
@@ -16,11 +17,15 @@ define(['js/Constants',
     'use strict';
 
     var DecoratorSVGExplorerDialog,
-        IMG_BASE = $('<div class="img"><img src=""/><div class="desc">description</div></div>'),
+        IMG_BASE = $('<div class="image-container"><img src=""/><div class="desc">description</div></div>'),
+        GROUP_TXT = '<li class="tab"><a href="#" data-toggle="tab">__GROUP_NAME__</a></li>',
         SVG_DIR = CONSTANTS.ASSETS_DECORATOR_SVG_FOLDER,
         DecoratorSVGIconList = [''].concat(decoratorSVG.DecoratorSVGIconList.slice(0)),
         DATA_FILENAME = 'data-filename',
-        DATA_SVG = 'data-normalized-filename';
+        DATA_SVG = 'data-normalized-filename',
+        DATA_TAB = 'data-tab-group',
+        TAB_GROUP_PREFIX = 'tab-group-',
+        UNGROUPED = '__UNGROUPED__';
 
 
     DecoratorSVGExplorerDialog = function () {
@@ -31,6 +36,9 @@ define(['js/Constants',
             $originalSelected;
 
         this._fnCallback = fnCallback;
+
+        this._groups = {};
+        this._groupNames = null;
 
         this._initDialog();
 
@@ -53,8 +61,6 @@ define(['js/Constants',
             $originalSelected = self._modalBody.find('[' + DATA_FILENAME + '="' + oldValue + '"]');
             this._setSelected(oldValue, $originalSelected);
         }
-
-
     };
 
     DecoratorSVGExplorerDialog.prototype.registerResult = function () {
@@ -66,46 +72,75 @@ define(['js/Constants',
             len = DecoratorSVGIconList.length,
             i,
             svg,
+            namePieces,
+            imgName,
+            tabGroupEl,
             divImg;
 
         this._dialog = $(DecoratorSVGExplorerDialogTemplate);
         this._modalBody = this._dialog.find('.modal-body');
         this._btnSelect = this._dialog.find('.btn-select');
         this._txtFind = this._dialog.find('#txtFilter');
+        this._groupTabList = this._dialog.find('ul.nav-tabs');
 
         for (i = 0; i < len; i += 1) {
             svg = DecoratorSVGIconList[i];
             divImg = IMG_BASE.clone();
+            namePieces = svg.split('/');
+            imgName = namePieces[namePieces.length - 1];
 
             if (i === 0 && svg === '') {
                 divImg.find('img').remove();
                 divImg.find('.desc').text('-- NONE --');
                 divImg.find('.desc').attr('title', '-- NONE --');
             } else {
+                // Trim the .svg part
+                imgName = imgName.substring(0, imgName.length - '.svg'.length);
                 divImg.find('img').attr('src', SVG_DIR + svg);
                 divImg.find('img').attr('title', svg);
-                divImg.find('.desc').text(svg);
+                divImg.find('.desc').text(imgName);
                 divImg.find('.desc').attr('title', svg);
             }
 
             divImg.data(DATA_FILENAME, svg);
             divImg.attr(DATA_FILENAME, svg);
 
-            divImg.attr(DATA_SVG, svg.toLowerCase());
+            divImg.attr(DATA_SVG, imgName.toLowerCase());
+            divImg.data(DATA_SVG, imgName.toLowerCase());
+
+            if (namePieces.length === 1) {
+                // These are the "old" SVGs at the root.
+                divImg.addClass(TAB_GROUP_PREFIX + UNGROUPED);
+            } else {
+                divImg.addClass(TAB_GROUP_PREFIX + namePieces[0]);
+                this._groups[namePieces[0]] = true;
+            }
 
             this._modalBody.append(divImg);
 
             self._setSelected();
         }
 
-        this._modalBody.on('mousedown', 'div.img', function () {
+        this._groupNames = Object.keys(this._groups);
+        // Add the groups tabs
+        tabGroupEl = $(GROUP_TXT.replace('__GROUP_NAME__', 'All'));
+        tabGroupEl.addClass('All active');
+        this._groupTabList.append(tabGroupEl);
+
+        for (i = 0; i < this._groupNames.length; i += 1) {
+            tabGroupEl = $(GROUP_TXT.replace('__GROUP_NAME__', this._groupNames[i]));
+            tabGroupEl.data(DATA_TAB, this._groupNames[i]);
+            this._groupTabList.append(tabGroupEl);
+        }
+
+        this._modalBody.on('mousedown', 'div.image-container', function () {
             var $el = $(this);
 
-            self._modalBody.find('div.img.selected').removeClass('selected');
+            self._modalBody.find('div.image-container.selected').removeClass('selected');
             self._setSelected($el.data(DATA_FILENAME), $el);
         });
 
-        this._modalBody.on('dblclick', 'div.img', function () {
+        this._modalBody.on('dblclick', 'div.image-container', function () {
             self.registerResult();
             self._dialog.modal('hide');
         });
@@ -122,10 +157,30 @@ define(['js/Constants',
         this._txtFind.on('keypress', function (e) {
             return e.keyCode !== 13;
         });
+
+        this._groupTabList.find('li.tab').on('click', function () {
+            var el = $(this),
+                groupClass;
+            self._setSelected();
+
+            if (el.hasClass('All')) {
+                self._modalBody.find('div.image-container').removeClass('not-in-tab-group');
+            } else {
+                groupClass = TAB_GROUP_PREFIX + el.data(DATA_TAB);
+                self._modalBody.find('div.image-container').each(function () {
+                    var divImg = $(this);
+                    if (divImg.hasClass(groupClass)) {
+                        divImg.removeClass('not-in-tab-group');
+                    } else {
+                        divImg.addClass('not-in-tab-group');
+                    }
+                });
+            }
+        });
     };
 
     DecoratorSVGExplorerDialog.prototype._setSelected = function (fileName, $selectedItem) {
-        this._modalBody.find('div.img.selected').removeClass('selected');
+        this._modalBody.find('div.image-container.selected').removeClass('selected');
 
         if ($selectedItem) {
             $selectedItem.addClass('selected');
@@ -143,10 +198,20 @@ define(['js/Constants',
     DecoratorSVGExplorerDialog.prototype._filter = function (fileName) {
         this._setSelected();
         if (fileName) {
-            this._modalBody.find('div.img').hide();
-            this._modalBody.find('div.img[' + DATA_SVG + '*="' + fileName.toLowerCase() + '"]').show();
+            this._modalBody.find('div.image-container').each(function () {
+                var divImg = $(this),
+                    name = divImg.data(DATA_SVG);
+
+                if (name && name.indexOf(fileName.toLowerCase()) < 0) {
+                    divImg.addClass('not-in-filter');
+                } else if (!name) {
+                    divImg.addClass('not-in-filter');
+                } else {
+                    divImg.removeClass('not-in-filter');
+                }
+            });
         } else {
-            this._modalBody.find('div.img').show();
+            this._modalBody.find('div.image-container').removeClass('not-in-filter');
         }
 
     };

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.css
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.css
@@ -3,7 +3,21 @@
  * 
  * Author: Robert Kereskenyi
  */
-.decorator-svg-dialog div.img {
+.decorator-svg-dialog .modal-header .header-icon {
+  font-size: 30px;
+  margin-right: 1ex;
+  margin-left: 0.4ex;
+  display: inline-block;
+  color: #2e6da4; }
+.decorator-svg-dialog .modal-header span {
+  font-size: 30px; }
+.decorator-svg-dialog .pre-body {
+  padding: 15px 15px 0 15px; }
+  .decorator-svg-dialog .pre-body .tabContainer ul.nav.nav-tabs {
+    margin-bottom: 0; }
+    .decorator-svg-dialog .pre-body .tabContainer ul.nav.nav-tabs li {
+      text-align: center; }
+.decorator-svg-dialog .image-container {
   margin: 3px;
   padding: 5px;
   border: 1px solid #EFEFEF;
@@ -13,13 +27,17 @@
   text-align: center;
   position: relative;
   cursor: pointer; }
-  .decorator-svg-dialog div.img img {
+  .decorator-svg-dialog .image-container.not-in-tab-group {
+    display: none; }
+  .decorator-svg-dialog .image-container.not-in-filter {
+    display: none; }
+  .decorator-svg-dialog .image-container img {
     display: inline;
     margin: 0;
     padding: 3px;
     max-width: 100%;
-    max-height: 68px; }
-  .decorator-svg-dialog div.img div.desc {
+    max-height: 48px; }
+  .decorator-svg-dialog .image-container div.desc {
     text-align: center;
     font-weight: normal;
     line-height: 20px;
@@ -31,10 +49,10 @@
     bottom: 0;
     overflow: hidden;
     text-overflow: ellipsis; }
-  .decorator-svg-dialog div.img:hover {
+  .decorator-svg-dialog .image-container:hover {
     border-color: #ababab;
     background-color: #efefef; }
-  .decorator-svg-dialog div.img.selected {
+  .decorator-svg-dialog .image-container.selected {
     border-color: #52a8ec;
     background-color: #dbeafc;
     -webkit-box-shadow: 0 0 15px 0 #1276d4 !important;

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.scss
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.scss
@@ -12,7 +12,33 @@ $desc-line-height: 20px;
 $desc-margin: 3px;
 
 .decorator-svg-dialog {
-  div.img {
+  .modal-header {
+    .header-icon {
+      font-size: 30px;
+      margin-right: 1ex;
+      margin-left: 0.4ex;
+      display: inline-block;
+      color: #2e6da4;
+    }
+    span {
+      font-size: 30px;
+    }
+  }
+  .pre-body {
+    padding: 15px 15px 0 15px;
+
+    .tabContainer {
+      ul.nav.nav-tabs {
+        margin-bottom: 0;
+
+        li {
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  .image-container {
     margin: $item-margin;
     padding: 5px;
     border: 1px solid #EFEFEF;
@@ -23,12 +49,20 @@ $desc-margin: 3px;
     position: relative;
     cursor: pointer;
 
+    &.not-in-tab-group {
+      display: none;
+    }
+
+    &.not-in-filter {
+      display: none;
+    }
+
     img {
       display: inline;
       margin: 0;
       padding: $img-margin;
       max-width: 100%;
-      max-height: $item-height - 2 * $img-margin - 2 * $desc-margin - $desc-line-height;
+      max-height: $item-height - 2 * $img-margin - 2 * $desc-margin - 2 * $desc-line-height;
     }
 
     div.desc {

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/templates/DecoratorSVGExplorerDialog.html
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/templates/DecoratorSVGExplorerDialog.html
@@ -3,7 +3,14 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">×</button>
-                <h3>Decorator icons</h3>
+                <i class="glyphicon glyphicon-picture header-icon"></i><span>SVG Icons</span>
+            </div>
+            <div class="pre-body">
+                <div class="tabContainer">
+                    <ul class="nav nav-tabs">
+                        <!--<li class="tab All"><a href="#" data-toggle="tab">All</a></li>-->
+                    </ul>
+                </div>
             </div>
             <div class="modal-body">
 
@@ -11,7 +18,7 @@
             <div class="modal-footer">
                 <div class="input-prepend pull-left">
                     <span class="add-on"><i class="icon-search"></i>
-                    </span><input id="txtFilter" class="input-xlarge" type="text" placeholder="Filter...">
+                    </span><input id="txtFilter" class="input-xlarge" type="text" placeholder="Enter filter...">
                 </div>
                 <a href="#" class="btn btn-primary btn-select disabled">Select</a>
                 <a href="#" class="btn btn-default" data-dismiss="modal">Close</a>

--- a/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
+++ b/src/client/js/Panels/ObjectBrowser/ObjectBrowserControlBase.js
@@ -28,10 +28,10 @@ define(['js/RegistryKeys'], function (REGISTRY_KEYS) {
         if (node) {
             if (expanded) {
                 iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON) ||
-                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON);
+                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON);
             } else {
                 iconName = node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON) ||
-                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_COLLAPSED_ICON);
+                    node.getRegistry(REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON);
             }
         }
 

--- a/src/common/regexp.js
+++ b/src/common/regexp.js
@@ -15,6 +15,7 @@ define([], function () {
         DOCUMENT_KEY = new RegExp('^[^(\$|\_)\.][^\.]*$'),//based on the MongoDB requirements (no '.' and no leading $)
         PROJECT_NAME = new RegExp('^[0-9a-zA-Z_]+$'),
 
+        INVALID_CSS_CHARS = new RegExp('[!"#$%&\'()\*\+,\./:;<=>\?@\[\\\]^`{\|}~ ]+', 'g'),
         GUID = new RegExp('[a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12}', 'i');
 
     return {
@@ -26,6 +27,7 @@ define([], function () {
         PROJECT: PROJECT,
         DOCUMENT_KEY: DOCUMENT_KEY,
         GUID: GUID,
+        INVALID_CSS_CHARS: INVALID_CSS_CHARS,
         PROJECT_NAME: PROJECT_NAME
     };
 });


### PR DESCRIPTION
This PR also covers:
- SVGDecorator adds css-class to the svg-containers.
- Fixes minor bug in fallback icon lookup for the object browsers.

For info how icons are used see:
https://github.com/webgme/webgme/wiki/SVG-Icons