### PR TITLE
Ensure Error when rejecting constraint after eval. Closes #939

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/ConstraintDetailsDialog.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/ConstraintDetailsDialog.js
@@ -49,10 +49,10 @@ define([
 
         closeSave = function () {
             var constDesc = {
-                'name': self._inputName.val(),
-                'script': self._codeMirror.getValue(),
-                'priority': self._inputPriority.val(),
-                'info': self._inputMessage.val()
+                name: self._inputName.val(),
+                script: self._codeMirror.getValue(),
+                priority: self._inputPriority.val(),
+                info: self._inputMessage.val()
             };
 
             self._dialog.modal('hide');
@@ -118,12 +118,14 @@ define([
 
         //click on SAVE button
         this._btnSave.on('click', function (event) {
-            var val = self._codeMirror.getValue();
+            var name = self._inputName.val();
 
             event.stopPropagation();
             event.preventDefault();
 
-            if (isValidConstraintName(val)) {
+            // TODO: Check the code using esprima...
+
+            if (isValidConstraintName(name)) {
                 closeSave();
             }
         });

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Constraints.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Constraints.js
@@ -15,7 +15,27 @@ define([
     'use strict';
 
     var MetaDecoratorDiagramDesignerWidgetConstraints,
-        SCRIPT_TEMPLATE = 'function(core, node, callback) {\ncallback(null,{hasViolation:false,message:\'\'});\n}';
+        SCRIPT_TEMPLATE = [
+            '/**',
+            ' * To be called when the constraint has been evaluated.',
+            ' * @callback constraintCallback',
+            ' * @param {string|Error} err - Should be null unless unexpected execution errors.',
+            ' * @param {object} result - Result of the constraint evaluation.',
+            ' * @param {boolean} result.hasViolation - Set to true if there were violations.',
+            ' * @param {string} [result.message] - Message to display in case of violation.',
+            ' */',
+            '',
+            '/**',
+            ' * The function defining the constraint.',
+            ' * @param {Core} core - API for retrieving data about the node.',
+            ' * @param {Node} node - The node being checked.',
+            ' * @param {constraintCallback} callback',
+            ' */',
+            'function (core, node, callback) {',
+            '    var result = {hasViolation: false, message: \'\'};',
+            '    // Here goes the constraint checking..',
+            '    callback(null, result)',
+            '}'].join('\n');
 
     MetaDecoratorDiagramDesignerWidgetConstraints = function () {
     };

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/templates/ConstraintDetailsDialog.html
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/templates/ConstraintDetailsDialog.html
@@ -24,7 +24,7 @@
 
                     <div class="col-sm-8 controls">
                         <input type="text" class="input-xxlarge info-input" id="inputMessage"
-                               placeholder="Info on the constraint...">
+                               placeholder="Info about the constraint...">
                     </div>
                 </div>
                 <!--

--- a/src/common/core/users/constraintchecker.js
+++ b/src/common/core/users/constraintchecker.js
@@ -157,7 +157,7 @@ define(['common/core/users/metarules', 'q'], function (metaRules, Q) {
         self.customContraints[script].call(self.customContraintsStorage[script], self.core, node,
             function (err, result) {
                 if (err) {
-                    deferred.reject(err);
+                    deferred.reject(err instanceof Error ? err : new Error(err));
                 } else {
                     deferred.resolve(result);
                 }


### PR DESCRIPTION
Check constraint name for invalid characters rather than the constraint script when saving from meta-decorator. 

Add a jsdoc description in the constraint template.