### PR TITLE
Closes #948 Ensure node loaded when setting state

### DIFF
--- a/src/client/js/Controls/PropertyGrid/Widgets/PointerWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/PointerWidget.js
@@ -208,13 +208,18 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase',
         if (ptrTo && ptrTo !== '_nullptr') {
             targetNodeObj = client.getNode(ptrTo);
             if (targetNodeObj) {
-                if (targetNodeObj.getParentId() || targetNodeObj.getParentId() === CONSTANTS.PROJECT_ROOT_ID) {
-                    WebGMEGlobal.State.registerActiveObject(targetNodeObj.getParentId());
-                    WebGMEGlobal.State.registerActiveSelection([ptrTo]);
-                } else {
-                    WebGMEGlobal.State.registerActiveObject(CONSTANTS.PROJECT_ROOT_ID);
-                    WebGMEGlobal.State.registerActiveSelection([ptrTo]);
-                }
+                WebGMEGlobal.State.registerActiveObject(ptrTo);
+                WebGMEGlobal.State.registerActiveSelection([]);
+                // Opening the parent and setting activeSelection does not makes sense for all visualizers.
+                //if (targetNodeObj.getParentId() || targetNodeObj.getParentId() === CONSTANTS.PROJECT_ROOT_ID) {
+                //    WebGMEGlobal.State.registerActiveObject(targetNodeObj.getParentId());
+                //    WebGMEGlobal.State.registerActiveSelection([ptrTo]);
+                //} else {
+                //    WebGMEGlobal.State.registerActiveObject(CONSTANTS.PROJECT_ROOT_ID);
+                //    WebGMEGlobal.State.registerActiveSelection([ptrTo]);
+                //}
+            } else {
+                // The targetNode should be loaded by the territory.
             }
         }
     };

--- a/src/client/js/Utils/StateManager.js
+++ b/src/client/js/Utils/StateManager.js
@@ -18,6 +18,13 @@ define([
     var _WebGMEState,
         logger,
         WebGMEStateModel = Backbone.Model.extend({
+
+            /**
+             * Sets the active node to the given id.
+             * N.B. Do NOT call this unless the node is guaranteed to be loaded. Either check that getNode(objId) is
+             * defined or (even better) create a territory and check if the node could be loaded.
+             * @param {string} objId
+             */
             registerActiveObject: function (objId) {
                 objId = objId === 'root' ? '' : objId;
                 logger.debug('registerActiveObject, objId: ', objId);


### PR DESCRIPTION
Before registering the activeObject to the state - the node must be guaranteed to be loaded.
When e.g. dbl-clicking a node in the tree-browser, this is always the case. However for the plugin- and constraint-results-dialogs this is not always the case.

Further these widgets should not try to set the parent as activeNode and the node as the selection.. Although this makes some sense in the context of the ModelEditor, this isn't necessarily the case in general.