### PR TITLE
Fixes #993 Library Update fails if there were a removal in the library

### DIFF
--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -136,7 +136,7 @@ define([
 
             function removeLibraryRelations(root, path) {
                 var overlay = self.getChild(root, CONSTANTS.OVERLAYS_PROPERTY),
-                    selfOverlays = JSON.parse(JSON.stringify(self.getProperty(overlay, path))),
+                    selfOverlays = JSON.parse(JSON.stringify(self.getProperty(overlay, path) || {})),
                     key, collKey, i;
 
                 for (key in selfOverlays) {

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -9,7 +9,7 @@ describe('Library core ', function () {
 
     var gmeConfig,
         logger,
-            Q,
+        Q,
         expect,
         storage,
         projectName = 'libCoreTests',
@@ -90,9 +90,9 @@ describe('Library core ', function () {
 
     after(function (done) {
         Q.allDone([
-                storage.closeDatabase(),
-                gmeAuth.unload()
-            ])
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
             .nodeify(done);
     });
 
@@ -851,6 +851,98 @@ describe('Library core ', function () {
                 expect(core.getPath(node)).to.equal('/node');
                 expect(core.getPath(core.getBase(node))).to.equal(libPath + '/Cont/toMove');
                 expect(core.getAllMetaNodes(node)[libPath + '/toAdd']).not.to.equal(undefined);
+                expect(core.getAllMetaNodes(node)[libPath + '/Cont']).to.equal(undefined);
+                expect(core.getAllMetaNodes(node)[libPath]).to.equal(undefined);
+                expect(core.getAllMetaNodes(node)[libPath] + '/Cont/toMove').not.to.equal(undefined);
+            })
+            .nodeify(done);
+    });
+
+    it('should update a library with removal of non-language node', function (done) {
+        var firstHash,
+            secondHash,
+            asyncRoot,
+            asyncFco,
+            libPath,
+            buildLibrary = function () {
+                var deferred = Q.defer(),
+                    lRoot = core.createNode(),
+                    lFco = core.createNode({parent: lRoot, base: null, relid: 'FCO'}),
+                    lCont = core.createNode({parent: lRoot, base: lFco, relid: 'Cont'}),
+                    lRem = core.createNode({parent: lCont, base: lFco, relid: 'toRemove'}),
+                    lMov = core.createNode({parent: lRoot, base: lFco, relid: 'toMove'}),
+                    lNew;
+
+                core.setAttribute(lRoot, 'name', 'ROOT');
+                core.setAttribute(lFco, 'name', 'FCO');
+                core.setAttribute(lCont, 'name', 'container');
+                core.setAttribute(lRem, 'name', 'itemToremove');
+                core.setAttribute(lMov, 'name', 'itemToMove');
+
+                core.addMember(lRoot, 'MetaAspectSet', lFco);
+                core.addMember(lRoot, 'MetaAspectSet', lRem);
+                core.addMember(lRoot, 'MetaAspectSet', lMov);
+
+                core.persist(lRoot);
+                firstHash = core.getHash(lRoot);
+
+                core.deleteNode(lCont);
+
+                core.persist(lRoot);
+                secondHash = core.getHash(lRoot);
+            };
+
+        buildLibrary();
+
+        asyncRoot = core.createNode();
+        asyncFco = core.createNode({parent: asyncRoot, base: null, relid: 'FCO'});
+
+        core.setAttribute(asyncRoot, 'name', 'ROOT');
+        core.setAttribute(asyncFco, 'name', 'FCO');
+        core.addMember(asyncRoot, 'MetaAspectSet', asyncFco);
+        expect(core.getPath(core.getFCO(asyncRoot))).to.equal('/FCO');
+
+        core.addLibrary(asyncRoot, 'library', firstHash, {})
+            .then(function () {
+                var libRoot = core.getLibraryRoot(asyncRoot, 'library');
+
+                expect(core.getLibraryNames(asyncRoot)).to.eql(['library']);
+                expect(libRoot).not.to.equal(null);
+                libPath = core.getPath(libRoot);
+                core.persist(asyncRoot);
+
+                return core.loadRoot(core.getHash(asyncRoot));
+            })
+            .then(function (root_) {
+                var node;
+                asyncRoot = root_;
+                asyncFco = core.getFCO(asyncRoot);
+
+                expect(core.getCollectionPaths(asyncFco, 'base')).to.eql([libPath + '/FCO']);
+
+                node = core.createNode({
+                    parent: asyncRoot,
+                    base: core.getAllMetaNodes(asyncRoot)[libPath + '/toMove'],
+                    relid: 'node'
+                });
+                return core.updateLibrary(asyncRoot, 'library', secondHash, {}, {});
+            })
+            .then(function () {
+                expect(core.getLibraryNames(asyncRoot)).to.eql(['library']);
+
+                core.persist(asyncRoot);
+
+                return core.loadRoot(core.getHash(asyncRoot));
+            })
+            .then(function (root_) {
+                asyncRoot = root_;
+                asyncFco = core.getFCO(asyncRoot);
+
+                return core.loadByPath(asyncRoot, '/node');
+            })
+            .then(function (node) {
+                expect(node).not.to.equal(null);
+                expect(core.getPath(node)).to.equal('/node');
                 expect(core.getAllMetaNodes(node)[libPath + '/Cont']).to.equal(undefined);
                 expect(core.getAllMetaNodes(node)[libPath]).to.equal(undefined);
                 expect(core.getAllMetaNodes(node)[libPath] + '/Cont/toMove').not.to.equal(undefined);


### PR DESCRIPTION
In case of non-language components of a library (example models, etc.) it is possible that no reference exists for the element at the time of removal, so we should be prepared for an unknown overlay information.

The change should be 'cherry-picked' into the master branch as well.