### PR TITLE
Implemented namespace selector and name-only type list in part-browser

### DIFF
--- a/src/client/js/Layouts/DefaultLayout/DefaultLayout.js
+++ b/src/client/js/Layouts/DefaultLayout/DefaultLayout.js
@@ -94,6 +94,7 @@ define(['jquery-layout',
             }, west: {
                 size: SIDE_PANEL_WIDTH,
                 minSize: SIDE_PANEL_WIDTH,
+                showOverflowOnHover:true,
                 resizable: true,
                 slidable: false,
                 spacing_open: SPACING_OPEN, //jshint ignore: line

--- a/src/client/js/PanelBase/PanelBaseWithHeader.js
+++ b/src/client/js/PanelBase/PanelBaseWithHeader.js
@@ -11,7 +11,8 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
     'use strict';
 
     var PanelBaseWithHeader,
-        BASE_CLASS = 'panel-base-wh'; // /styles/PanelBaseWithHeader.scss
+        BASE_CLASS = 'panel-base-wh', // /styles/PanelBaseWithHeader.scss
+        SCROLL_CLASS = 'panel-base-scroll';
 
     //inherit from PanelBase Phase #1
     PanelBaseWithHeader = function (options, layoutManager) {
@@ -32,10 +33,10 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
     //inherit from PanelBase Phase #2
     PanelBaseWithHeader.OPTIONS = _.extend(PanelBase.OPTIONS, {
         HEADER_TITLE: 'HEADER_TITLE',
-        FLOATING_TITLE: 'FLOATING_TITLE'
+        FLOATING_TITLE: 'FLOATING_TITLE',
+        NO_SCROLLING: 'NO_SCROLLING'
     });
     _.extend(PanelBaseWithHeader.prototype, PanelBase.prototype);
-
 
     /* OVERRIDE PanelBase members */
     PanelBaseWithHeader.prototype.setSize = function (width, height) {
@@ -44,11 +45,9 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
         this.onResize(this.size.width, this.size.height);
     };
 
-
     PanelBaseWithHeader.prototype.onReadOnlyChanged = function (isReadOnly) {
         this._onReadOnlyChanged(isReadOnly);
     };
-
 
     /* CUSTOM MEMBERS */
     PanelBaseWithHeader.prototype.initUI = function (options) {
@@ -62,6 +61,11 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
 
         //add own class
         this.$_el.addClass(BASE_CLASS);
+
+        //by default we also add the scrolling
+        if (options[PanelBaseWithHeader.OPTIONS.NO_SCROLLING] !== true) {
+            this.$_el.addClass(SCROLL_CLASS);
+        }
 
         //Create Panel's HEADER
         this.$panelHeader = $('<div/>', {
@@ -121,7 +125,6 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
         }
     };
 
-
     /************** CUSTOM RESIZE HANDLER *****************/
     PanelBaseWithHeader.prototype._setSize = function (w, h) {
         var panelHeaderHeight = this.$panelHeader.outerHeight(true),
@@ -150,7 +153,6 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
         };
     };
     /************** END OF --- CUSTOM RESIZE HANDLER *****************/
-
 
     /************** CUSTOM READ-ONLY CHANGED HANDLER *****************/
     PanelBaseWithHeader.prototype._onReadOnlyChanged = function (isReadOnly) {

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
@@ -50,7 +50,6 @@
       left: 0; }
   .panel-base-wh .panel-body {
     position: relative;
-    overflow: auto;
     background-color: white; }
   .panel-base-wh .floating-title {
     position: absolute;

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
@@ -91,7 +91,10 @@
     border: 1px solid #00235b; }
   .panel-base-wh.w-tabs .floating-title {
     top: 30px; }
-
+.panel-base-scroll {}
+  .panel-base-scroll .panel-body {
+    overflow: auto;
+  }
 .side-panel .panel-base-wh {
   position: relative;
   padding: 0;

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
@@ -188,6 +188,11 @@ $panel-header-title-font-size: 0.85em;
   }
 }
 
+.panel-base-scroll {
+  .panel-body {
+    overflow: auto;
+  }
+}
 .side-panel {
 
   .panel-base-wh {

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
@@ -116,7 +116,6 @@ $panel-header-title-font-size: 0.85em;
 
   .panel-body {
     position: relative;
-    overflow: auto;
     background-color: $panel-body-background-color;
   }
 

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanel.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanel.js
@@ -21,6 +21,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         //set properties from options
         options[PanelBaseWithHeader.OPTIONS.LOGGER_INSTANCE_NAME] = 'PartBrowserPanel';
         options[PanelBaseWithHeader.OPTIONS.HEADER_TITLE] = false;
+        options[PanelBaseWithHeader.OPTIONS.NO_SCROLLING] = true;
 
         //call parent's constructor
         __parent__.apply(this, [options]);

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -143,7 +143,6 @@ define(['js/logger',
             keys,
             i,
             self = this,
-            div,
             newTerritoryRules;
 
         // TODO: later we should apply project specific sorting if it is defined.
@@ -167,14 +166,13 @@ define(['js/logger',
 
             if (!this._descriptorCollection[keys[i]] ||
                 (this._descriptorCollection[keys[i]].visibility !== newDescriptor[keys[i]].visibility)) {
-                div = this._partBrowserView._getPartDiv(keys[i]);
                 if (newDescriptor[keys[i]].visibility === 'hidden') {
-                    div.hide();
+                    this._partBrowserView.hidePart(keys[i]);
                 } else if (newDescriptor[keys[i]].visibility === 'visible') {
-                    div.show();
+                    this._partBrowserView.showPart(keys[i]);
                     this._partBrowserView.setEnabled(keys[i], true);
                 } else {
-                    div.show();
+                    this._partBrowserView.showPart(keys[i]);
                     this._partBrowserView.setEnabled(keys[i], false);
                 }
             }

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -20,6 +20,8 @@ define(['js/logger',
     'use strict';
 
     var PartBrowserControl,
+        ALL_NSP = 'ALL',
+        NO_LIBS = 'Exclude Libraries',
         WIDGET_NAME = 'PartBrowser',
         DEFAULT_DECORATOR = 'ModelDecorator';
 
@@ -29,7 +31,7 @@ define(['js/logger',
         this._client = myClient;
         this._partBrowserView = myPartBrowserView;
 
-        this._partBrowserView.onSelectorChanged = function (newValue) {
+        this._partBrowserView.onSelectorChanged = function (/*newValue*/) {
             self._updateDescriptor(self._getPartDescriptorCollection());
         };
 
@@ -108,7 +110,7 @@ define(['js/logger',
             }
         });
 
-        this._nodeEventHandling = function (events) {
+        this._nodeEventHandling = function (/*events*/) {
             var /*metaChange = false,
              metaNodes = self._client.getAllMetaNodes() || [],
              metaPaths = [],
@@ -168,7 +170,7 @@ define(['js/logger',
             result[guids[i]] = {
                 path: allMetaNodes[guidLookupTable[guids[i]]].getId(),
                 name: allMetaNodes[guidLookupTable[guids[i]]].getAttribute('name')
-            }
+            };
         }
 
         result.libraryNames = this._client.getLibraryNames().sort();
@@ -188,7 +190,7 @@ define(['js/logger',
                 return descriptor[key];
             })  // turn the object into an array
             .sort(self._defaultCompare)                 // sort the objects, using the default compare
-            .map(function (value, index) {
+            .map(function (value/*, index*/) {
                 return value.id;
             }); // get only the ids
 
@@ -250,11 +252,11 @@ define(['js/logger',
             librarySelector = this._partBrowserView.getCurrentSelectorValue(),
             shouldFilterOutItem = function (key) {
                 var namespace = librarySelector;
-                if (librarySelector === 'all namespaces') {
+                if (librarySelector === ALL_NSP) {
                     return false;
                 }
 
-                if (librarySelector === 'local') {
+                if (librarySelector === NO_LIBS) {
                     namespace = '';
                 }
 
@@ -440,8 +442,8 @@ define(['js/logger',
             libraryNames = self._client.getLibraryNames().sort();
         if (libraryNames.length > 0) {
             libraryNames.unshift('-');
-            libraryNames.unshift('local');
-            libraryNames.unshift('all namespaces');
+            libraryNames.unshift(NO_LIBS);
+            libraryNames.unshift(ALL_NSP);
         }
         self._partBrowserView.updateSelectorInfo(libraryNames);
     };

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -171,6 +171,7 @@ define(['js/logger',
             }
         }
 
+        result.libraryNames = this._client.getLibraryNames().sort();
         return result;
     };
 
@@ -439,9 +440,9 @@ define(['js/logger',
             libraryNames = self._client.getLibraryNames().sort();
         if (libraryNames.length > 0) {
             libraryNames.unshift('-');
+            libraryNames.unshift('local');
+            libraryNames.unshift('all namespaces');
         }
-        libraryNames.unshift('local');
-        libraryNames.unshift('all namespaces');
         self._partBrowserView.updateSelectorInfo(libraryNames);
     };
     return PartBrowserControl;

--- a/src/client/js/Toolbar/ToolbarDropDownButton.js
+++ b/src/client/js/Toolbar/ToolbarDropDownButton.js
@@ -158,5 +158,21 @@ define(['./ButtonBase',
         this._logger.debug('destroyed');
     };
 
+    ToolbarDropDownButton.prototype.dropDownText = function (value) {
+        var oldHtml = this._dropDownBtn.html(),
+            index,
+            newHtml;
+
+        if (typeof value === 'string') {
+            //setter
+            index = oldHtml.indexOf('<span');
+            newHtml = value + ' ' + oldHtml.substr(index);
+            this._dropDownBtn.html(newHtml);
+        } else {
+            //getter
+            return oldHtml.slice(0, oldHtml.indexOf('<span')).slice(0, -1);
+        }
+    };
+
     return ToolbarDropDownButton;
 });

--- a/src/client/js/Toolbar/ToolbarDropDownButton.js
+++ b/src/client/js/Toolbar/ToolbarDropDownButton.js
@@ -42,7 +42,14 @@ define(['./ButtonBase',
         }
         //delete params.clickFn;
 
+        this._dropDownTxt = params.text;
+        this._dropDownLimit = params.limitTxtLength || 0;
+        delete params.text;
+
         this._dropDownBtn = buttonBase.createButton(params);
+
+        this.dropDownText(this._dropDownTxt);
+
         caret = CARET_BASE.clone();
 
         this._ulMenu = UL_BASE.clone();
@@ -161,16 +168,22 @@ define(['./ButtonBase',
     ToolbarDropDownButton.prototype.dropDownText = function (value) {
         var oldHtml = this._dropDownBtn.html(),
             index,
-            newHtml;
+            newHtml,
+            label;
 
         if (typeof value === 'string') {
+            this._dropDownTxt = value;
+            label = value;
+            if (this._dropDownLimit && label.length > this._dropDownLimit) {
+                label = label.substr(0, this._dropDownLimit) + '...';
+            }
             //setter
             index = oldHtml.indexOf('<span');
-            newHtml = value + ' ' + oldHtml.substr(index);
+            newHtml = label + ' ' + oldHtml.substr(index);
             this._dropDownBtn.html(newHtml);
         } else {
             //getter
-            return oldHtml.slice(0, oldHtml.indexOf('<span')).slice(0, -1);
+            return this._dropDownTxt;
         }
     };
 

--- a/src/client/js/Toolbar/styles/Toolbar.css
+++ b/src/client/js/Toolbar/styles/Toolbar.css
@@ -123,5 +123,3 @@ div.toolbar-container .btn {
   padding: 1px 5px;
   margin: 3px 5px !important;
   box-shadow: none; }
-
-/*# sourceMappingURL=Toolbar.css.map */

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -67,9 +67,8 @@ define([
         });
 
         this._selector = new ToolbarDropDownButton({
-            title: 'Namespace list',
-            showSelected: true,
-            text: 'active library selection'
+            title: 'Namespace selector',
+            showSelected: true
         });
 
         this._container.append(this._selector.el);
@@ -158,7 +157,8 @@ define([
 
             this._parts[partId] = {
                 decoratorInstance: decoratorInstance,
-                decoratorClass: partDesc.decoratorClass
+                decoratorClass: partDesc.decoratorClass,
+                filtered: false
             };
 
             return decoratorInstance;
@@ -360,10 +360,13 @@ define([
         }
     };
 
-    PartBrowserWidget.prototype.hidePart = function (partId) {
+    PartBrowserWidget.prototype.hidePart = function (partId, becauseFilter) {
         var partDiv = this._getPartDiv(partId);
 
         if (partDiv && partDiv.decorated && partDiv.onlyName) {
+            if (becauseFilter) {
+
+            }
             partDiv.decorated.hide();
             partDiv.onlyName.hide();
         } else {
@@ -371,7 +374,7 @@ define([
         }
     };
 
-    PartBrowserWidget.prototype.showPart = function (partId) {
+    PartBrowserWidget.prototype.showPart = function (partId, becauseFilter) {
         var partDiv = this._getPartDiv(partId);
 
         if (partDiv && partDiv.decorated && partDiv.onlyName) {
@@ -382,15 +385,44 @@ define([
         }
     };
 
-    PartBrowserWidget.prototype.setNameSpaceList = function(namespaces){
-        var i;
-        this._selector.clear();
+    PartBrowserWidget.prototype.getCurrentSelectorValue = function () {
+        return this._selector.dropDownText();
+    };
 
-        for(i=0;i<namespaces.length;i+=1){
-            this._selector.addButton({
+    PartBrowserWidget.prototype.updateSelectorInfo = function (valueList) {
+        var i,
+            self = this,
+            currentSelection = self.getCurrentSelectorValue(),
+            selection = function (selectionData) {
 
-            });
+                if (self._selector.dropDownText() !== selectionData.value) {
+                    self._selector.dropDownText(selectionData.value);
+                    self.onSelectorChanged(selectionData.value);
+                }
+            };
+
+        self._selector.clear();
+
+        for (i = 0; i < valueList.length; i += 1) {
+            if (valueList[i] === '-') {
+                self._selector.addDivider();
+            } else {
+                self._selector.addButton({
+                    text: valueList[i],
+                    clickFn: selection,
+                    data: {value: valueList[i]}
+                });
+            }
         }
+
+        if (valueList.indexOf(currentSelection) === -1) {
+            self._selector.dropDownText(valueList[0]);
+            self.onSelectorChanged(valueList[0]);
+        }
+    };
+
+    PartBrowserWidget.prototype.onSelectorChanged = function (newValue) {
+        this._logger.error('onSelectorChanged function should be overwritten for proper usage!');
     };
 
     return PartBrowserWidget;

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -20,7 +20,7 @@ define([
     var PartBrowserWidget,
         PART_BROWSER_CLASS = 'part-browser',
         PART_CLASS = 'part',
-        NAME_PART_CLASS = 'name-part open-link';
+        NAME_PART_CLASS = 'name-part';
 
     PartBrowserWidget = function (container /*, params*/) {
         this._logger = Logger.create('gme:Widgets:PartBrowser:PartBrowserWidget.DecoratorBase',
@@ -58,11 +58,6 @@ define([
                 self._namelist.hide();
             }
         });
-        this._listSwitcher.addButton({
-            title: 'Only part name list',
-            icon: 'glyphicon glyphicon-list',
-            data: {isList: true}
-        });
 
         this._listSwitcher.addButton({
             title: 'Decorated part list',
@@ -70,10 +65,23 @@ define([
             data: {isList: false}
         });
 
+        this._listSwitcher.addButton({
+            title: 'Only part name list',
+            icon: 'glyphicon glyphicon-list',
+            data: {isList: true}
+        });
+
         this._selector = new ToolbarDropDownButton({
             title: 'Namespace selector',
             showSelected: true,
-            limitTxtLength: 9
+            limitTxtLength: 8,
+            clickFn: function () {
+                if (self._el.css('overflow') === 'auto') {
+                    self._el.css('overflow', 'visible');
+                } else {
+                    self._el.css('overflow', 'auto');
+                }
+            }
         });
 
         this._toolbar.append(this._listSwitcher.el);
@@ -89,8 +97,8 @@ define([
         this._el.append(this._container);
 
         // By default only names are listed.
-        this._list.hide();
-        this._namelist.show();
+        this._list.show();
+        this._namelist.hide();
     };
 
     PartBrowserWidget.prototype.clear = function () {
@@ -134,7 +142,7 @@ define([
             partContainerDiv.decorated.attr({id: partId});
 
             partContainerDiv.onlyName = this.$_DOMBaseForName.clone();
-            partContainerDiv.onlyName.attr({id: partId});
+            partContainerDiv.onlyName.attr({id: partId, title: partDesc.name});
             partContainerDiv.onlyName.append(partDesc.name);
 
             //render the part inside 'partContainerDiv'
@@ -402,7 +410,7 @@ define([
             title,
             currentSelection = self.getCurrentSelectorValue(),
             selection = function (selectionData) {
-
+                self._el.css('overflow', 'auto');
                 if (self._selector.dropDownText() !== selectionData.value) {
                     self._selector.dropDownText(selectionData.value);
                     self.onSelectorChanged(selectionData.value);

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -41,7 +41,9 @@ define([
         this._container = $('<div/>');
         this._container.addClass(PART_BROWSER_CLASS);
         this._list = $('<ul/>');
+        this._list.addClass(PART_CLASS);
         this._namelist = $('<ul/>');
+        this._namelist.addClass(NAME_PART_CLASS);
         //this._list.addClass(PART_BROWSER_CLASS);
         this._listSwitcher = new ToolbarRadioButtonGroup(function (data) {
             if (data.isList) {
@@ -68,7 +70,8 @@ define([
 
         this._selector = new ToolbarDropDownButton({
             title: 'Namespace selector',
-            showSelected: true
+            showSelected: true,
+            limitTxtLength: 9
         });
 
         this._container.append(this._selector.el);
@@ -392,6 +395,7 @@ define([
     PartBrowserWidget.prototype.updateSelectorInfo = function (valueList) {
         var i,
             self = this,
+            title,
             currentSelection = self.getCurrentSelectorValue(),
             selection = function (selectionData) {
 
@@ -407,7 +411,15 @@ define([
             if (valueList[i] === '-') {
                 self._selector.addDivider();
             } else {
+                if (valueList[i] === 'all namespaces') {
+                    title = 'show all Meta elements';
+                } else if (valueList[i] === 'local') {
+                    title = 'show elements that were defined in this project';
+                } else {
+                    title = 'show elements of \'' + valueList[i] + '\' namespace';
+                }
                 self._selector.addButton({
+                    title: title,
                     text: valueList[i],
                     clickFn: selection,
                     data: {value: valueList[i]}

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -18,6 +18,8 @@ define([
     'use strict';
 
     var PartBrowserWidget,
+        ALL_NSP = 'ALL',
+        NO_LIBS = 'Exclude Libraries',
         PART_BROWSER_CLASS = 'part-browser',
         PART_CLASS = 'part',
         NAME_PART_CLASS = 'name-part';
@@ -114,7 +116,10 @@ define([
 
     PartBrowserWidget.prototype.addPart = function (partId, partDesc) {
         var partContainerDiv = this._getPartDiv(partId),
-            partContainerLi = {decorated: $('<li />'), onlyName: $('<li />')},
+            partContainerLi = {
+                decorated: $('<li />', {class: 'decorated-list-item'}),
+                onlyName: $('<li />', {class: 'name-list-item'})
+            },
             DecoratorClass = partDesc.decoratorClass,
             decoratorInstance;
 
@@ -191,9 +196,9 @@ define([
             };
 
         if (params.realDragTarget) {
-            dragParams.helper = function (el, event, dragInfo) {
+            dragParams.helper = function (/*el, event, dragInfo*/) {
                 return params.realDragTarget.clone();
-            }
+            };
         }
 
         dragSource.makeDraggable(el, dragParams);
@@ -384,7 +389,7 @@ define([
         }
     };
 
-    PartBrowserWidget.prototype.showPart = function (partId, becauseFilter) {
+    PartBrowserWidget.prototype.showPart = function (partId/*, becauseFilter*/) {
         var partDiv = this._getPartDiv(partId);
 
         if (partDiv && partDiv.decorated && partDiv.onlyName) {
@@ -421,12 +426,12 @@ define([
             if (valueList[i] === '-') {
                 self._selector.addDivider();
             } else {
-                if (valueList[i] === 'all namespaces') {
-                    title = 'show all Meta elements';
-                } else if (valueList[i] === 'local') {
-                    title = 'show elements that were defined in this project';
+                if (valueList[i] === ALL_NSP) {
+                    title = 'Show all available meta nodes.';
+                } else if (valueList[i] === NO_LIBS) {
+                    title = 'Exclude meta nodes defined in attached libraries.';
                 } else {
-                    title = 'show elements of \'' + valueList[i] + '\' namespace';
+                    title = 'Show meta nodes from the library/namespace "' + valueList[i] + '".';
                 }
                 self._selector.addButton({
                     title: title,
@@ -450,7 +455,7 @@ define([
     };
 
     PartBrowserWidget.prototype.onSelectorChanged = function (newValue) {
-        this._logger.error('onSelectorChanged function should be overwritten for proper usage!');
+        this._logger.error('onSelectorChanged function should be overwritten for proper usage!', newValue);
     };
 
     return PartBrowserWidget;

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -433,10 +433,16 @@ define([
             }
         }
 
-        if (valueList.indexOf(currentSelection) === -1) {
-            self._selector.dropDownText(valueList[0]);
-            self.onSelectorChanged(valueList[0]);
+        if(valueList.length === 0){
+            self._selector.hide();
+        } else {
+            self._selector.show();
+            if (valueList.indexOf(currentSelection) === -1) {
+                self._selector.dropDownText(valueList[0]);
+                self.onSelectorChanged(valueList[0]);
+            }
         }
+
     };
 
     PartBrowserWidget.prototype.onSelectorChanged = function (newValue) {

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -39,8 +39,10 @@ define([
         //this._el.addClass(PART_BROWSER_CLASS);
         this._showNamesOnly = true;
         this._container = $('<div/>');
+        this._container.css({width: '100%', height: '100%'});
         this._toolbar = $('<div/>');
         this._partsContainer = $('<div/>');
+        this._partsContainer.css({width: '100%', height: '100%'});
         this._partsContainer.addClass(PART_BROWSER_CLASS);
         this._list = $('<ul/>');
         this._list.addClass(PART_CLASS);
@@ -74,14 +76,7 @@ define([
         this._selector = new ToolbarDropDownButton({
             title: 'Namespace selector',
             showSelected: true,
-            limitTxtLength: 8,
-            clickFn: function () {
-                if (self._el.css('overflow') === 'auto') {
-                    self._el.css('overflow', 'visible');
-                } else {
-                    self._el.css('overflow', 'auto');
-                }
-            }
+            limitTxtLength: 8
         });
 
         this._toolbar.append(this._listSwitcher.el);
@@ -410,7 +405,6 @@ define([
             title,
             currentSelection = self.getCurrentSelectorValue(),
             selection = function (selectionData) {
-                self._el.css('overflow', 'auto');
                 if (self._selector.dropDownText() !== selectionData.value) {
                     self._selector.dropDownText(selectionData.value);
                     self.onSelectorChanged(selectionData.value);

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -10,8 +10,10 @@ define([
     'js/logger',
     'js/Constants',
     'js/DragDrop/DragSource',
+    'js/Toolbar/ToolbarDropDownButton',
+    'js/Toolbar/ToolbarButton',
     'css!./styles/PartBrowserWidget.css'
-], function (Logger, CONSTANTS, dragSource) {
+], function (Logger, CONSTANTS, dragSource, ToolbarDropDownButton, ToolbarButton) {
 
     'use strict';
 
@@ -32,15 +34,30 @@ define([
 
     PartBrowserWidget.prototype._initialize = function () {
         //set Widget title
-        this._el.addClass(PART_BROWSER_CLASS);
-
+        //this._el.addClass(PART_BROWSER_CLASS);
+        this._container = $('<div/>');
+        this._container.addClass(PART_BROWSER_CLASS);
         this._list = $('<ul/>');
+        //this._list.addClass(PART_BROWSER_CLASS);
+        this._listSwitcher = new ToolbarButton({
+            icon:'glyphicon glyphicon-home'
+        });
 
+        this._selector = new ToolbarDropDownButton({
+            title: 'Namespace list',
+            icon: 'glyphicon glyphicon-list',
+            showSelected: true,
+            text: 'checking'
+        });
+
+        this._container.append(this._selector.el);
+        this._container.append(this._listSwitcher.el);
+        this._container.append(this._list);
         this._parts = {};
 
         this._partDraggableEl = {};
 
-        this._el.append(this._list);
+        this._el.append(this._container);
     };
 
     PartBrowserWidget.prototype.clear = function () {

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -396,7 +396,11 @@ define([
     };
 
     PartBrowserWidget.prototype.getCurrentSelectorValue = function () {
-        return this._selector.dropDownText();
+        if (this._selector.el.is(':hidden')) {
+            return '';
+        }
+
+        return this._selector.dropDownText() || '';
     };
 
     PartBrowserWidget.prototype.updateSelectorInfo = function (valueList) {
@@ -433,7 +437,7 @@ define([
             }
         }
 
-        if(valueList.length === 0){
+        if (valueList.length === 0) {
             self._selector.hide();
         } else {
             self._selector.show();

--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -20,7 +20,7 @@ define([
     var PartBrowserWidget,
         PART_BROWSER_CLASS = 'part-browser',
         PART_CLASS = 'part',
-        NAME_PART_CLASS = 'name-part';
+        NAME_PART_CLASS = 'name-part open-link';
 
     PartBrowserWidget = function (container /*, params*/) {
         this._logger = Logger.create('gme:Widgets:PartBrowser:PartBrowserWidget.DecoratorBase',
@@ -39,7 +39,9 @@ define([
         //this._el.addClass(PART_BROWSER_CLASS);
         this._showNamesOnly = true;
         this._container = $('<div/>');
-        this._container.addClass(PART_BROWSER_CLASS);
+        this._toolbar = $('<div/>');
+        this._partsContainer = $('<div/>');
+        this._partsContainer.addClass(PART_BROWSER_CLASS);
         this._list = $('<ul/>');
         this._list.addClass(PART_CLASS);
         this._namelist = $('<ul/>');
@@ -74,14 +76,16 @@ define([
             limitTxtLength: 9
         });
 
-        this._container.append(this._selector.el);
-        this._container.append(this._listSwitcher.el);
-        this._container.append(this._list);
-        this._container.append(this._namelist);
+        this._toolbar.append(this._listSwitcher.el);
+        this._toolbar.append(this._selector.el);
+        this._partsContainer.append(this._list);
+        this._partsContainer.append(this._namelist);
         this._parts = {};
 
         this._partDraggableEl = {};
 
+        this._container.append(this._toolbar);
+        this._container.append(this._partsContainer);
         this._el.append(this._container);
 
         // By default only names are listed.
@@ -107,7 +111,7 @@ define([
 
     PartBrowserWidget.prototype.addPart = function (partId, partDesc) {
         var partContainerDiv = this._getPartDiv(partId),
-            partContainerLi = {decorated: $('<li/>'), onlyName: $('<li/>')},
+            partContainerLi = {decorated: $('<li />'), onlyName: $('<li />')},
             DecoratorClass = partDesc.decoratorClass,
             decoratorInstance;
 

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -7,6 +7,12 @@
     margin: 0;
     white-space: nowrap;
     padding: 0; }
+  .part-browser > ul.part {
+    text-align: center;
+  }
+  .part-browser > ul.name-part {
+    text-align: left;
+  }
     .part-browser > ul > li {
       list-style-type: none;
       padding: 0px;

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -17,3 +17,6 @@
       .part-browser > ul > li div.part {
         display: inline-block;
         cursor: pointer; }
+      .part-browser > ul > li div.name-part {
+        display: inline-block;
+        cursor: pointer; }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -1,7 +1,7 @@
 .part-browser {
   text-align: center;
-  overflow-x: hidden;
-  overflow-y: hidden; }
+  overflow-x: visible;
+  overflow-y: visible; }
   .part-browser > ul {
     list-style-type: none;
     margin: 0;

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -1,7 +1,7 @@
 .part-browser {
-  text-align: center;
   height: 100%;
   width: 100%;
+  text-align: center;
   overflow-x: auto;
   overflow-y: auto; }
   .part-browser > ul {
@@ -9,25 +9,19 @@
     margin: 0;
     white-space: nowrap;
     padding: 0; }
-  .part-browser > ul.part {
-    text-align: center;
-  }
-  .part-browser > ul.name-part {
-    text-align: left;
-    overflow-x: hidden;
-    text-overflow: ellipsis;
-  }
     .part-browser > ul > li {
       list-style-type: none;
       padding: 0px;
-      margin: 15px 10px 5px 10px;
       text-decoration: none;
       color: black;
       font-size: 10px; }
+      .part-browser > ul > li.decorated-list-item {
+        margin: 15px 10px 5px 10px; }
+      .part-browser > ul > li.name-list-item {
+        margin: 0 0 0 0; }
       .part-browser > ul > li div.part {
         display: inline-block;
-        cursor: pointer;
-      }
+        cursor: pointer; }
       .part-browser > ul > li div.name-part {
         display: inline-block;
         cursor: pointer;
@@ -37,9 +31,11 @@
         height: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
+        padding: 3px 12px 3px 12px; }
       .part-browser > ul > li div.name-part:hover {
-        text-decoration: underline;
         color: #FF7700;
-        background-color:#EEEEEE;
-      }
+        background-color: #EEEEEE; }
+  .part-browser > ul.part {
+    text-align: center; }
+  .part-browser > ul.name-part {
+    text-align: left; }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -22,7 +22,18 @@
       font-size: 10px; }
       .part-browser > ul > li div.part {
         display: inline-block;
-        cursor: pointer; }
+        cursor: pointer;
+      }
       .part-browser > ul > li div.name-part {
         display: inline-block;
-        cursor: pointer; }
+        cursor: pointer;
+        font-size: 12px;
+        color: #3160AB;
+        width: 100%;
+        height: 100%;
+      }
+      .part-browser > ul > li div.name-part:hover {
+        text-decoration: underline;
+        color: #FF7700;
+        background-color:#EEEEEE;
+      }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.css
@@ -1,7 +1,9 @@
 .part-browser {
   text-align: center;
-  overflow-x: visible;
-  overflow-y: visible; }
+  height: 100%;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: auto; }
   .part-browser > ul {
     list-style-type: none;
     margin: 0;
@@ -12,6 +14,8 @@
   }
   .part-browser > ul.name-part {
     text-align: left;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
   }
     .part-browser > ul > li {
       list-style-type: none;
@@ -31,6 +35,8 @@
         color: #3160AB;
         width: 100%;
         height: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       .part-browser > ul > li div.name-part:hover {
         text-decoration: underline;

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -1,9 +1,11 @@
 $part-browser-li-margin-top: 15px;
 
 .part-browser {
+  height: 100%;
+  width: 100%;
   text-align: center;
-  overflow-x: visible;
-  overflow-y: visible;
+  overflow-x: auto;
+  overflow-y: auto;
 
   > ul {
     list-style-type: none;
@@ -30,6 +32,8 @@ $part-browser-li-margin-top: 15px;
         color: #3160AB;
         width: 100%;
         height: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       div.name-part:hover{
         text-decoration: underline;

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -16,7 +16,12 @@ $part-browser-li-margin-top: 15px;
     > li {
       list-style-type: none;
       padding: 0px;
-      margin: $part-browser-li-margin-top 10px 5px 10px;
+      &.decorated-list-item {
+        margin: $part-browser-li-margin-top 10px 5px 10px;
+      }
+      &.name-list-item {
+        margin: 0 0 0 0;
+      }
       text-decoration: none;
       color: black;
       font-size: 10px;
@@ -34,9 +39,10 @@ $part-browser-li-margin-top: 15px;
         height: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 12px 3px 12px;
       }
       div.name-part:hover{
-        text-decoration: underline;
+        //text-decoration: underline;
         color: #FF7700;
         background-color:#EEEEEE;
       }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -29,4 +29,10 @@ $part-browser-li-margin-top: 15px;
       }
     }
   }
+  > ul.part {
+    text-align: center;
+  }
+  > ul.name-part {
+    text-align: left;
+  }
 }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -2,8 +2,8 @@ $part-browser-li-margin-top: 15px;
 
 .part-browser {
   text-align: center;
-  overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-x: visible;
+  overflow-y: visible;
 
   > ul {
     list-style-type: none;

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -23,6 +23,10 @@ $part-browser-li-margin-top: 15px;
         display: inline-block;
         cursor: pointer;
       }
+      div.name-part {
+        display: inline-block;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
+++ b/src/client/js/Widgets/PartBrowser/styles/PartBrowserWidget.scss
@@ -26,6 +26,15 @@ $part-browser-li-margin-top: 15px;
       div.name-part {
         display: inline-block;
         cursor: pointer;
+        font-size: 12px;
+        color: #3160AB;
+        width: 100%;
+        height: 100%;
+      }
+      div.name-part:hover{
+        text-decoration: underline;
+        color: #FF7700;
+        background-color:#EEEEEE;
       }
     }
   }

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -238,15 +238,19 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     GMENode.prototype.isLibraryElement = function () {
         return this._state.core.isLibraryElement(this._state.nodes[this._id].node);
     };
-    
+
     GMENode.prototype.getFullyQualifiedName = function () {
         return this._state.core.getFullyQualifiedName(this._state.nodes[this._id].node);
+    };
+
+    GMENode.prototype.getNamespace = function () {
+        return this._state.core.getNamespace(this._state.nodes[this._id].node);
     };
 
     GMENode.prototype.getLibraryGuid = function () {
         return this._state.core.getLibraryGuid(this._state.nodes[this._id].node);
     };
-    
+
     GMENode.prototype.getCrosscutsInfo = function () {
         return this._state.core.getRegistry(this._state.nodes[this._id].node, REG_KEYS.CROSSCUTS) || [];
     };


### PR DESCRIPTION
New buttons are made available for the part-browser:
- first is a dropdown button where the user can select the namespace and only the elements of that namespace will be shown in the partbrowser
- secondly there is a switch button, so the user can toggle between a name-only and a decorated part-browser (when the name only part-browser is used, the draggable object still remains the decorated one)