### PR TITLE
Introduce getNamespace on core to distinguish between meta-nodes with dots in name.

### DIFF
--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1877,9 +1877,6 @@ define([
          * Returns the fully qualified name of the node, which is the list of its namespaces separated
          * by dot and followed by the name of the node.
          *
-         * TODO: Consider renaming this method since the returned name is not
-         * TODO: guaranteed to be unique.
-         *
          * @param {module:Core~Node} node - the node in question.
          *
          * @return {string} - Returns the fully qualified name of the node,
@@ -1953,9 +1950,11 @@ define([
 
         /**
          * Returns all the Meta nodes within the given library.
+         * By default it will include nodes defined in any library within the given library.
          *
          * @param {module:Core~Node} node - any node of your project.
          * @param {string} name - name of your library.
+         * @param {bool} [onlyOwn] - if true only returns with Meta nodes defined in the library itself.
          *
          * @return {module:Core~Node[]} - Returns an array of core nodes that are part of your meta from
          * the given library.

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1859,8 +1859,26 @@ define([
         this.isLibraryElement = core.isLibraryElement;
 
         /**
+         * Returns the resolved namespace for the node. If node is not in a library it returns the
+         * empty string. If the node is in a library of a library -
+         * the full name space is the library names joined together by dots.
+         *
+         * @param {module:Core~Node} node - the node in question.
+         *
+         * @return {string} - Returns the name space of the node.
+         *
+         * @example NS1.NS2
+         *
+         * @func
+         */
+        this.getNamespace = core.getNamespace;
+
+        /**
          * Returns the fully qualified name of the node, which is the list of its namespaces separated
          * by dot and followed by the name of the node.
+         *
+         * TODO: Consider renaming this method since the returned name is not
+         * TODO: guaranteed to be unique.
          *
          * @param {module:Core~Node} node - the node in question.
          *

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -770,14 +770,20 @@ define([
                 return Object.keys(self.getRoot(node).libraryRoots);
             };
 
-            this.getLibraryMetaNodes = function (node, name) {
+            this.getLibraryMetaNodes = function (node, name, onlyOwn) {
                 var allNodes = self.getAllMetaNodes(node),
                     libraryNodes = {},
                     path;
 
                 for (path in allNodes) {
-                    if (self.getNamespace(allNodes[path]) === name) {
-                        libraryNodes[path] = allNodes[path];
+                    if (onlyOwn) {
+                        if (self.getNamespace(allNodes[path]) === name) {
+                            libraryNodes[path] = allNodes[path];
+                        }
+                    } else {
+                        if (self.getNamespace(allNodes[path]).indexOf(name) === 0) {
+                            libraryNodes[path] = allNodes[path];
+                        }
                     }
                 }
 

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -571,6 +571,17 @@ define([
                 return false;
             };
 
+            this.getNamespace = function (node) {
+                var libPrefix = getLibraryName(node);
+
+                if (libPrefix) {
+                    // Trim the trailing dot..
+                    libPrefix = libPrefix.substring(0, libPrefix.length - 1);
+                }
+
+                return libPrefix;
+            };
+
             this.getFullyQualifiedName = function (node) {
                 ASSERT(self.isValidNode(node));
                 return getLibraryName(node) + self.getAttribute(node, 'name');
@@ -765,8 +776,7 @@ define([
                     path;
 
                 for (path in allNodes) {
-                    if (self.getFullyQualifiedName(allNodes[path])
-                            .indexOf(name + CONSTANTS.NAMESPACE_SEPARATOR) === 0) {
+                    if (self.getNamespace(allNodes[path]) === name) {
                         libraryNodes[path] = allNodes[path];
                     }
                 }

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -4,7 +4,7 @@
  */
 var testFixture = require('../../_globals.js');
 
-describe.only('Library core ', function () {
+describe('Library core ', function () {
     'use strict';
 
     var gmeConfig,

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -4,7 +4,7 @@
  */
 var testFixture = require('../../_globals.js');
 
-describe('Library core ', function () {
+describe.only('Library core ', function () {
     'use strict';
 
     var gmeConfig,
@@ -851,5 +851,30 @@ describe('Library core ', function () {
                 expect(core.getAllMetaNodes(node)[libPath] + '/Cont/toMove').not.to.equal(undefined);
             })
             .nodeify(done);
+    });
+
+    it ('getNamespace should return empty string for non-library nodes', function () {
+        expect(core.getNamespace(core.getFCO(root))).to.equal('');
+    });
+
+    it ('getNamespace should return library name for nodes in a library', function () {
+        var libNodes = core.getLibraryMetaNodes(root, 'basicLibrary');
+
+        Object.keys(libNodes).forEach(function (libNodePath) {
+            expect(core.getNamespace(libNodes[libNodePath])).to.equal('basicLibrary');
+        });
+    });
+
+    it('getLibraryMetaNodes should distinguish between nodes with same full-name', function () {
+        var fcoNode = core.getFCO(root),
+            libNames = core.getLibraryNames(fcoNode),
+            newFcoName;
+
+        expect(libNames).to.deep.equal(['basicLibrary']);
+
+        newFcoName = 'basicLibrary' + '.' + 'I';
+        core.setAttribute(fcoNode, 'name', newFcoName);
+
+        expect(Object.keys(core.getLibraryMetaNodes(fcoNode, 'basicLibrary'))).to.deep.equal(['/L/I']);
     });
 });


### PR DESCRIPTION
Use this method in `core.getLibraryMetaNodes` to avoid getting nodes that aren't part of the library.

Example:
If a project has a library `FSM` with a meta-node named `State` and the project has its own meta-node with with name `FSM.State` - `core.getLibraryMetaNodes(node, 'FSM')` would return both these nodes.