### PR TITLE
Focus-able div elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "tests"
   ],
   "dependencies": {
-    "isis-ui-components": "0.2.17",
+    "isis-ui-components": "vu-isis/isis-ui-components#master",
     "angular": "1.3.15",
     "backbone": "1.2.3",
     "underscore": "1.8.3",

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "tests"
   ],
   "dependencies": {
-    "isis-ui-components": "vu-isis/isis-ui-components#master",
+    "isis-ui-components": "0.2.18",
     "angular": "1.3.15",
     "backbone": "1.2.3",
     "underscore": "1.8.3",


### PR DESCRIPTION
I have checked the behavior of the isis-ui-components and it appears to be unchanged.
My sample application: webgme-immortals uses the revised css for focusable main-menu elements.
Here is the style/immortals.css : 

```
ul.dropdown-navigator > li:not(.separator):hover > div.hierarchical-menu {
  transition-delay: 5s;
}

ul.dropdown-navigator > li:focus {
  visibility: visible;
  pointer-events: none;
}

ul.dropdown-navigator > li:focus > div.hierarchical-menu {
    pointer-events: none;
    visibility: visible;
    z-index: 3;
  }

ul.dropdown-navigator > li:focus > div.hierarchical-menu > ul.menu-contents {
      visibility: visible;
      opacity: 1;
      pointer-events: auto;
    }

ul.dropdown-navigator > li > div.hierarchical-menu > ul.menu-contents {
      visibility: hidden;
      opacity: 0;
      transition: visibility 0.5s;
    }
```