### PR TITLE
Plugin fast forward

### DIFF
--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -14,8 +14,10 @@ define([
     'plugin/PluginResult',
     'plugin/PluginMessage',
     'plugin/PluginNodeDescription',
+    'plugin/util',
     'common/storage/constants',
-], function (PluginConfig, PluginResult, PluginMessage, PluginNodeDescription, STORAGE_CONSTANTS) {
+    'q'
+], function (PluginConfig, PluginResult, PluginMessage, PluginNodeDescription, pluginUtil, STORAGE_CONSTANTS, Q) {
     'use strict';
 
     /**
@@ -493,6 +495,28 @@ define([
             .nodeify(callback);
     };
 
+    PluginBase.prototype.fastForward = function (callback) {
+        var self = this,
+            options;
+
+        return this.project.getBranchHash(this.branchName)
+            .then(function (branchHash) {
+                options = {
+                    activeNode: this.core.getPath(this.activeNode),
+                    activeSelection: this.activeSelection.forEach(function (node) {
+                        return self.core.getPath(node);
+                    }),
+                    namespace: this.namespace
+                };
+                
+                
+            })
+            .then(function () {
+                
+            })
+            .nodeify(callback);
+    };
+
     /**
      * Adds the commit to the results. N.B. if you're using your own save method - make sure to update
      * this.currentHash and this.branchName accordingly before adding the commit.
@@ -505,6 +529,7 @@ define([
             branchName: this.branchName,
             status: status
         };
+
         this.result.addCommit(newCommit);
         this.logger.debug('newCommit added', newCommit);
     };
@@ -540,10 +565,12 @@ define([
         } else {
             this.logger = console;
         }
+
         if (!gmeConfig) {
             // TODO: Remove this check at some point
             throw new Error('gmeConfig was not provided to Plugin.initialize!');
         }
+
         this.blobClient = blobClient;
         this.gmeConfig = gmeConfig;
 
@@ -595,9 +622,8 @@ define([
      * @returns {PluginConfig}
      */
     PluginBase.prototype.getDefaultConfig = function () {
-        var configStructure = this.getConfigStructure();
-
-        var defaultConfig = new PluginConfig();
+        var configStructure = this.getConfigStructure(),
+            defaultConfig = new PluginConfig();
 
         for (var i = 0; i < configStructure.length; i += 1) {
             defaultConfig[configStructure[i].name] = configStructure[i].value;

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -510,17 +510,19 @@ define([
 
         return self.project.getBranchHash(self.branchName)
             .then(function (branchHash) {
-                options = {
-                    activeNode: self.core.getPath(self.activeNode),
-                    activeSelection: self.activeSelection.forEach(function (node) {
-                        return self.core.getPath(node);
-                    }),
-                    namespace: self.namespace
-                };
-
-                if (branchHash === self.currentHash) {
+                if (branchHash === '') {
+                    throw new Error('Branch does not exist [' + self.branchName + ']');
+                } else if (branchHash === self.currentHash) {
                     return false;
                 } else {
+                    options = {
+                        activeNode: self.core.getPath(self.activeNode),
+                        activeSelection: self.activeSelection.forEach(function (node) {
+                            return self.core.getPath(node);
+                        }),
+                        namespace: self.namespace
+                    };
+
                     return pluginUtil.loadNodesAtCommitHash(
                         self.project,
                         self.core,

--- a/src/plugin/managerbase.js
+++ b/src/plugin/managerbase.js
@@ -350,67 +350,6 @@ define([
 
             return deferred.promise;
         };
-
-        this.loadNodeByPath = function (pluginContext, path) {
-            var deferred = Q.defer();
-            pluginContext.core.loadByPath(pluginContext.rootNode, path, function (err, node) {
-                if (err) {
-                    deferred.reject(err);
-                } else {
-                    deferred.resolve(node);
-                }
-            });
-            return deferred.promise;
-        };
-
-        this.loadNodesByPath = function (pluginContext, nodePaths, returnNameMap) {
-            var deferred = Q.defer(),
-                len = nodePaths.length,
-                error = '',
-                nodes = [];
-
-            var allNodesLoadedHandler = function () {
-                var nameToNode = {};
-
-                if (error) {
-                    deferred.reject(error);
-                    return;
-                }
-
-                if (returnNameMap) {
-                    nodes.map(function (node) {
-                        if (nameToNode[pluginContext.core.getFullyQualifiedName(node)]) {
-                            self.logger.error('Meta-nodes share the same full name. Will still proceed..',
-                                pluginContext.core.getFullyQualifiedName(node));
-                        }
-                        nameToNode[pluginContext.core.getFullyQualifiedName(node)] = node;
-                    });
-                    deferred.resolve(nameToNode);
-                } else {
-                    deferred.resolve(nodes);
-                }
-            };
-
-            var loadedNodeHandler = function (err, nodeObj) {
-                if (err) {
-                    error += err;
-                }
-                nodes.push(nodeObj);
-
-                if (nodes.length === nodePaths.length) {
-                    allNodesLoadedHandler();
-                }
-            };
-
-            if (len === 0) {
-                allNodesLoadedHandler();
-            }
-            while (len--) {
-                pluginContext.core.loadByPath(pluginContext.rootNode, nodePaths[len], loadedNodeHandler);
-            }
-
-            return deferred.promise;
-        };
     }
 
     return PluginManagerBase;

--- a/src/plugin/util.js
+++ b/src/plugin/util.js
@@ -1,0 +1,117 @@
+/*globals define*/
+/*jshint node:true, browser: true*/
+/**
+ * Helper functions used by plugins and plugin-managers.
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+define(['q'], function (Q) {
+    'use strict';
+
+    /**
+     *
+     * @param {object} project
+     * @param {object} core
+     * @param {string} commitHash
+     * @param {GmeLogger} logger
+     * @param {object} options
+     * @param {string} [options.activeNode=''] - path to active node
+     * @param {string[]} [options.activeSelection=[]] - paths to selected nodes.
+     * @param {string} [options.namespace=''] - used namespace during execution ('' represents all namespaces).
+     * @param callback
+     * @returns {*}
+     */
+    function loadNodesAtCommitHash(project, core, commitHash, logger, options, callback) {
+        var result = {
+            commitHash: commitHash,
+            rootHash: null,
+            rootNode: null,
+            activeNode: null,
+            activeSelection: null,
+            META: {}
+        };
+
+        return Q.ninvoke(project, 'loadObject', commitHash)
+            .then(function (commitObject) {
+                result.rootHash = commitObject.root;
+                logger.debug('commitObject loaded');
+
+                // Load root node.
+                return core.loadRoot(result.rootHash);
+            })
+            .then(function (rootNode) {
+                result.rootNode = rootNode;
+                logger.debug('rootNode loaded');
+
+                // Load active node.
+                return core.loadByPath(result.rootNode, options.activeNode || '');
+            })
+            .then(function (activeNode) {
+                result.activeNode = activeNode;
+                logger.debug('activeNode loaded');
+
+                // Load active selection.
+                options.activeSelection = options.activeSelection || [];
+
+                return Q.all(options.activeSelection.map(function (nodePath) {
+                    return core.loadByPath(result.rootNode, nodePath);
+                }));
+            })
+            .then(function (activeSelection) {
+                var paths2MetaNodes = core.getAllMetaNodes(result.rootNode),
+                    libraryNames = core.getLibraryNames(result.rootNode),
+                    metaNodeName,
+                    nodeNamespace,
+                    fullName,
+                    path;
+
+                result.activeSelection = activeSelection;
+                logger.debug('activeSelection loaded');
+
+                // Gather the META nodes and "sort" based on given namespace.
+                function startsWith(str, pattern) {
+                    return str.indexOf(pattern) === 0;
+                }
+
+                if (options.namespace) {
+                    if (libraryNames.indexOf(options.namespace) === -1) {
+                        throw new Error('Given namespace does not exist among the available: "' +
+                            libraryNames + '".');
+                    }
+
+                    for (path in paths2MetaNodes) {
+                        nodeNamespace = core.getNamespace(paths2MetaNodes[path]);
+                        metaNodeName = core.getAttribute(paths2MetaNodes[path], 'name');
+
+                        if (startsWith(nodeNamespace, options.namespace)) {
+                            // Trim the based on the chosen namespace (+1 is to remove any dot).
+                            nodeNamespace = nodeNamespace.substring(options.namespace.length + 1);
+                            if (nodeNamespace) {
+                                result.META[nodeNamespace + '.' + metaNodeName] = paths2MetaNodes[path];
+                            } else {
+                                result.META[metaNodeName] = paths2MetaNodes[path];
+                            }
+                        } else {
+                            // Meta node is not within the given namespace and will not be added to META.
+                        }
+                    }
+                } else {
+                    for (path in paths2MetaNodes) {
+                        fullName = core.getFullyQualifiedName(paths2MetaNodes[path]);
+                        if (result.META[fullName]) {
+                            logger.error('Meta-nodes share the same full name. Will still proceed..', fullName);
+                        }
+
+                        result.META[fullName] = paths2MetaNodes[path];
+                    }
+                }
+
+                return result;
+            })
+            .nodeify(callback);
+    }
+
+    return {
+        loadNodesAtCommitHash: loadNodesAtCommitHash
+    };
+});

--- a/test/plugin/coreplugins/ExecutorPlugin/ExecutorPlugin.spec.js
+++ b/test/plugin/coreplugins/ExecutorPlugin/ExecutorPlugin.spec.js
@@ -5,7 +5,7 @@
 
 var testFixture = require('../../../_globals.js');
 
-describe.only('Executor Plugin', function () {
+describe('Executor Plugin', function () {
     'use strict';
 
     var Q = testFixture.Q,

--- a/test/plugin/coreplugins/ExecutorPlugin/ExecutorPlugin.spec.js
+++ b/test/plugin/coreplugins/ExecutorPlugin/ExecutorPlugin.spec.js
@@ -5,7 +5,7 @@
 
 var testFixture = require('../../../_globals.js');
 
-describe('Executor Plugin', function () {
+describe.only('Executor Plugin', function () {
     'use strict';
 
     var Q = testFixture.Q,
@@ -33,8 +33,7 @@ describe('Executor Plugin', function () {
 
         path = require('path'),
         runPlugin = require('../../../../src/bin/run_plugin'),
-        filename = path.normalize('../../../../src/bin/run_plugin.js'),
-        oldProcessExit = process.exit;
+        filename = path.normalize('../../../../src/bin/run_plugin.js');
 
 
     // COPY PASTED CODE STARTS FROM test/server/middleware/executor/worker/node_worker.spec.js
@@ -170,10 +169,6 @@ describe('Executor Plugin', function () {
 
         // COPY PASTED CODE ENDS FROM test/server/middleware/executor/worker/node_worker.spec.js
 
-        afterEach(function () {
-            process.exit = oldProcessExit;
-        });
-
         it('should run ExecutorPlugin and update the model', function (done) {
             var configFileName = './test/plugin/coreplugins/ExecutorPlugin/config.' + platform + '.json',
                 args = [
@@ -189,11 +184,6 @@ describe('Executor Plugin', function () {
                     'b1'];
 
             this.timeout(10000);
-
-            process.exit = function (code) {
-                expect(code).to.equal(0);
-            };
-
 
             Q.ninvoke(runPlugin, 'main', args)
                 .then(function (result) {
@@ -238,11 +228,6 @@ describe('Executor Plugin', function () {
 
             this.timeout(10000);
 
-            process.exit = function (code) {
-                expect(code).to.equal(0);
-            };
-
-
             Q.ninvoke(runPlugin, 'main', args)
                 .then(function (result) {
                     expect(result.success).to.equal(true);
@@ -262,16 +247,15 @@ describe('Executor Plugin', function () {
 
             this.timeout(10000);
 
-            process.exit = function (code) {
-                expect(code).to.equal(1);
-                //done();
-            };
-
-
             runPlugin.main(['node', filename, 'ExecutorPlugin', projectName, '-j', configFileName],
                 function (err, result) {
-                    expect(err).to.equal('No activeNode specified or rootNode. Execute on any other node.');
+                    if (err) {
+                        done(err);
+                        return;
+                    }
+
                     expect(result.success).to.equal(false);
+                    expect(result.error).to.equal('No activeNode specified or rootNode. Execute on any other node.');
                     done();
                 });
         });
@@ -281,15 +265,11 @@ describe('Executor Plugin', function () {
 
             this.timeout(10000);
 
-            process.exit = function (code) {
-                expect(code).to.equal(1);
-            };
-
-
             runPlugin.main(['node', filename, 'ExecutorPlugin', projectName, '-s', '/1', '-j', configFileName],
                 function (err, result) {
                     try {
-                        expect(err.message).to.include('Job execution failed');
+                        expect(err).to.equal(null);
+                        expect(result.error).to.include('Job execution failed');
                         expect(result.success).to.equal(false);
                         expect(result.artifacts instanceof Array).to.equal(true);
                         expect(result.artifacts.length).to.equal(4);

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -33,7 +33,8 @@ describe('CorePlugins', function () {
             'MultipleMainCallbackCalls',
             'PluginForked',
             'InvalidActiveNode',
-            'ConstraintEvaluator'
+            'ConstraintEvaluator',
+            'FastForward'
         ],
 
         pluginsShouldFail = [

--- a/test/plugin/scenarios/FastForward.spec.js
+++ b/test/plugin/scenarios/FastForward.spec.js
@@ -1,0 +1,144 @@
+/*globals*/
+/*jshint node:true, mocha:true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+var testFixture = require('../../_globals');
+
+describe('FastForward test', function () {
+    'use strict';
+
+    var pluginName = 'FastForward',
+        logger = testFixture.logger.fork(pluginName),
+        gmeConfig = testFixture.getGmeConfig(),
+        storage,
+        core,
+        expect = testFixture.expect,
+        Q = testFixture.Q,
+        PluginCliManager = require('../../../src/plugin/climanager'),
+        project,
+        projectName = 'plugin_FastForward',
+        commitHash,
+        gmeAuth;
+
+    before(function (done) {
+        var importParam = {
+            projectSeed: './seeds/EmptyProject.webgmex',
+            projectName: projectName,
+            logger: logger,
+            gmeConfig: gmeConfig
+        };
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                return testFixture.importProject(storage, importParam);
+            })
+            .then(function (importResult) {
+                project = importResult.project;
+                commitHash = importResult.commitHash;
+                core = importResult.core;
+                return Q.allDone([
+                    testFixture.loadRootNodeFromCommit(project, core, commitHash),
+                    project.createBranch('b1', commitHash),
+                    project.createBranch('b2', commitHash)
+                    ]);
+            })
+            .then(function (res) {
+                var persisted;
+                core.setAttribute(res[0], 'name', 'Root2');
+                persisted = core.persist(res[0]);
+                return project.makeCommit('b2', [commitHash], persisted.rootHash, persisted.objects, 'ff');
+            })
+            .nodeify(done);
+    });
+
+    after(function (done) {
+        Q.allDone([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
+            .nodeify(done);
+    });
+
+    it('should succeed when no changes made', function (done) {
+        var pluginContext = {
+                activeNode: '',
+                branchName: 'b1',
+                commitHash: commitHash
+            },
+            pluginManager = new PluginCliManager(project, logger, gmeConfig);
+
+        pluginManager.executePlugin(pluginName, null, pluginContext, function (err, result) {
+            try {
+                expect(result.success).to.equal(true);
+                expect(result.commits.length).to.equal(2);
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('should fast-forward and succeed when "changes made"', function (done) {
+        var pluginContext = {
+                activeNode: '',
+                branchName: 'b2',
+                commitHash: commitHash,
+                activeSelection: ['/1']
+            },
+            pluginManager = new PluginCliManager(project, logger, gmeConfig);
+
+        pluginManager.executePlugin(pluginName, null, pluginContext, function (err, result) {
+            try {
+                expect(result.success).to.equal(true);
+                expect(result.commits.length).to.equal(2);
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('should fail when not running from a branch', function (done) {
+        var pluginContext = {
+                activeNode: '',
+                commitHash: commitHash
+            },
+            pluginManager = new PluginCliManager(project, logger, gmeConfig);
+
+        pluginManager.executePlugin(pluginName, null, pluginContext, function (err, result) {
+            try {
+                expect(result.success).to.equal(false);
+                expect(result.error).to.include('Invalid argument, data.branchName');
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('should fail when running on non-existing branch', function (done) {
+        var pluginContext = {
+                activeNode: '',
+                branchName: 'doesNotExist',
+                commitHash: commitHash
+            },
+            pluginManager = new PluginCliManager(project, logger, gmeConfig);
+
+        pluginManager.executePlugin(pluginName, null, pluginContext, function (err, result) {
+            try {
+                expect(result.success).to.equal(false);
+                expect(result.error).to.include('Branch does not exist');
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+});

--- a/test/plugin/scenarios/plugins/FastForward/FastForward.js
+++ b/test/plugin/scenarios/plugins/FastForward/FastForward.js
@@ -1,0 +1,55 @@
+/*globals define*/
+/*jshint node:true, browser:true*/
+
+if (typeof define === 'undefined') {
+
+} else {
+    define([
+        'plugin/PluginConfig',
+        'plugin/PluginBase',
+        'text!./metadata.json'
+    ], function (PluginConfig,
+                 PluginBase,
+                 pluginMetadata) {
+        'use strict';
+
+        pluginMetadata = JSON.parse(pluginMetadata);
+        var FastForward = function () {
+            // Call base class' constructor.
+            PluginBase.call(this);
+            this.pluginMetadata = pluginMetadata;
+        };
+
+        FastForward.metadata = pluginMetadata;
+
+        FastForward.prototype = Object.create(PluginBase.prototype);
+        FastForward.prototype.constructor = FastForward;
+
+        FastForward.prototype.main = function (callback) {
+            var self = this,
+                startingCommitHash = self.currentHash;
+
+            self.fastForward()
+                .then(function (didUpdate) {
+                    if (didUpdate === true && startingCommitHash === self.currentHash) {
+                        throw new Error('didUpdate was true but still on same currentHash!');
+                    } else if (didUpdate === false && startingCommitHash !== self.currentHash) {
+                        throw new Error('didUpdate was false but changed currentHash!');
+                    }
+
+                    self.core.setAttribute(self.activeNode, 'name', 'aNewNameWasSet');
+
+                    return self.save('changed name of activeNode');
+                })
+                .then(function () {
+                    self.result.setSuccess(true);
+                    callback(null, self.result);
+                })
+                .catch(function (err) {
+                    callback(err, self.result);
+                });
+        };
+
+        return FastForward;
+    });
+}

--- a/test/plugin/scenarios/plugins/FastForward/metadata.json
+++ b/test/plugin/scenarios/plugins/FastForward/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "FastForward",
+  "name": "Fast Forward",
+  "version": "2.2.0",
+  "description": "",
+  "icon": {
+    "src": "",
+    "class": "fa fa-cogs"
+  },
+  "disableServerSideExecution": false,
+  "disableBrowserSideExecution": false,
+  "configStructure": []
+}


### PR DESCRIPTION
Add plugin-base method `.fastForward` to update affected plugin instance nodes and fields to the "current" hash of the branch.
N.B. Any plugin specifically saved node-references will of course not be updated by this method. This method is used when waiting for a long running execution job or spawned job. Any changes to the model should be done after a fast-forward invocation.

This PR also moves the process.exit calls in `bin/run_plugin.js` to take place in the ` if (require.main === module)`-clause. Further the main does not return error if the plugin fails expectedly. In that case the caller should checked the `result.success` and `result.error`.
