### PR TITLE
Fix base loading mechanism

### DIFF
--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -303,7 +303,7 @@ define([
          * hierarchy. If there is no such relative id reserved, the call will return with null.
          * @param {module:Core~Node} parent - the container node in question.
          * @param {string} relativeId - the relative id of the child in question.
-         * @param {function(string, module:Core~Node | null)} callback
+         * @param {function(string, module:Core~Node)} callback
          *
          * @func
          */
@@ -314,7 +314,7 @@ define([
          * and returns the node it finds at the ends of the path. If there is no node, the function will return null.
          * @param {module:Core~Node} startNode - the starting node of our search.
          * @param {string} relativePath - the relative path - built by relative ids - of the node in question.
-         * @param {function(string, module:Core~Node | null)} callback
+         * @param {function(string, module:Core~Node)} callback
          *
          * @func
          */
@@ -348,7 +348,7 @@ define([
          * finally if the returned value is undefined than there is no such pointer defined for the given node.
          * @param {module:Core~Node} source - the container node in question.
          * @param {string} pointerName - the relative id of the child in question.
-         * @param {function(string, module:Core~Node | null | undefined)} callback
+         * @param {function(string, module:Core~Node)} callback
          *
          * @func
          */

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -240,7 +240,7 @@ define([
         //this.isObject = core.isObject;
 
         /**
-         * Checks if the node in question exists or not.
+         * Checks if the node in question has some actual data.
          * @param {module:Core~Node} node - the node in question.
          *
          * @return {bool} Returns true if the node is 'empty' meaning that it is not reserved by real data.
@@ -300,10 +300,10 @@ define([
          * Loads the child of the given parent pointed by the relative id. Behind the scenes, it means
          * that it actually loads the data pointed by a hash stored inside the parent under the given id
          * and wraps it in a node object which will be connected to the parent as a child in the containment
-         * hierarchy.
+         * hierarchy. If there is no such relative id reserved, the call will return with null.
          * @param {module:Core~Node} parent - the container node in question.
          * @param {string} relativeId - the relative id of the child in question.
-         * @param {function(string, module:Core~Node)} callback
+         * @param {function(string, module:Core~Node | null)} callback
          *
          * @func
          */
@@ -311,11 +311,10 @@ define([
 
         /**
          * From the given starting node, it loads the path given as a series of relative ids (separated by '/')
-         * and returns the node it finds at the ends of the path. If there is no node, it will not stop but create
-         * empty nodes on demand and return a new empty node back.
+         * and returns the node it finds at the ends of the path. If there is no node, the function will return null.
          * @param {module:Core~Node} startNode - the starting node of our search.
          * @param {string} relativePath - the relative path - built by relative ids - of the node in question.
-         * @param {function(string, module:Core~Node)} callback
+         * @param {function(string, module:Core~Node | null)} callback
          *
          * @func
          */
@@ -349,7 +348,7 @@ define([
          * finally if the returned value is undefined than there is no such pointer defined for the given node.
          * @param {module:Core~Node} source - the container node in question.
          * @param {string} pointerName - the relative id of the child in question.
-         * @param {function(string, module:Core~Node)} callback
+         * @param {function(string, module:Core~Node | null | undefined)} callback
          *
          * @func
          */

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -79,7 +79,7 @@ define([
                 }
             }
             //normal child - as every node should have a base, it is normally mean a direct child of the ROOT
-            if(self.getChildrenRelids(node).indexOf(relid) === -1){
+            if (self.getChildrenRelids(node).indexOf(relid) === -1) {
                 return null;
             }
 
@@ -797,7 +797,7 @@ define([
         };
 
         this.getBase = function (node) {
-            ASSERT((node));
+            ASSERT(self.isValidNode(node));
 
             // TODO: check if base has moved
             return node.base;

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -78,7 +78,11 @@ define([
                     }, basechild, child, node, relid);
                 }
             }
-            //normal child
+            //normal child - as every node should have a base, it is normally mean a direct child of the ROOT
+            if(self.getChildrenRelids(node).indexOf(relid) === -1){
+                return null;
+            }
+
             return TASYNC.call(loadBase, innerCore.loadChild(node, relid));
         }
 
@@ -130,14 +134,16 @@ define([
                 ASSERT(node.base === undefined || node.base === null); //kecso
 
                 if (target === null) {
-                    node.base = null;
-                    return node;
-                } else {
-                    return TASYNC.call(function (n, b) {
-                        n.base = b;
-                        return n;
-                    }, node, loadBase(target));
+                    // At this point the base node should be a valid node
+                    logger.warn('node [' + innerCore.getPath(node) +
+                        '] removed due to missing base in inheritance chain');
+                    innerCore.deleteNode(node);
+                    //core.persist(core.getRoot(node));
+                    return null;
                 }
+
+                node.base = target;
+                return node;
             }
         }
 
@@ -304,7 +310,6 @@ define([
             test('base', typeof node.base === 'object');
         }
 
-
         function getProperty(node, name) {
             var property;
             while (property === undefined && node !== null) {
@@ -371,6 +376,7 @@ define([
             }
             return filtered;
         }
+
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
@@ -392,7 +398,7 @@ define([
             return TASYNC.call(function (child) {
                 if (child && self.isInheritanceContainmentCollision(child, self.getParent(child))) {
                     logger.error('node[' + self.getPath(child) +
-                                 '] was deleted due to inheritance-containment collision');
+                        '] was deleted due to inheritance-containment collision');
                     self.deleteNode(child);
                     //core.persist(core.getRoot(child));
                     return null;
@@ -807,7 +813,7 @@ define([
             //TODO this restriction should be removed after clarification of the different scenarios and outcomes
             //changing base from or to a node which has children is not allowed currently
             ASSERT((base === null || oldBase === null) ||
-                   (self.getChildrenRelids(base).length === 0 && self.getChildrenRelids(oldBase).length === 0));
+                (self.getChildrenRelids(base).length === 0 && self.getChildrenRelids(oldBase).length === 0));
 
             if (!!base) {
                 //TODO maybe this is not the best way, needs to be double checked

--- a/src/common/core/users/constraintchecker.js
+++ b/src/common/core/users/constraintchecker.js
@@ -52,7 +52,7 @@ define(['common/core/users/metarules', 'q'], function (metaRules, Q) {
             self.core.loadByPath(self.rootNode, path, function (err, node) {
                 if (err) {
                     deferred.reject(new Error(err));
-                } else if (self.core.isEmpty(node)) {
+                } else if (node === null) {
                     deferred.reject(new Error('Given nodePath does not exist "' + path + '"!'));
                 } else {
                     deferred.resolve(node);

--- a/src/common/core/users/metarules.js
+++ b/src/common/core/users/metarules.js
@@ -12,7 +12,7 @@ define(['q'], function (Q) {
     function loadNode(core, rootNode, nodePath) {
         return core.loadByPath(rootNode, nodePath)
             .then(function (node) {
-                if (core.isEmpty(node)) {
+                if (node === null) {
                     throw new Error('Given nodePath does not exist "' + nodePath + '"!');
                 } else {
                     return node;
@@ -101,7 +101,6 @@ define(['q'], function (Q) {
          *       maxItems: [ -1, 4 ]
          *   }
          */
-
 
         // Initialize the number of matches for each valid type.
         matches = subMetaRules.items.map(function () {
@@ -312,11 +311,11 @@ define(['q'], function (Q) {
         meta = core.getJsonMeta(node);
 
         return Q.all([
-            checkPointerRules(meta, core, node),
-            checkSetRules(meta, core, node),
-            checkChildrenRules(meta, core, node),
-            checkAttributeRules(meta, core, node)
-        ])
+                checkPointerRules(meta, core, node),
+                checkSetRules(meta, core, node),
+                checkChildrenRules(meta, core, node),
+                checkAttributeRules(meta, core, node)
+            ])
             .then(function (results) {
                 var i;
                 for (i = 0; i < results.length; i += 1) {

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -225,7 +225,6 @@ function clearDBAndGetGMEAuth(gmeConfigParameter, projectNameOrNames, callback) 
         })
         .catch(deferred.reject);
 
-
     return deferred.promise.nodeify(callback);
 }
 
@@ -348,7 +347,7 @@ function loadNode(core, rootNode, nodePath, callback) {
     core.loadByPath(rootNode, nodePath, function (err, node) {
         if (err) {
             deferred.reject(new Error(err));
-        } else if (core.isEmpty(node)) {
+        } else if (node === null) {
             deferred.reject(new Error('Given nodePath does not exist "' + nodePath + '"!'));
         } else {
             deferred.resolve(node);
@@ -463,10 +462,8 @@ function openSocketIo(server, agent, userName, password, token) {
             deferred.reject(err);
         });
 
-
     return deferred.promise;
 }
-
 
 WebGME.addToRequireJsPaths(gmeConfig);
 

--- a/test/common/core/coreQ.spec.js
+++ b/test/common/core/coreQ.spec.js
@@ -50,9 +50,9 @@ describe('CoreQ Async with Promises', function () {
 
     after(function (done) {
         Q.allDone([
-            storage.closeDatabase(),
-            gmeAuth.unload()
-        ])
+                storage.closeDatabase(),
+                gmeAuth.unload()
+            ])
             .nodeify(done);
     });
 
@@ -251,5 +251,26 @@ describe('CoreQ Async with Promises', function () {
                 expect(err.message).to.include('ASSERT failed');
             })
             .nodeify(done);
+    });
+
+    it('should return with an null if invalid path is loaded', function (done) {
+        core.loadRoot(rootHash)
+            .then(function (root) {
+                return core.loadByPath(root, '/not/valid/path');
+            })
+            .then(function (node) {
+                expect(node).to.equal(null);
+            })
+            .nodeify(done);
+    });
+
+    it('should ASSERT if isEmpty is called on a non-node object', function () {
+        try {
+            core.isEmpty({});
+        } catch (e) {
+            expect(e).not.to.equal(null);
+            return;
+        }
+        throw new Error('should have failed to use isEmpty');
     });
 });

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -15,9 +15,11 @@ describe('coretype', function () {
         Type = testFixture.requirejs('common/core/coretype'),
         Rel = testFixture.requirejs('common/core/corerel'),
         Tree = testFixture.requirejs('common/core/coretree'),
+        NullPtr = testFixture.requirejs('common/core/nullpointercore'),
         TASYNC = testFixture.requirejs('common/core/tasync'),
         Core = function (s, options) {
-            return new Type(new Rel(new Tree(s, options), options), options);
+            return new NullPtr(
+                new Type(new NullPtr(new Rel(new Tree(s, options), options), options), options), options);
         },
         projectName = 'coreTypeTesting',
         projectId = testFixture.projectName2Id(projectName),
@@ -37,9 +39,9 @@ describe('coretype', function () {
 
     after(function (done) {
         Q.allDone([
-            storage.closeDatabase(),
-            gmeAuth.unload()
-        ])
+                storage.closeDatabase(),
+                gmeAuth.unload()
+            ])
             .nodeify(done);
     });
 
@@ -122,7 +124,6 @@ describe('coretype', function () {
             core.getPath(core.getTypeRoot(instance)).should.be.eql(core.getPath(base));
             (core.getTypeRoot(base) === null).should.be.true;
 
-
             done();
         }, core.loadChildren(root));
     });
@@ -143,7 +144,6 @@ describe('coretype', function () {
             (core.getOwnPointerPath(instance, 'parent') === undefined).should.be.true;
             core.getOwnPointerNames(instance).should.be.eql(['base']);
             core.getPointerPath(instance, 'parent').should.be.eql(core.getPath(root));
-
 
             done();
         }, core.loadChildren(root));
@@ -411,7 +411,6 @@ describe('coretype', function () {
             instB = core.createNode({parent: root, base: typeB}),
             relid = core.getRelid(instA);
 
-
         instA = core.moveNode(instA, instB);
         instB = core.moveNode(instB, typeA);
 
@@ -427,7 +426,6 @@ describe('coretype', function () {
             typeB = core.createNode({parent: root}),
             instA = core.createNode({parent: root, base: typeA}),
             path = core.getPath(instA);
-
 
         typeA = core.moveNode(typeA, typeB);
         typeB = core.moveNode(typeB, instA);
@@ -449,6 +447,7 @@ describe('coretype', function () {
             instA = core.createNode({parent: root, base: typeA, relid: '12'}),
             path = core.getPath(instA);
 
+        expect(core.getPointerPath(typeA, 'base')).to.equal(null);
         //we have to save and reload otherwise the base is still in the cache so it can be loaded without a problem
         core.persist(root);
 


### PR DESCRIPTION
The correction is related to #909.
During load the core needs to check if the base of the node is valid, not only before it instructs the base to be loaded, but after the load has finished (as the base could be removed during load as well).
The change also clears up the usage of the isEmpty core function. 
If the load 'fails' because the requested node is non-existent or invalid, the load will return a null.