### PR TITLE
Delete webgme-token before emitting notification.

### DIFF
--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -865,6 +865,9 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                 getUserIdFromToken(socket, data.webgmeToken)
                     .then(function (userId) {
                         logger.debug('Incoming notification from', userId, {metadata: data});
+                        data.userId = userId;
+                        delete data.webgmeToken;
+
                         if (data.type === CONSTANTS.PLUGIN_NOTIFICATION) {
                             if (data.socketId) {
                                 webSocket.to(data.socketId).emit(CONSTANTS.NOTIFICATION, data);


### PR DESCRIPTION
N.B. This security issue only applies if add-ons are enabled and sends notifications.

Before emitting notifications to the branch room the webgmeToken must be deleted - if not other users will receive that token.