### PR TITLE
Send patch objects for all nodes and calc. changed nodes.

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -172,7 +172,7 @@ var path = require('path'),
             // If true events such as PROJECT_CREATED and BRANCH_CREATED will only be broadcasted
             // and not emitted back to the web-socket that triggered the event.
             broadcastProjectEvents: false,
-            emitCommittedCoreObjects: true,
+            maxEmittedCoreObjects: -1,
             loadBucketSize: 100,
             loadBucketTimer: 10,
             clientCacheSize: 2000, // overwrites cache on client
@@ -182,8 +182,7 @@ var path = require('path'),
                 options: { // if mongo - settings will be used from config.mongo
                     //port: 6666
                 }
-            },
-            patchRootCommunicationEnabled: true
+            }
         },
 
         visualization: {

--- a/config/config.test.js
+++ b/config/config.test.js
@@ -22,7 +22,6 @@ config.authentication.salts = 1;
 //FIXME: Have a common dir for this..
 config.plugin.basePaths.push(path.join(__dirname, '../test/plugin/scenarios/plugins'));
 config.plugin.allowServerExecution = true;
-config.storage.emitCommittedCoreObjects = false;
 config.storage.database.options = {
     //port: 6666
 };

--- a/config/validator.js
+++ b/config/validator.js
@@ -214,7 +214,11 @@ function validateConfig(configOrFileName) {
     expectedKeys.push('storage');
     assertObject('config.storage', config.storage);
     assertBoolean('config.storage.broadcastProjectEvents', config.storage.broadcastProjectEvents);
-    assertBoolean('config.storage.emitCommittedCoreObjects', config.storage.emitCommittedCoreObjects);
+    warnDeprecated('config.storage.emitCommittedCoreObjects', config.storage.emitCommittedCoreObjects,
+        'see new config at config.storage.maxEmittedCoreObjects');
+    assertNumber('config.storage.maxEmittedCoreObjects', config.storage.maxEmittedCoreObjects);
+    warnDeprecated('config.storage.patchRootCommunicationEnabled', config.storage.patchRootCommunicationEnabled,
+        'Since 1.7.0 all node changes are transmitted as patch objects (unless newly created).');
     assertNumber('config.storage.cache', config.storage.cache);
     assertNumber('config.storage.loadBucketSize', config.storage.loadBucketSize);
     assertNumber('config.storage.loadBucketTimer', config.storage.loadBucketTimer);

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -79,6 +79,7 @@ define([
                 loading: {
                     rootHash: null,
                     commitHash: null,
+                    changedNodes: null,
                     next: null
                 }
 
@@ -618,7 +619,7 @@ define([
                     if (!err && commitObj) {
                         logState('info', 'selectCommit loaded commit');
                         self.dispatchEvent(CONSTANTS.BRANCH_CHANGED, null);
-                        loading(commitObj.root, commitHash, function (err, aborted) {
+                        loading(commitObj.root, commitHash, null, function (err, aborted) {
                             if (err) {
                                 logger.error('loading returned error', commitObj.root, err);
                                 logState('error', 'selectCommit loading');
@@ -685,7 +686,7 @@ define([
                 self.dispatchEvent(CONSTANTS.REDO_AVAILABLE, canRedo());
 
                 logger.debug('loading commitHash, local?', commitHash, data.local);
-                loading(commitData.commitObject.root, commitHash, function (err, aborted) {
+                loading(commitData.commitObject.root, commitHash, commitData.changedNodes, function (err, aborted) {
                     if (err) {
                         logger.error('hashUpdateHandler invoked loading and it returned error',
                             commitData.commitObject.root, err);
@@ -1138,17 +1139,85 @@ define([
 
         function getModifiedNodes(newerNodes) {
             var modifiedNodes = [],
+                updatedMetaPaths = [],
+                metaNodes,
+                metaPath,
+                updatePath,
+                loadUnloadPath,
+                pathPieces,
                 i;
+
+            // For the client these rules apply for finding the affected nodes.
+            // 1. Updates should be triggered to any node that core.isTypeOf (i.e. mixins accounted for).
+            // 2. Root node should always be triggered.
+            // 3. loads/unloads should trigger updates for the parent chain.
+
+            if (state.loading.changedNodes) {
+                // 1. Account for mixins - i.e resolve isTypeOf.
+                // Gather all meta-nodes that had an update.
+                metaNodes = state.core.getAllMetaNodes(newerNodes[ROOT_PATH].node);
+                for (updatePath in state.loading.changedNodes.update) {
+                    if (metaNodes.hasOwnProperty(updatePath)) {
+                        updatedMetaPaths.push(updatePath);
+                    }
+                }
+
+                if (updatedMetaPaths.length > 0) {
+                    // There are meta-nodes with updates.
+                    for (metaPath in metaNodes) {
+                        // For all meta nodes..
+                        if (metaNodes.hasOwnProperty(metaPath)) {
+                            for (i = 0; i < updatedMetaPaths.length; i += 1) {
+                                // check if it is a typeOf (includes mixins) any of the updated meta-nodes
+                                if (state.core.isTypeOf(metaNodes[metaPath],
+                                        metaNodes[updatedMetaPaths[i]]) === true) {
+                                    // if so add its path to the update nodes.
+                                    state.loading.changedNodes.update[metaPath] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                //console.log('Update after meta considered', Object.keys(state.loading.changedNodes.update));
+
+                // 2. Add Root node
+                state.loading.changedNodes.update[ROOT_PATH] = true;
+
+                // 3. Account for loads and unloads.
+                for (loadUnloadPath in state.loading.changedNodes.load) {
+                    if (state.loading.changedNodes.load.hasOwnProperty(loadUnloadPath)) {
+                        pathPieces = loadUnloadPath.split('/');
+                        while (pathPieces.length > 2) {
+                            pathPieces.pop();
+                            state.loading.changedNodes.update[pathPieces.join('/')] = true;
+                        }
+                    }
+                }
+
+                for (loadUnloadPath in state.loading.changedNodes.unload) {
+                    if (state.loading.changedNodes.unload.hasOwnProperty(loadUnloadPath)) {
+                        pathPieces = loadUnloadPath.split('/');
+                        while (pathPieces.length > 2) {
+                            pathPieces.pop();
+                            state.loading.changedNodes.update[pathPieces.join('/')] = true;
+                        }
+                    }
+                }
+
+                //console.log('Update after loads and unloads considered',
+                //    Object.keys(state.loading.changedNodes.update));
+            }
 
             for (i in state.nodes) {
                 if (state.nodes.hasOwnProperty(i)) {
-                    if (newerNodes[i]) {
-                        if (newerNodes[i].hash !== state.nodes[i].hash && state.nodes[i].hash !== '') {
+                    if (newerNodes[i] && newerNodes[i].hash !== state.nodes[i].hash && state.nodes[i].hash !== '') {
+                        if (wasNodeUpdated(state.loading.changedNodes, newerNodes[i].node)) {
                             modifiedNodes.push(i);
                         }
                     }
                 }
             }
+            //console.log('NewerNodes, modifiedNodes', Object.keys(newerNodes).length, modifiedNodes.length);
             return modifiedNodes;
         }
 
@@ -1341,30 +1410,6 @@ define([
             }
         }
 
-        // FIXME: Move this to common/util
-        function orderStringArrayByElementLength(strArray) {
-            var ordered = [],
-                i, j, index;
-
-            for (i = 0; i < strArray.length; i++) {
-                index = -1;
-                j = 0;
-                while (index === -1 && j < ordered.length) {
-                    if (ordered[j].length > strArray[i].length) {
-                        index = j;
-                    }
-                    j++;
-                }
-
-                if (index === -1) {
-                    ordered.push(strArray[i]);
-                } else {
-                    ordered.splice(index, 0, strArray[i]);
-                }
-            }
-            return ordered;
-        }
-
         this.startTransaction = function (msg) {
             if (state.inTransaction) {
                 logger.error('Already in transaction, will proceed though..');
@@ -1534,12 +1579,16 @@ define([
             var modifiedPaths,
                 i;
 
+            //console.time('switchStates');
+
             logger.debug('switching project state [C#' +
                 state.commitHash + ']->[C#' + state.loading.commitHash + '] : [R#' +
                 state.rootHash + ']->[R#' + state.loading.rootHash + ']');
             refreshMetaNodes(state.nodes, state.loadNodes);
 
+            //console.time('getModifiedNodes');
             modifiedPaths = getModifiedNodes(state.loadNodes);
+            //console.timeEnd('getModifiedNodes');
             state.nodes = state.loadNodes;
             state.loadNodes = {};
 
@@ -1563,9 +1612,11 @@ define([
             } else {
                 state.loading.next(null);
             }
+
+            //console.timeEnd('switchStates');
         }
 
-        function loading(newRootHash, newCommitHash, callback) {
+        function loading(newRootHash, newCommitHash, changedNodes, callback) {
             var i, j,
                 userIds,
                 patternPaths,
@@ -1582,6 +1633,7 @@ define([
             state.loading.rootHash = newRootHash;
             state.loading.commitHash = newCommitHash;
             state.loading.next = callback;
+            state.loading.changedNodes = changedNodes;
 
             state.core.loadRoot(state.loading.rootHash, function (err, root) {
                 if (err) {
@@ -1598,7 +1650,7 @@ define([
                 };
 
                 //we first only set the counter of patterns but we also generate a completely separate pattern queue
-                //as we cannot be sure if all the users will remain at the point of giving the actual load command!!!
+                //as we cannot be sure if all the users will remain at the point of giving the actual load command!
                 userIds = Object.keys(state.users);
                 for (i = 0; i < userIds.length; i += 1) {
                     state.ongoingLoadPatternsCounter += Object.keys(state.users[userIds[i]].PATTERNS || {}).length;
@@ -1637,6 +1689,29 @@ define([
                         patternsToLoad[i].id, patternsToLoad[i].pattern, state.loadNodes, loadingPatternFinished);
                 }
             });
+        }
+
+        function wasNodeUpdated(changedNodes, node) {
+            // Is changedNodes available at all, if not emitt for all nodes.
+            if (!changedNodes) {
+                return true;
+            }
+
+            // Did the node have a collection update?
+            if (changedNodes.partialUpdate[state.core.getPath(node)] === true) {
+                return true;
+            }
+
+            // Did any of the base classes have a non-collection update?
+            while (node) {
+                if (changedNodes.update[state.core.getPath(node)] === true) {
+                    return true;
+                }
+
+                node = state.core.getBase(node);
+            }
+
+            return false;
         }
 
         function cleanUsersTerritories() {

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -207,7 +207,9 @@ define([
                 if (state.nodes[path]) {
                     //TODO we try to avoid this
                 } else {
-                    state.nodes[path] = {node: node, hash: ''/*,incomplete:true,basic:basic*/};
+                    state.nodes[path] = {
+                        node: node
+                    };
                     //TODO this only needed when real eventing will be reintroduced
                     //_inheritanceHash[path] = getInheritanceChain(node);
                 }
@@ -1143,6 +1145,7 @@ define([
                 metaNodes,
                 metaPath,
                 updatePath,
+                nodePath,
                 loadUnloadPath,
                 pathPieces,
                 i;
@@ -1186,20 +1189,22 @@ define([
                 // 3. Account for loads and unloads.
                 for (loadUnloadPath in state.loading.changedNodes.load) {
                     if (state.loading.changedNodes.load.hasOwnProperty(loadUnloadPath)) {
-                        pathPieces = loadUnloadPath.split('/');
+                        pathPieces = loadUnloadPath.split(CONSTANTS.CORE.PATH_SEP);
                         while (pathPieces.length > 2) {
                             pathPieces.pop();
-                            state.loading.changedNodes.update[pathPieces.join('/')] = true;
+                            state.loading.changedNodes
+                                .update[pathPieces.join(CONSTANTS.CORE.PATH_SEP)] = true;
                         }
                     }
                 }
 
                 for (loadUnloadPath in state.loading.changedNodes.unload) {
                     if (state.loading.changedNodes.unload.hasOwnProperty(loadUnloadPath)) {
-                        pathPieces = loadUnloadPath.split('/');
+                        pathPieces = loadUnloadPath.split(CONSTANTS.CORE.PATH_SEP);
                         while (pathPieces.length > 2) {
                             pathPieces.pop();
-                            state.loading.changedNodes.update[pathPieces.join('/')] = true;
+                            state.loading.changedNodes
+                                .update[pathPieces.join(CONSTANTS.CORE.PATH_SEP)] = true;
                         }
                     }
                 }
@@ -1208,13 +1213,11 @@ define([
                 //    Object.keys(state.loading.changedNodes.update));
             }
 
-            for (i in state.nodes) {
-                if (state.nodes.hasOwnProperty(i)) {
-                    if (newerNodes[i] && newerNodes[i].hash !== state.nodes[i].hash && state.nodes[i].hash !== '') {
-                        if (wasNodeUpdated(state.loading.changedNodes, newerNodes[i].node)) {
-                            modifiedNodes.push(i);
-                        }
-                    }
+            for (nodePath in state.nodes) {
+                if (state.nodes.hasOwnProperty(nodePath) && newerNodes.hasOwnProperty(nodePath) &&
+                    wasNodeUpdated(state.loading.changedNodes, newerNodes[nodePath].node)) {
+
+                    modifiedNodes.push(nodePath);
                 }
             }
             //console.log('NewerNodes, modifiedNodes', Object.keys(newerNodes).length, modifiedNodes.length);
@@ -1340,7 +1343,9 @@ define([
                 };
 
             if (!nodesSoFar[path]) {
-                nodesSoFar[path] = {node: node, incomplete: true, basic: true, hash: getStringHash(node)};
+                nodesSoFar[path] = {
+                    node: node
+                };
             }
             if (level > 0) {
                 if (missing > 0) {
@@ -1395,10 +1400,7 @@ define([
                         path = core.getPath(node);
                         if (!nodesSoFar[path]) {
                             nodesSoFar[path] = {
-                                node: node,
-                                incomplete: false,
-                                basic: true,
-                                hash: getStringHash(node)
+                                node: node
                             };
                         }
                         base = node;
@@ -1643,10 +1645,7 @@ define([
 
                 state.inLoading = true;
                 state.loadNodes[state.core.getPath(root)] = {
-                    node: root,
-                    incomplete: true,
-                    basic: true,
-                    hash: getStringHash(root)
+                    node: root
                 };
 
                 //we first only set the counter of patterns but we also generate a completely separate pattern queue

--- a/src/client/js/client/constants.js
+++ b/src/client/js/client/constants.js
@@ -5,12 +5,16 @@
  * @author pmeijer / https://github.com/pmeijer
  */
 
-define(['common/storage/constants'], function (STORAGE_CONSTANTS) {
+define([
+    'common/storage/constants',
+    'common/core/constants'
+], function (STORAGE_CONSTANTS, CORE_CONSTANTS) {
     'use strict';
 
     return {
 
         STORAGE: STORAGE_CONSTANTS,
+        CORE: CORE_CONSTANTS,
 
         BRANCH_STATUS: STORAGE_CONSTANTS.BRANCH_STATUS,
 

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -15,6 +15,7 @@ define([], function () {
         SET_MODIFIED_REGISTRY: '_sets_',
         MEMBER_RELATION: 'member',
         BASE_POINTER: 'base',
+        PATH_SEP: '/',
 
         NULLPTR_NAME: '_null_pointer',
         NULLPTR_RELID: '_nullptr',

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -143,7 +143,7 @@ define([
             return relid.charAt(0) !== '_';
         }
 
-        function __saveData(data) {
+        function __saveData(data, root, path) {
             ASSERT(__isMutableData(data));
 
             var done = __getEmptyData(),
@@ -157,7 +157,7 @@ define([
                 key = keys[i];
                 child = data[key];
                 if (__isMutableData(child)) {
-                    sub = __saveData(child);
+                    sub = __saveData(child, root, path + '/' + key);
                     if (sub === __getEmptyData()) {
                         delete data[key];
                     } else {
@@ -180,7 +180,19 @@ define([
                     data[ID_NAME] = hash;
 
                     done = data;
+
                     storage.insertObject(data, stackedObjects);
+                    stackedObjects[hash] = {
+                        newHash: hash,
+                        newData: data,
+                        oldHash: root.initial[path] && root.initial[path].hash,
+                        oldData: root.initial[path] && root.initial[path].data
+                    };
+
+                    root.initial[path] = {
+                        hash: hash,
+                        data: data
+                    };
                     //stackedObjects[hash] = data;
                 }
             }
@@ -196,8 +208,10 @@ define([
                 children: [],
                 data: data,
                 initial: {
-                    hash: data[storage.ID_NAME],
-                    data: data
+                    '': {
+                        hash: data[storage.ID_NAME],
+                        data: data
+                    }
                 },
                 rootid: ++rootCounter
             };
@@ -209,12 +223,18 @@ define([
         }
 
         function __loadChild2(node, newdata) {
+            var root = self.getRoot(node),
+                path = self.getPath(node);
+
             node = self.normalize(node);
 
             // TODO: this is a hack, we should avoid loading it multiple times
             if (REGEXP.DB_HASH.test(node.data)) {
                 ASSERT(node.data === newdata[ID_NAME]);
-
+                root.initial[path] = {
+                    hash: node.data,
+                    data: newdata
+                };
                 node.data = newdata;
                 __reloadChildrenData(node);
             } else {
@@ -496,7 +516,9 @@ define([
                 data: {
                     _mutable: true
                 },
-                initial: null,
+                initial: {
+                    '': null
+                },
                 rootid: ++rootCounter
             };
             root.data[ID_NAME] = '';
@@ -578,7 +600,7 @@ define([
 
                 for (var i = 0; i < roots.length; ++i) {
                     if (__isMutableData(roots[i].data)) {
-                        __saveData(roots[i].data);
+                        __saveData(roots[i].data, roots[i], '');
                     }
                 }
             }
@@ -802,7 +824,7 @@ define([
                 return {rootHash: node.data[ID_NAME], objects: {}};
             }
 
-            updated = __saveData(node.data);
+            updated = __saveData(node.data, node, '');
             if (updated !== __getEmptyData()) {
                 result = {};
                 result.objects = stackedObjects;
@@ -811,23 +833,23 @@ define([
             } else {
                 result = {rootHash: node.data[ID_NAME], objects: {}};
             }
-            if (result.objects[result.rootHash]) {
-                if (gmeConfig.storage.patchRootCommunicationEnabled && node.initial) {
-                    //TODO this method will change when we will pack similar data for every node
-                    result.objects[result.rootHash] = {
-                        newData: result.objects[result.rootHash],
-                        newHash: result.rootHash,
-                        oldData: node.initial.data,
-                        oldHash: node.initial.hash
-                    };
-                }
-
-                node.initial = {
-                    data: result.objects[result.rootHash].newData || result.objects[result.rootHash],
-                    hash: result.rootHash
-                };
-
-            }
+            //if (result.objects[result.rootHash]) {
+            //    if (gmeConfig.storage.patchRootCommunicationEnabled && node.initial) {
+            //        //TODO this method will change when we will pack similar data for every node
+            //        result.objects[result.rootHash] = {
+            //            newData: result.objects[result.rootHash],
+            //            newHash: result.rootHash,
+            //            oldData: node.initial.data,
+            //            oldHash: node.initial.hash
+            //        };
+            //    }
+            //
+            //    node.initial = {
+            //        data: result.objects[result.rootHash].newData || result.objects[result.rootHash],
+            //        hash: result.rootHash
+            //    };
+            //
+            //}
 
             return result;
         };

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -383,7 +383,7 @@ define([
             //handling patch object creation
             //console.time('patch-computation');
             for (i = 0; i < keys.length; i += 1) {
-                if (UTIL.isPatchObjectFromCore(coreObjects[keys[i]])) {
+                if (UTIL.coreObjectHasOldAndNewData(coreObjects[keys[i]])) {
                     // Patch type object.
                     persistQueueElement[keys[i]] = coreObjects[keys[i]].newData;
                     if (keys[i] === rootHash) {
@@ -391,9 +391,9 @@ define([
                     }
                     commitData.coreObjects[keys[i]] = UTIL.getPatchObject(coreObjects[keys[i]].oldData,
                         coreObjects[keys[i]].newData);
-                    if (keys[i] === rootHash) {
+                    //if (keys[i] === rootHash) {
                         //console.timeEnd('root-patch-computation');
-                    }
+                    //}
                 } else if (coreObjects[keys[i]].newData) {
                     // A new object with no previous data (send the entire data).
                     commitData.coreObjects[keys[i]] = coreObjects[keys[i]].newData;

--- a/src/common/storage/util.js
+++ b/src/common/storage/util.js
@@ -52,7 +52,7 @@ define(['common/storage/constants', 'common/util/jsonPatcher'], function (CONSTA
 
             return patchObject;
         },
-        isPatchObjectFromCore: function (coreObj) {
+        coreObjectHasOldAndNewData: function (coreObj) {
             return !!(coreObj.oldHash && coreObj.newHash && coreObj.oldData && coreObj.newData);
         },
         getChangedNodes: jsonPatcher.getChangedNodes,

--- a/src/common/storage/util.js
+++ b/src/common/storage/util.js
@@ -52,6 +52,10 @@ define(['common/storage/constants', 'common/util/jsonPatcher'], function (CONSTA
 
             return patchObject;
         },
+        isPatchObjectFromCore: function (coreObj) {
+            return !!(coreObj.oldHash && coreObj.newHash && coreObj.oldData && coreObj.newData);
+        },
+        getChangedNodes: jsonPatcher.getChangedNodes,
         applyPatch: jsonPatcher.apply
     };
 });

--- a/src/common/util/jsonPatcher.js
+++ b/src/common/util/jsonPatcher.js
@@ -204,6 +204,10 @@ define([
         return d >= 0 && str.lastIndexOf(pattern) === d;
     }
 
+    function _startsWith(str, pattern) {
+        return str.indexOf(pattern) === 0;
+    }
+
     function _isOvr(path) {
         return path.indexOf('/ovr/') === 0;
     }
@@ -252,14 +256,14 @@ define([
 
         updatesPath = Object.keys(res.update);
         for (i = 0; i < updatesPath; i += 1) {
-            if (updatesPath[i].indexOf(gmePath) === 0) {
+            if (_startsWith(updatesPath[i], gmePath)) {
                 delete res.update[gmePath];
             }
         }
 
         updatesPath = Object.keys(res.partialUpdate);
         for (i = 0; i < updatesPath; i += 1) {
-            if (updatesPath[i].indexOf(gmePath) === 0) {
+            if (_startsWith(updatesPath[i], gmePath)) {
                 delete res.partialUpdate[gmePath];
             }
         }

--- a/src/common/util/jsonPatcher.js
+++ b/src/common/util/jsonPatcher.js
@@ -9,7 +9,11 @@
  * @author kecso / https://github.com/kecso
  */
 
-define(['common/util/canon'], function (CANON) {
+define([
+    'common/util/canon',
+    'common/util/random',
+    'common/core/constants'
+], function (CANON, RANDOM, CORE_CONSTANTS) {
 
     'use strict';
 
@@ -31,17 +35,26 @@ define(['common/util/canon'], function (CANON) {
                 for (i in target) {
                     if (excludeList.indexOf(i) === -1 && target.hasOwnProperty(i)) {
                         if (!source.hasOwnProperty(i)) {
-                            patch.push({op: 'add', path: basePath + _strEncode(i), value: target[i]});
+                            patch.push({
+                                op: 'add',
+                                path: basePath + _strEncode(i),
+                                value: target[i]
+                            });
                         }
                     }
                 }
 
-                //update
+                //replace
                 if (!noUpdate) {
                     for (i in target) {
                         if (excludeList.indexOf(i) === -1 && target.hasOwnProperty(i)) {
                             if (source.hasOwnProperty(i) && CANON.stringify(source[i]) !== CANON.stringify(target[i])) {
-                                patch.push({op: 'replace', path: basePath + _strEncode(i), value: target[i]});
+                                patch.push({
+                                    op: 'replace',
+                                    path: basePath + _strEncode(i),
+                                    value: target[i]
+                                    //oldValue: source[i]
+                                });
                             }
                         }
                     }
@@ -51,7 +64,11 @@ define(['common/util/canon'], function (CANON) {
                 for (i in source) {
                     if (excludeList.indexOf(i) === -1 && source.hasOwnProperty(i)) {
                         if (!target.hasOwnProperty(i)) {
-                            patch.push({op: 'remove', path: basePath + _strEncode(i)});
+                            patch.push({
+                                op: 'remove',
+                                path: basePath + _strEncode(i)
+                                //oldValue: source[i]
+                            });
                         }
                     }
                 }
@@ -182,8 +199,167 @@ define(['common/util/canon'], function (CANON) {
         return result;
     }
 
+    function _endsWith(str, pattern) {
+        var d = str.length - pattern.length;
+        return d >= 0 && str.lastIndexOf(pattern) === d;
+    }
+
+    function _isOvr(path) {
+        return path.indexOf('/ovr/') === 0;
+    }
+
+    function _isRelid(path) {
+        return RANDOM.isValidRelid(path.substring(1));
+    }
+
+    function _isGmePath(path) {
+        var relIds = path.split('/'),
+            result = false,
+            i;
+
+        for (i = 1; i < relIds.length; i += 1) {
+            if (RANDOM.isValidRelid(relIds[i]) === false) {
+                return false;
+            } else {
+                result = true;
+            }
+        }
+
+        return result;
+    }
+
+    function _inLoadOrUnload(res, gmePath) {
+        var pathPieces = gmePath.split('/'),
+            parentPath;
+
+        parentPath = gmePath;
+
+        do {
+            if (res.load[parentPath] || res.unload[parentPath]) {
+                return true;
+            }
+
+            pathPieces.pop();
+            parentPath = pathPieces.join('/');
+        } while (pathPieces.length > 1);
+
+        return false;
+    }
+
+    function _removeFromUpdates(res, gmePath) {
+        var updatesPath,
+            i;
+
+        updatesPath = Object.keys(res.update);
+        for (i = 0; i < updatesPath; i += 1) {
+            if (updatesPath[i].indexOf(gmePath) === 0) {
+                delete res.update[gmePath];
+            }
+        }
+
+        updatesPath = Object.keys(res.partialUpdate);
+        for (i = 0; i < updatesPath; i += 1) {
+            if (updatesPath[i].indexOf(gmePath) === 0) {
+                delete res.partialUpdate[gmePath];
+            }
+        }
+    }
+
+    function _getChangedNodesRec(patch, res, hash, gmePath) {
+        var nodePatches = patch[hash] && patch[hash].patch, // Changes regarding node with hash
+            i,
+            ownChange = false,
+            pathPieces,
+            relGmePath,
+            absGmePath,
+            patchPath;
+
+        if (!nodePatches) {
+            // E.g. if the node was added the full data is given instead of a patch.
+            return;
+        }
+
+        for (i = 0; i < nodePatches.length; i += 1) {
+            patchPath = nodePatches[i].path;
+
+            if (_isOvr(patchPath) === true) {
+                pathPieces = patchPath.substring('/ovr/'.length).split('/');
+                relGmePath = _strDecode(pathPieces[0]);
+                absGmePath = gmePath + relGmePath;
+                if (_isGmePath(relGmePath) && _inLoadOrUnload(res, absGmePath) === false) {
+                    if (pathPieces.length === 1) {
+                        // The entire stored overlay was removed/added - trigger a full event.
+                        // TODO: There are rare cases where only partialUpdates should be triggered.
+                        res.update[absGmePath] = true;
+                    } else if (pathPieces.length === 2) {
+                        if (_endsWith(pathPieces[1], CORE_CONSTANTS.COLLECTION_NAME_SUFFIX)) {
+                            // Target-change - only trigger event for the actual node.
+                            res.partialUpdate[absGmePath] = true;
+                        } else {
+                            // Source-change - trigger full event.
+                            res.update[absGmePath] = true;
+                        }
+                    } else {
+                        throw new Error('pathPieces longer than 2 ' + nodePatches[i]);
+                    }
+                } else if (relGmePath === '/_nullptr') {
+                    ownChange = true;
+                }
+
+            } else if (_isRelid(patchPath) === true) {
+                // There was a change in one of the children..
+                switch (nodePatches[i].op) {
+                    case 'add':
+                        res.load[gmePath + patchPath] = true;
+                        _removeFromUpdates(res, gmePath + patchPath);
+                        break;
+                    case 'remove':
+                        res.unload[gmePath + patchPath] = true;
+                        _removeFromUpdates(res, gmePath + patchPath);
+                        break;
+                    case 'replace':
+                        _getChangedNodesRec(patch, res, nodePatches[i].value, gmePath + patchPath);
+                        break;
+                    default:
+                        throw new Error('Unexpected patch operation ' + nodePatches[i]);
+                }
+            } else {
+                ownChange = true;
+            }
+        }
+
+        if (ownChange) {
+            res.update[gmePath] = true;
+        }
+    }
+
+    /**
+     *
+     * @param {object} patch
+     * @returns {object}
+     */
+    function getChangedNodes(patch, rootHash) {
+        var res;
+
+        if (patch[rootHash] && patch[rootHash].patch) {
+            res = {
+                load: {},
+                unload: {},
+                update: {},
+                partialUpdate: {}
+            };
+
+            _getChangedNodesRec(patch, res, rootHash, '');
+        } else {
+            res = null;
+        }
+
+        return res;
+    }
+
     return {
         create: create,
-        apply: apply
+        apply: apply,
+        getChangedNodes: getChangedNodes
     };
 });

--- a/src/common/util/util.js
+++ b/src/common/util/util.js
@@ -29,8 +29,34 @@ define([], function () {
         }
     }
 
+    function orderStringArrayByElementLength(strArray) {
+        var ordered = [],
+            i, j, index;
+
+        for (i = 0; i < strArray.length; i += 1) {
+            index = -1;
+            j = 0;
+            while (index === -1 && j < ordered.length) {
+                if (ordered[j].length > strArray[i].length) {
+                    index = j;
+                }
+
+                j += 1;
+            }
+
+            if (index === -1) {
+                ordered.push(strArray[i]);
+            } else {
+                ordered.splice(index, 0, strArray[i]);
+            }
+        }
+
+        return ordered;
+    }
+
     return {
         isTrueObject: isTrueObject,
-        updateFieldsRec: updateFieldsRec
+        updateFieldsRec: updateFieldsRec,
+        orderStringArrayByElementLength: orderStringArrayByElementLength
     };
 })

--- a/src/server/storage/userproject.js
+++ b/src/server/storage/userproject.js
@@ -88,7 +88,7 @@ function UserProject(dbProject, storage, mainLogger, gmeConfig) {
             i;
 
         for (i = 0; i < keys.length; i += 1) {
-            if (UTIL.isPatchObjectFromCore(coreObjects[keys[i]])) {
+            if (UTIL.coreObjectHasOldAndNewData(coreObjects[keys[i]])) {
                 // Patch type object.
                 data.coreObjects[keys[i]] = UTIL.getPatchObject(coreObjects[keys[i]].oldData,
                     coreObjects[keys[i]].newData);

--- a/src/server/storage/userproject.js
+++ b/src/server/storage/userproject.js
@@ -9,6 +9,7 @@
 
 var CONSTANTS = requireJS('common/storage/constants'),
     GENKEY = requireJS('common/util/key'),
+    UTIL = requireJS('common/storage/util'),
     ProjectInterface = requireJS('common/storage/project/interface');
 
 /**
@@ -76,13 +77,32 @@ function UserProject(dbProject, storage, mainLogger, gmeConfig) {
     // Functions defined in ProjectInterface
     this.makeCommit = function (branchName, parents, rootHash, coreObjects, msg, callback) {
         var self = this,
+            keys = Object.keys(coreObjects),
             data = {
                 username: self.userName,
                 projectId: self.projectId,
                 commitObject: self.createCommitObject(parents, rootHash, null, msg),
-                coreObjects: coreObjects
-            };
+                coreObjects: {},
+                changedNodes: null
+            },
+            i;
 
+        for (i = 0; i < keys.length; i += 1) {
+            if (UTIL.isPatchObjectFromCore(coreObjects[keys[i]])) {
+                // Patch type object.
+                data.coreObjects[keys[i]] = UTIL.getPatchObject(coreObjects[keys[i]].oldData,
+                    coreObjects[keys[i]].newData);
+            } else if (coreObjects[keys[i]].newData) {
+                // A new object with no previous data (send the entire data).
+                data.coreObjects[keys[i]] = coreObjects[keys[i]].newData;
+            } else {
+                // A regular object.
+                // TODO: Is this deprecated?
+                data.coreObjects[keys[i]] = coreObjects[keys[i]];
+            }
+        }
+
+        data.changedNodes = UTIL.getChangedNodes(data.coreObjects, rootHash);
         if (branchName) {
             data.branchName = branchName;
         }

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -1946,7 +1946,7 @@ describe('GME client', function () {
                 } else if (tOneState === 'modified') {
                     //finally our modification should generate events
                     //the number of events should remain the same as the newObject will not generate one!
-                    expect(events).to.have.length(8);
+                    expect(events).to.have.length(5);
                     eventPaths = getEventPaths(events);
                     expect(eventPaths).not.to.include.members([newNodePath]);
                     for (i = 1; i < events.length; i += 1) {
@@ -2012,7 +2012,7 @@ describe('GME client', function () {
                 } else if (tOneState === 'modified') {
                     //finally our modification should generate events
                     //the number of events should remain the same as the newObject will not generate one!
-                    expect(events).to.have.length(8);
+                    expect(events).to.have.length(5);
                     eventPaths = getEventPaths(events);
                     expect(eventPaths).not.to.include.members([newnodePath]);
                     for (i = 1; i < events.length; i += 1) {
@@ -2413,7 +2413,8 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            'should set the given pointer of the node to the specified target');
                         expect(events).to.include({eid: '/323573539', etype: 'update'});
                         expect(events).to.include({eid: '/1', etype: 'update'});
 
@@ -2550,7 +2551,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(8);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2635,7 +2636,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(8);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2723,7 +2724,10 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(8);
+                    events.forEach(function (e) {
+                        console.log(e);
+                    });
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2815,7 +2819,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(5);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2902,7 +2906,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(4);
                     expect(events).to.include({eid: '', etype: 'update'});
 
                     for (i = 1; i < events.length; i++) {
@@ -2921,7 +2925,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getAttribute('name')).to.equal('check');
                     expect(node.getRegistry('position')).to.deep.equal({x: 200, y: 300});
-                    expect(node.getChildrenIds()).to.have.length(3);
+                    expect(node.getChildrenIds()).to.have.length(3, 'should create a child');
                 }
             });
         });
@@ -2959,7 +2963,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(4);
                     expect(events).to.include({eid: '', etype: 'update'});
 
                     for (i = 1; i < events.length; i++) {
@@ -2977,7 +2981,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getAttribute('name')).to.equal('check');
                     expect(node.getRegistry('position')).to.deep.equal({x: 100, y: 100});
-                    expect(node.getChildrenIds()).to.have.length(3);
+                    expect(node.getChildrenIds()).to.have.length(3, 'should create a child at default position');
                 }
             });
         });
@@ -3035,7 +3039,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(11);
+                    expect(events).to.have.length(8);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -3130,7 +3134,7 @@ describe('GME client', function () {
                 if (testState === 'containerCreated') {
                     testState = 'territoryExtended';
 
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(4);
 
                     for (i = 1; i < events.length; i++) {
                         if (initialPaths.indexOf(events[i].eid) === -1) {
@@ -3166,7 +3170,7 @@ describe('GME client', function () {
 
                 if (testState === 'final') {
 
-                    expect(events).to.have.length(11);
+                    expect(events).to.have.length(9);
                     expect(events).to.include({eid: '/1697300825', etype: 'unload'});
                     expect(events).to.include({eid: '/1400778473', etype: 'unload'});
                     expect(events).to.include({eid: containerId + '/1697300825', etype: 'load'});
@@ -3300,7 +3304,8 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'checking';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[first] should add the given node as a new member to the specified set of our node');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3313,7 +3318,8 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[second] should add the given node as a new member to the specified set of our node');
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3340,7 +3346,8 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'checking';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[first] should remove the given member of the specified set of the node');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3353,7 +3360,8 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[second] should remove the given member of the specified set of the node');
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3380,7 +3388,8 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'checking';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            'should set the given attribute of the specified member of the set');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3398,7 +3407,7 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2);
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3433,7 +3442,8 @@ describe('GME client', function () {
                 function (events) {
                     if (testState === 'init') {
                         testState = 'add';
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            'should remove the specific attribute of the set member');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3452,7 +3462,7 @@ describe('GME client', function () {
 
                     if (testState === 'add') {
                         testState = 'del';
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2);
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
                         expect(node.getMemberIds('set')).to.include('/1697300825');
@@ -3468,7 +3478,7 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'del') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2);
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
                         expect(node.getMemberIds('set')).to.include('/1697300825');
@@ -3495,7 +3505,7 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'checking';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3, 'should set the given registry key of the set member');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3513,7 +3523,7 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2);
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3549,7 +3559,8 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'add';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[first] should remove the specified registry key of the set member');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/1697300825', etype: 'load'});
 
@@ -3568,7 +3579,8 @@ describe('GME client', function () {
 
                     if (testState === 'add') {
                         testState = 'del';
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2,
+                            '[second] should remove the specified registry key of the set member');
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3585,7 +3597,8 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'del') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(2,
+                            '[thrid] should remove the specified registry key of the set member');
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
@@ -3651,7 +3664,8 @@ describe('GME client', function () {
                     if (testState === 'init') {
                         testState = 'checking';
 
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[first] should remove the given set of the node');
                         expect(events).to.include({eid: '/323573539', etype: 'load'});
                         expect(events).to.include({eid: '/701504349', etype: 'load'});
 
@@ -3668,7 +3682,8 @@ describe('GME client', function () {
                     }
 
                     if (testState === 'checking') {
-                        expect(events).to.have.length(3);
+                        expect(events).to.have.length(3,
+                            '[second] should remove the given set of the node');
 
                         node = client.getNode('/701504349');
                         expect(node).not.to.equal(null);
@@ -3726,7 +3741,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(4);
                     expect(events).to.include({eid: newId, etype: 'load'});
 
                     node = client.getNode(newId);
@@ -3774,7 +3789,7 @@ describe('GME client', function () {
                 }
 
                 if (testState === 'checking') {
-                    expect(events).to.have.length(9);
+                    expect(events).to.have.length(3);
                     expect(events).to.include({eid: newId, etype: 'load'});
 
                     node = client.getNode(newId);

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2727,7 +2727,7 @@ describe('GME client', function () {
                     events.forEach(function (e) {
                         console.log(e);
                     });
-                    expect(events).to.have.length(6);
+                    expect(events).to.have.length(7);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {

--- a/test/common/core/coretree.spec.js
+++ b/test/common/core/coretree.spec.js
@@ -350,7 +350,7 @@ describe('CoreTree', function () {
             expect(coreTree.getProperty(root, 'prop')).to.equal('valueOne');
             child = coreTree.createChild(root);
 
-            expect(root.initial.hash).to.equal(hashes[0]);
+            expect(root.initial[''].hash).to.equal(hashes[0]);
 
             coreTree.setProperty(child, 'prop', 'childValue');
             coreTree.setProperty(root, 'prop', 'secondValue');
@@ -359,7 +359,7 @@ describe('CoreTree', function () {
             expect(persisted.rootHash).not.to.equal(undefined);
 
             hashes.unshift(persisted.rootHash);
-            expect(root.initial.hash).to.equal(hashes[0]);
+            expect(root.initial[''].hash).to.equal(hashes[0]);
 
             expect(coreTree.getProperty(root, 'prop')).to.equal('secondValue');
             expect(coreTree.getProperty(child, 'prop')).to.equal('childValue');
@@ -373,7 +373,7 @@ describe('CoreTree', function () {
             expect(persisted.rootHash).not.to.equal(undefined);
 
             hashes.unshift(persisted.rootHash);
-            expect(root.initial.hash).to.equal(hashes[0]);
+            expect(root.initial[''].hash).to.equal(hashes[0]);
 
             expect(coreTree.getProperty(root, 'prop')).to.equal('secondValue');
             expect(coreTree.getProperty(child, 'prop')).to.equal('finalValue');

--- a/test/common/util/jsonPatcher.spec.js
+++ b/test/common/util/jsonPatcher.spec.js
@@ -1,6 +1,8 @@
+// jscs:disable
 /*jshint node:true, mocha:true, expr:true*/
 /**
  * @author kecso / https://github.com/kecso
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 var testFixture = require('../../_globals.js');
@@ -50,11 +52,11 @@ describe('jsonPatcher', function () {
         });
 
         it('should remove an inner field', function () {
-            var result = patcher.apply({one:{two:3}}, [{op: 'remove', path: '/one/two'}]);
+            var result = patcher.apply({one: {two: 3}}, [{op: 'remove', path: '/one/two'}]);
 
             expect(result.status).to.equal('success');
             expect(result.faults).to.have.length(0);
-            expect(result.result).to.eql({one:{}});
+            expect(result.result).to.eql({one: {}});
         });
 
         it('should fail to patch if operation path is not a string', function () {
@@ -679,6 +681,993 @@ describe('jsonPatcher', function () {
             //the _id field is ignored during patch so we have to set that manually
             patchRoot.result._id = tRootData._id;
             expect(patchRoot.result).to.eql(tRootData);
+        });
+    });
+
+    describe('getChangedNodes', function () {
+
+        describe('atomic UI changes', function () {
+            it('should trigger node update on rename', function () {
+                var patch = {
+                        "#fb0486e86f0ad0898912e0b4e255122e0350aeb4": {
+                            "type": "patch",
+                            "base": "#8fecce4f3794188b854414a80fd9638fc1d07e68",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/atr/name",
+                                    "value": "newName"
+                                }
+                            ],
+                            "_id": "#fb0486e86f0ad0898912e0b4e255122e0350aeb4"
+                        },
+                        "#16092f7ac5d8f1e24f0de9d98b7a81d06aa5b338": {
+                            "type": "patch",
+                            "base": "#a6293984b74258e3545fc97f2b1fc2755fcdd305",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/0",
+                                    "value": "#fb0486e86f0ad0898912e0b4e255122e0350aeb4"
+                                }
+                            ],
+                            "_id": "#16092f7ac5d8f1e24f0de9d98b7a81d06aa5b338"
+                        }
+                    },
+                    rootHash = "#16092f7ac5d8f1e24f0de9d98b7a81d06aa5b338",
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {},
+                    "unload": {},
+                    "update": {
+                        "/0": true
+                    }
+                });
+            });
+
+            it('should trigger root and src update, and partial for target when assigning ptr', function () {
+                var patch = {
+                        "#133828453a145c33dbf15e575a78fc643769e261": {
+                            "type": "patch",
+                            "base": "#16092f7ac5d8f1e24f0de9d98b7a81d06aa5b338",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2f0/pointer-inv",
+                                    "value": [
+                                        "/V/t"
+                                    ]
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fV%2ft/pointer",
+                                    "value": "/0"
+                                }
+                            ],
+                            "_id": "#133828453a145c33dbf15e575a78fc643769e261"
+                        }
+                    },
+                    rootHash = '#133828453a145c33dbf15e575a78fc643769e261',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/0": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/V/t": true
+                    }
+                });
+            });
+
+            it('should trigger partial for base and load for new node', function () {
+                var patch = {
+                        "#d19c1afb79df6d2f1f4fd8f36ac246758bbdd03d": {
+                            "_id": "#d19c1afb79df6d2f1f4fd8f36ac246758bbdd03d",
+                            "atr": {
+                                "_relguid": "6192aa8225261b0f1bded6a1cf46ab5d"
+                            },
+                            "reg": {
+                                "position": {
+                                    "x": 323,
+                                    "y": 462
+                                }
+                            }
+                        },
+                        "#b5531098ab865da6929de708187f4bf069b6bdf1": {
+                            "type": "patch",
+                            "base": "#133828453a145c33dbf15e575a78fc643769e261",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/z",
+                                    "value": "#d19c1afb79df6d2f1f4fd8f36ac246758bbdd03d"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fz",
+                                    "value": {
+                                        "base": "/X"
+                                    }
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fX/base-inv",
+                                    "value": [
+                                        "/H",
+                                        "/6",
+                                        "/V/t",
+                                        "/z"
+                                    ]
+                                }
+                            ],
+                            "_id": "#b5531098ab865da6929de708187f4bf069b6bdf1"
+                        }
+                    },
+                    rootHash = '#b5531098ab865da6929de708187f4bf069b6bdf1',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {
+                        "/z": true
+                    },
+                    "partialUpdate": {
+                        "/X": true
+                    },
+                    "unload": {},
+                    "update": {}
+                });
+            });
+
+            it('should trigger partial for base and load for new node (w/o new node data)', function () {
+                var patch = {
+                        "#b5531098ab865da6929de708187f4bf069b6bdf1": {
+                            "type": "patch",
+                            "base": "#133828453a145c33dbf15e575a78fc643769e261",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/z",
+                                    "value": "#d19c1afb79df6d2f1f4fd8f36ac246758bbdd03d"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fz",
+                                    "value": {
+                                        "base": "/X"
+                                    }
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fX/base-inv",
+                                    "value": [
+                                        "/H",
+                                        "/6",
+                                        "/V/t",
+                                        "/z"
+                                    ]
+                                }
+                            ],
+                            "_id": "#b5531098ab865da6929de708187f4bf069b6bdf1"
+                        }
+                    },
+                    rootHash = '#b5531098ab865da6929de708187f4bf069b6bdf1',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {
+                        "/z": true
+                    },
+                    "partialUpdate": {
+                        "/X": true
+                    },
+                    "unload": {},
+                    "update": {}
+                });
+            });
+
+            it('should partial for base and load for new child node', function () {
+                var patch = {
+                        "#a8c328811b2be4f51bbb47f99a0a11b4cd3d29f5": {
+                            "_id": "#a8c328811b2be4f51bbb47f99a0a11b4cd3d29f5",
+                            "atr": {
+                                "_relguid": "4da61ec306c8adbb310ca8f48e95fbce"
+                            },
+                            "reg": {
+                                "position": {
+                                    "x": 349,
+                                    "y": 397
+                                }
+                            }
+                        },
+                        "#4cc8d5613f6f0ebacab8ef26d36e5cad5b5411ca": {
+                            "type": "patch",
+                            "base": "#0f663cc6808d813ccb35b518e02244766c141e99",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/0",
+                                    "value": "#a8c328811b2be4f51bbb47f99a0a11b4cd3d29f5"
+                                }
+                            ],
+                            "_id": "#4cc8d5613f6f0ebacab8ef26d36e5cad5b5411ca"
+                        },
+                        "#086ab52b1eda9e280f7ecad2860d328ef635df04": {
+                            "type": "patch",
+                            "base": "#133828453a145c33dbf15e575a78fc643769e261",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/V",
+                                    "value": "#4cc8d5613f6f0ebacab8ef26d36e5cad5b5411ca"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fV%2f0",
+                                    "value": {
+                                        "base": "/X"
+                                    }
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fX/base-inv",
+                                    "value": [
+                                        "/H",
+                                        "/6",
+                                        "/V/t",
+                                        "/V/0"
+                                    ]
+                                }
+                            ],
+                            "_id": "#086ab52b1eda9e280f7ecad2860d328ef635df04"
+                        }
+                    },
+                    rootHash = '#086ab52b1eda9e280f7ecad2860d328ef635df04',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {
+                        "/V/0": true
+                    },
+                    "partialUpdate": {
+                        "/X": true
+                    },
+                    "unload": {},
+                    "update": {}
+                });
+            });
+
+            it('should trigger node update, partial for new- and old-target when setting pointer of child', function () {
+                var patch = {
+                        "#560c2be25f858cc2b9847bcf69fff47273bb2a3b": {
+                            "type": "patch",
+                            "base": "#78e88668266c4e6832109975278f1174fb01a814",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fH/pointer-inv",
+                                    "value": [
+                                        "/X",
+                                        "/V/0/8"
+                                    ]
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fJ/pointer-inv"
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fV%2f0%2f8/pointer",
+                                    "value": "/H"
+                                }
+                            ],
+                            "_id": "#560c2be25f858cc2b9847bcf69fff47273bb2a3b"
+                        }
+                    },
+                    rootHash = '#560c2be25f858cc2b9847bcf69fff47273bb2a3b',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/H": true,
+                        "/J": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/V/0/8": true
+                    }
+                });
+            });
+
+            it('should trigger node update and partial for new member when adding first to set', function () {
+                var patch = {
+                        "#1e6a11ebcb0422c5fa27779e17768764e309f9be": {
+                            "type": "patch",
+                            "base": "#c3d75c6ef45a4e29b4bfaec3e3d772decbb95a30",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/reg/_sets_",
+                                    "value": 12
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/_sets/MYSET/1596560450",
+                                    "value": {
+                                        "reg": {
+                                            "_": "_",
+                                            "position": {
+                                                "x": 899,
+                                                "y": 156
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "_id": "#1e6a11ebcb0422c5fa27779e17768764e309f9be"
+                        },
+                        "#a07ec3f1ae81107e65a31b344306b8856c82f92b": {
+                            "type": "patch",
+                            "base": "#3fddf3b7385ee43bf5a81a33e85fd0c370003323",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/x",
+                                    "value": "#1e6a11ebcb0422c5fa27779e17768764e309f9be"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fx%2f_sets%2fMYSET%2f1596560450",
+                                    "value": {
+                                        "member": "/6"
+                                    }
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2f6/member-inv",
+                                    "value": [
+                                        "/x/_sets/MYSET/1596560450"
+                                    ]
+                                }
+                            ],
+                            "_id": "#a07ec3f1ae81107e65a31b344306b8856c82f92b"
+                        }
+                    },
+                    rootHash = '#a07ec3f1ae81107e65a31b344306b8856c82f92b',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/6": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/x": true
+                    }
+                });
+            });
+
+            it('should trigger node update and partial for new member when adding second to set', function () {
+                var patch = {
+                        "#7641989e3645c9a5000a79740d943dc6be31fef9": {
+                            "type": "patch",
+                            "base": "#1e6a11ebcb0422c5fa27779e17768764e309f9be",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/reg/_sets_",
+                                    "value": 15
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/_sets/MYSET/2107174038",
+                                    "value": {
+                                        "reg": {
+                                            "_": "_",
+                                            "position": {
+                                                "x": 448,
+                                                "y": 225
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "_id": "#7641989e3645c9a5000a79740d943dc6be31fef9"
+                        },
+                        "#afc5c6d1102f217bb6691b7ac734050c3a399b13": {
+                            "type": "patch",
+                            "base": "#a07ec3f1ae81107e65a31b344306b8856c82f92b",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/x",
+                                    "value": "#7641989e3645c9a5000a79740d943dc6be31fef9"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fx%2f_sets%2fMYSET%2f2107174038",
+                                    "value": {
+                                        "member": "/s"
+                                    }
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fs/member-inv",
+                                    "value": [
+                                        "/x/_sets/MYSET/2107174038"
+                                    ]
+                                }
+                            ],
+                            "_id": "#afc5c6d1102f217bb6691b7ac734050c3a399b13"
+                        }
+                    },
+                    rootHash = '#afc5c6d1102f217bb6691b7ac734050c3a399b13',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/s": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/x": true
+                    }
+                });
+            });
+
+            it('should trigger node update and partial for new member when removing from set', function () {
+                var patch = {
+                        "#22af45dbf74b6df70a0450ef7c311e223fa3a060": {
+                            "type": "patch",
+                            "base": "#7641989e3645c9a5000a79740d943dc6be31fef9",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/reg/_sets_",
+                                    "value": 16
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/_sets/MYSET/2107174038"
+                                }
+                            ],
+                            "_id": "#22af45dbf74b6df70a0450ef7c311e223fa3a060"
+                        },
+                        "#16acc59ac9a618367025a1be86c3e5be3d43b170": {
+                            "type": "patch",
+                            "base": "#afc5c6d1102f217bb6691b7ac734050c3a399b13",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/x",
+                                    "value": "#22af45dbf74b6df70a0450ef7c311e223fa3a060"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fx%2f_sets%2fMYSET%2f2107174038"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fs/member-inv"
+                                }
+                            ],
+                            "_id": "#16acc59ac9a618367025a1be86c3e5be3d43b170"
+                        }
+                    },
+                    rootHash = '#16acc59ac9a618367025a1be86c3e5be3d43b170',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/s": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/x": true
+                    }
+                });
+            });
+
+            it('should trigger node update and partial for new member when removing last from set', function () {
+                var patch = {
+                        "#eb8393c403ce1ef5459f1a3eec65393ab29373fd": {
+                            "type": "patch",
+                            "base": "#22af45dbf74b6df70a0450ef7c311e223fa3a060",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/reg/_sets_",
+                                    "value": 17
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/_sets/MYSET/1596560450"
+                                }
+                            ],
+                            "_id": "#eb8393c403ce1ef5459f1a3eec65393ab29373fd"
+                        },
+                        "#3950c5a6f043bac0324a89035631f3060217a779": {
+                            "type": "patch",
+                            "base": "#16acc59ac9a618367025a1be86c3e5be3d43b170",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/x",
+                                    "value": "#eb8393c403ce1ef5459f1a3eec65393ab29373fd"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fx%2f_sets%2fMYSET%2f1596560450"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2f6/member-inv"
+                                }
+                            ],
+                            "_id": "#3950c5a6f043bac0324a89035631f3060217a779"
+                        }
+                    },
+                    rootHash = '#3950c5a6f043bac0324a89035631f3060217a779',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/6": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/x": true
+                    }
+                });
+            });
+
+            it('should trigger node update and partial for new member when removing last from set', function () {
+                var patch = {
+                        "#eb8393c403ce1ef5459f1a3eec65393ab29373fd": {
+                            "type": "patch",
+                            "base": "#22af45dbf74b6df70a0450ef7c311e223fa3a060",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/reg/_sets_",
+                                    "value": 17
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/_sets/MYSET/1596560450"
+                                }
+                            ],
+                            "_id": "#eb8393c403ce1ef5459f1a3eec65393ab29373fd"
+                        },
+                        "#3950c5a6f043bac0324a89035631f3060217a779": {
+                            "type": "patch",
+                            "base": "#16acc59ac9a618367025a1be86c3e5be3d43b170",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/x",
+                                    "value": "#eb8393c403ce1ef5459f1a3eec65393ab29373fd"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fx%2f_sets%2fMYSET%2f1596560450"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2f6/member-inv"
+                                }
+                            ],
+                            "_id": "#3950c5a6f043bac0324a89035631f3060217a779"
+                        }
+                    },
+                    rootHash = '#3950c5a6f043bac0324a89035631f3060217a779',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/6": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/x": true
+                    }
+                });
+            });
+
+            it('should trigger partial for bases and one unload when removing tree', function () {
+                var patch = {
+                        "#95890feca384fcf91ab3882a6af8dc2b3f663560": {
+                            "type": "patch",
+                            "base": "#91bf42c5702877278421c9e38c0154b79b02fc84",
+                            "patch": [
+                                {
+                                    "op": "remove",
+                                    "path": "/f"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2ff"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2ff%2fb"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2ff%2fb%2fB"
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2f5/base-inv",
+                                    "value": [
+                                        "/x"
+                                    ]
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fx/base-inv"
+                                }
+                            ],
+                            "_id": "#95890feca384fcf91ab3882a6af8dc2b3f663560"
+                        }
+                    },
+                    rootHash = '#95890feca384fcf91ab3882a6af8dc2b3f663560',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/5": true,
+                        "/x": true
+                    },
+                    "unload": {
+                        "/f": true
+                    },
+                    "update": {}
+                });
+            });
+
+            it('should trigger partial for target and update for node when adding meta-relation rule', function () {
+                var patch = {
+                        "#d199d3d4c68aaabef85057ed45543c22ec503e9b": {
+                            "type": "patch",
+                            "base": "#7cecebfd8dfa56113037e18fe218eb7e3e369524",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/_meta",
+                                    "value": {
+                                        "_nullptr": {
+                                            "atr": {
+                                                "name": "_null_pointer"
+                                            }
+                                        },
+                                        "ovr": {
+                                            "": {
+                                                "dst": "/_nullptr"
+                                            },
+                                            "/_nullptr": {
+                                                "dst-inv": [
+                                                    ""
+                                                ]
+                                            }
+                                        },
+                                        "_p_dst": {
+                                            "_sets": {
+                                                "items": {
+                                                    "1440215960": {
+                                                        "reg": {
+                                                            "_": "_"
+                                                        },
+                                                        "atr": {
+                                                            "min": -1,
+                                                            "max": 1
+                                                        }
+                                                    },
+                                                    "reg": {
+                                                        "_": "_"
+                                                    }
+                                                },
+                                                "_nullptr": {
+                                                    "atr": {
+                                                        "name": "_null_pointer"
+                                                    }
+                                                },
+                                                "ovr": {
+                                                    "": {
+                                                        "items": "/_nullptr"
+                                                    },
+                                                    "/_nullptr": {
+                                                        "items-inv": [
+                                                            ""
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            "reg": {
+                                                "_sets_": 4
+                                            },
+                                            "atr": {
+                                                "min": 1,
+                                                "max": 1
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/reg/_meta_event_",
+                                    "value": 1
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/",
+                                    "value": {
+                                        "dst": "/_nullptr"
+                                    }
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2f_nullptr",
+                                    "value": {
+                                        "dst-inv": [
+                                            ""
+                                        ]
+                                    }
+                                }
+                            ],
+                            "_id": "#d199d3d4c68aaabef85057ed45543c22ec503e9b"
+                        },
+                        "#d29851a5740abe0bb15a6c66ae3e4417838c0a6e": {
+                            "type": "patch",
+                            "base": "#59d1eda58dbbd5debcaede465702ca850042d874",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/I",
+                                    "value": "#d199d3d4c68aaabef85057ed45543c22ec503e9b"
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fI%2f_meta%2f_p_dst%2f_sets%2fitems%2f1440215960",
+                                    "value": {
+                                        "member": "/X"
+                                    }
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fX/member-inv",
+                                    "value": [
+                                        "/_sets/MetaAspectSet_68f8146d-b1b7-6c40-3464-f8c070e97e8d/959350925",
+                                        "/_sets/MetaAspectSet/930819433",
+                                        "/I/_meta/_p_dst/_sets/items/1440215960"
+                                    ]
+                                }
+                            ],
+                            "_id": "#d29851a5740abe0bb15a6c66ae3e4417838c0a6e"
+                        }
+                    },
+                    rootHash = '#d29851a5740abe0bb15a6c66ae3e4417838c0a6e',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/X": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/I": true
+                    }
+                });
+            });
+
+            it('should trigger partial for old target and update for node when assigning null-ptr', function () {
+                var patch = {
+                        "#6e53191b6a8a6fa397d07b7cc4b0fc6d0e3a8a96": {
+                            "type": "patch",
+                            "base": "#3029a3057e53852274089ecaaf6d2922494d8fea",
+                            "patch": [
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/",
+                                    "value": {
+                                        "dst": "/_nullptr"
+                                    }
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2f_nullptr",
+                                    "value": {
+                                        "dst-inv": [
+                                            ""
+                                        ]
+                                    }
+                                }
+                            ],
+                            "_id": "#6e53191b6a8a6fa397d07b7cc4b0fc6d0e3a8a96"
+                        },
+                        "#858fc3cb6f6f6928a092973a24d383ee2b995cad": {
+                            "type": "patch",
+                            "base": "#e11239afeca9f11371c3b1e2d77fce2c128030a3",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/p",
+                                    "value": "#6e53191b6a8a6fa397d07b7cc4b0fc6d0e3a8a96"
+                                }
+                            ],
+                            "_id": "#858fc3cb6f6f6928a092973a24d383ee2b995cad"
+                        },
+                        "#995fe834735afcf2e6eef1774670e1db00fe3a9c": {
+                            "type": "patch",
+                            "base": "#7053826de17ad7bfd83734857be26bfcb5340ce9",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/8",
+                                    "value": "#858fc3cb6f6f6928a092973a24d383ee2b995cad"
+                                }
+                            ],
+                            "_id": "#995fe834735afcf2e6eef1774670e1db00fe3a9c"
+                        },
+                        "#8db8723681444c52158ef4380806d94f6dae1ee3": {
+                            "type": "patch",
+                            "base": "#9900a9dc636511418e3f0e9696041aeb13c70964",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/v",
+                                    "value": "#995fe834735afcf2e6eef1774670e1db00fe3a9c"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fX/dst-inv"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2fv%2f8%2fp/dst"
+                                }
+                            ],
+                            "_id": "#8db8723681444c52158ef4380806d94f6dae1ee3"
+                        }
+                    },
+                    rootHash = '#8db8723681444c52158ef4380806d94f6dae1ee3',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/X": true
+                    },
+                    "unload": {},
+                    "update": {
+                        "/v/8/p": true
+                    }
+                });
+            });
+
+            it('should trigger update for node when removing null-ptr', function () {
+                var patch = {
+                        "#e03246442ede7798d74468fd410667e637d067f0": {
+                            "type": "patch",
+                            "base": "#1c4ce40c293925d319b789902cd48aac06425253",
+                            "patch": [
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/"
+                                },
+                                {
+                                    "op": "remove",
+                                    "path": "/ovr/%2f_nullptr"
+                                }
+                            ],
+                            "_id": "#e03246442ede7798d74468fd410667e637d067f0"
+                        },
+                        "#7bb2676d43fc1d5859940ab6b88a2b91910b2cf1": {
+                            "type": "patch",
+                            "base": "#e4fc8df1cf55997789b793681266a79ec6b62020",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/p",
+                                    "value": "#e03246442ede7798d74468fd410667e637d067f0"
+                                }
+                            ],
+                            "_id": "#7bb2676d43fc1d5859940ab6b88a2b91910b2cf1"
+                        },
+                        "#4eccb177f8687e1a7ed605ad97af4cddff486cd3": {
+                            "type": "patch",
+                            "base": "#7a3b8e90fd41a8f893f34119f661d5956038149b",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/8",
+                                    "value": "#7bb2676d43fc1d5859940ab6b88a2b91910b2cf1"
+                                }
+                            ],
+                            "_id": "#4eccb177f8687e1a7ed605ad97af4cddff486cd3"
+                        },
+                        "#310cf492269ffa0e4b3ce35b9fc15470cbaa0bbc": {
+                            "type": "patch",
+                            "base": "#ab59c006e6a1fe5c86c07826b2d57656a57f8b11",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/v",
+                                    "value": "#4eccb177f8687e1a7ed605ad97af4cddff486cd3"
+                                }
+                            ],
+                            "_id": "#310cf492269ffa0e4b3ce35b9fc15470cbaa0bbc"
+                        }
+                    },
+                    rootHash = '#310cf492269ffa0e4b3ce35b9fc15470cbaa0bbc',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {},
+                    "unload": {},
+                    "update": {
+                        "/v/8/p": true
+                    }
+                });
+            });
+
+            it('should trigger update for node changing base and partial for new and old target', function () {
+                var patch = {
+                        "#e2d5181eb73aec7a337c1968d16d1dfaa0b385f7": {
+                            "type": "patch",
+                            "base": "#0fba0faa4259e8441dc4b97de9b4af0bd288b271",
+                            "patch": [
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2f1/base-inv",
+                                    "value": [
+                                        "/I"
+                                    ]
+                                },
+                                {
+                                    "op": "add",
+                                    "path": "/ovr/%2fI/base-inv",
+                                    "value": [
+                                        "/X"
+                                    ]
+                                },
+                                {
+                                    "op": "replace",
+                                    "path": "/ovr/%2fX/base",
+                                    "value": "/I"
+                                }
+                            ],
+                            "_id": "#e2d5181eb73aec7a337c1968d16d1dfaa0b385f7"
+                        }
+                    },
+                    rootHash = '#e2d5181eb73aec7a337c1968d16d1dfaa0b385f7',
+                    result = patcher.getChangedNodes(patch, rootHash);
+
+                expect(result).to.deep.equal({
+                    "load": {},
+                    "partialUpdate": {
+                        "/1": true,
+                        "/I": true,
+                    },
+                    "unload": {},
+                    "update": {
+                        "/X": true
+                    }
+                });
+            });
         });
     });
 });

--- a/test/server/storage/safestorage.spec.js
+++ b/test/server/storage/safestorage.spec.js
@@ -1238,7 +1238,6 @@ describe('SafeStorage', function () {
                         persisted = importResult.core.persist(rootNode);
                         expect(Object.keys(persisted.objects).length).to.equal(2);
                         newRootHash = persisted.rootHash;
-                        console.log(persisted);
                         return project.makeCommit(
                             'newNodesNotEmitted',
                             [importResult.commitHash],


### PR DESCRIPTION
With this implementation patch objects are always sent during a makeCommit and all core-objects are sent as such (not only the root).
On top of that the commitData also contains the changed nodes as dictionary, with keys update, partialUpdate, load and unload. They in turn contain the paths of the affected nodes. These are kept to a minimum and the client does some logic on top of that to figure out which nodes did have changes (load and unload are currently not used as events).

The breaking change is that a directly connected storage must make commits through the Project (unless there's no nodes in that commit). This is always possible since in order to get the core-objects in the first place the user needs a core which in turn needs a project.

The `emitCommittedCoreObjects` config has changed to `maxEmittedCoreObjects` which is a number (negative means not cap). N.B. this config only applies to newly created objects - not the patches (which are always sent).