### PR TITLE
Continuous integration tests now use node version 4.x and 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ cache:
 #   depth: 5
 
 node_js:
-  - "4.3"
-  - "0.12"
+  - "4"
+  - "6"
 
 env:
   - TEST_BROWSER=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 
 environment:
   matrix:
-  - nodejs_version: "4.2"
+  - nodejs_version: "4"
     platform: x64
   # - nodejs_version: "4.2"
   #   platform: x86


### PR DESCRIPTION
This means webgme now officially supports these versions.