### PR TITLE
Fixes #963 Adding and removing library node to main meta sheet removes the node from the global meta.

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
@@ -50,6 +50,7 @@ define([
         this.name = '';
         this._attributeNames = [];
         this._attributes = {};
+        this._inLibrary = false;
         this._skinParts = {
             $name: undefined,
             $attributesContainer: undefined,
@@ -78,17 +79,15 @@ define([
     //jshint camelcase: false
     MetaDecoratorDiagramDesignerWidget.prototype.on_addTo = function () {
         var self = this,
-            node = self._control._client.getNode(self._metaInfo[CONSTANTS.GME_ID]),
-            belongsToLibrary = false;
+            node = self._control._client.getNode(self._metaInfo[CONSTANTS.GME_ID]);
 
         if (node && (node.isLibraryElement() || node.isLibraryRoot())) {
-            belongsToLibrary = true;
             self._inLibrary = true;
         }
 
         this._renderContent();
 
-        if (belongsToLibrary) {
+        if (self._inLibrary) {
             this.readOnlyMode(true);
         } else {
             // set title editable on double-click

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.css
@@ -112,6 +112,14 @@
     width: 15px;
     margin-top: 2px;
     border-radius: 5px; }
+.meta-decorator .meta-lock {
+  position: absolute;
+  top: 0;
+  left: 1px;
+  height: 15px;
+  width: 15px;
+  margin-top: 2px;
+  border-radius: 5px; }
   .meta-decorator.abstract .name {
     font-style: italic;
     color: #aaaaaa; }

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.scss
@@ -156,6 +156,16 @@ $abstract-class-name-color: #AAAAAA;
     border-radius: 5px;
   }
 
+  .meta-lock {
+    position: absolute;
+    top: 0;
+    left: 1px;
+    height: 15px;
+    width: 15px;
+    margin-top: 2px;
+    border-radius: 5px;
+  }
+
   &.abstract {
     .name {
       font-style: italic;

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -518,8 +518,13 @@ define(['js/logger',
 
                     //if the items is not present anywhere else, remove it from the META's global sheet too
                     if (self._metaAspectSheetsPerMember[gmeID].length === 1) {
-                        _client.removeMember(aspectNodeID, gmeID, MetaEditorConstants.META_ASPECT_SET_NAME);
-                        _client.setMeta(gmeID, {});
+                        nodeObj = _client.getNode(gmeID);
+                        if (nodeObj && (nodeObj.isLibraryElement() || nodeObj.isLibraryRoot())) {
+                            //library elements will not be lost at all
+                        } else {
+                            _client.removeMember(aspectNodeID, gmeID, MetaEditorConstants.META_ASPECT_SET_NAME);
+                            _client.setMeta(gmeID, {});
+                        }
                     }
                 } else if (self._connectionListByID.hasOwnProperty(itemsToDelete[len])) {
                     //entity is a connection, just simply delete it
@@ -540,7 +545,12 @@ define(['js/logger',
                 //entity is a box
                 //check to see if this gmeID is present on any other sheet at all
                 if (this._metaAspectSheetsPerMember[gmeID].length === 1) {
-                    metaInfoToBeLost.push(gmeID);
+                    nodeObj = _client.getNode(gmeID);
+                    if (nodeObj && (nodeObj.isLibraryElement() || nodeObj.isLibraryRoot())) {
+                        //library elements will not be lost at all
+                    } else {
+                        metaInfoToBeLost.push(gmeID);
+                    }
                 }
             }
         }
@@ -833,7 +843,12 @@ define(['js/logger',
                 //entity is a box
                 //check to see if this gmeID is present on any other sheet at all
                 if (this._metaAspectSheetsPerMember[gmeID].length === 1) {
-                    metaAspectMemberToBeLost.push(gmeID);
+                    nodeObj = _client.getNode(gmeID);
+                    if (nodeObj && (nodeObj.isLibraryElement() || nodeObj.isLibraryRoot())) {
+                        //library elements will not be lost
+                    } else {
+                        metaAspectMemberToBeLost.push(gmeID);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- now MetaDecorator uses FQN
- the library elements are 'read-only' but can be put onto any sheet
- when removing library elements, they will be removed without question as they cannot loose their meta information
Fixes #955
- constraints now cannot be added/changed for library nodes