### PR TITLE
Get api/users should return same user structure as /user and /users/:username.

### DIFF
--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -496,7 +496,8 @@ function GMEAuth(session, gmeConfig) {
                 var i;
                 for (i = 0; i < userDataArray.length; i += 1) {
                     delete userDataArray[i].passwordHash;
-                    // TODO: Consider removing settings and data here.
+                    userDataArray[i].data = userDataArray[i].data || {};
+                    userDataArray[i].settings = userDataArray[i].settings || {};
                 }
                 return userDataArray;
             })


### PR DESCRIPTION
gmeAuth.listUsers now adds empty settings and data - if not present.