### PR TITLE
Auto merge when making commits

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -194,6 +194,8 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
  - Time in milliseconds (after a new bucket has been created) before triggering a load of objects from the server.
 - `config.storage.keyType = 'plainSha'`
  - Algorithm used when hashing the objects in the database, can be `'plainSHA1'`, `'rand160Bits'` or `'ZSSHA'`.
+- `config.storage.autoMerge.enable = false`
+ - (N.B. Experimental feature) If enable, incoming commits to branches that initially were `FORKED` will be attempted to be merged with the head of the branch. Use with caution as larger (+100k nodes) projects can slow down the commit rate.
 - `config.storage.database.type = 'mongo'`
  - Type of database to store the data (metadata e.g. _users is always stored in mongo), can be `'mongo'`, `'redis'` or `'memory'`.
 - `config.storage.database.options = '{}'`

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -186,7 +186,7 @@ var path = require('path'),
             loadBucketTimer: 10,
             clientCacheSize: 2000, // overwrites cache on client
             autoMerge: {
-                enable: true
+                enable: false
             },
             keyType: 'plainSHA1', // 'rand160Bits', 'ZSSHA', 'plainSHA1',
             database: {

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -185,6 +185,9 @@ var path = require('path'),
             loadBucketSize: 100,
             loadBucketTimer: 10,
             clientCacheSize: 2000, // overwrites cache on client
+            autoMerge: {
+                enable: true
+            },
             keyType: 'plainSHA1', // 'rand160Bits', 'ZSSHA', 'plainSHA1',
             database: {
                 type: 'mongo', // mongo, redis, memory

--- a/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
+++ b/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
@@ -121,6 +121,8 @@ define(['js/util',
                     message = 'started from';
                 } else if (commits[c].status === storageUtil.CONSTANTS.SYNCED) {
                     message = 'updated';
+                } else if (commits[c].status === storageUtil.CONSTANTS.MERGED) {
+                    message = 'merged into';
                 } else if (!commits[c].status) {
                     // When null or undefined there was no branch target for the commit..
                     message = 'made commit';

--- a/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
+++ b/src/client/js/Widgets/BranchStatus/BranchStatusWidget.js
@@ -182,6 +182,9 @@ define([
             case CONSTANTS.CLIENT.BRANCH_STATUS.AHEAD_SYNC:
                 this._branchAhead(eventData);
                 break;
+            case CONSTANTS.CLIENT.BRANCH_STATUS.MERGING:
+                this._branchMerging(eventData);
+                break;
             case CONSTANTS.CLIENT.BRANCH_STATUS.PULLING:
                 this._branchPulling(eventData);
                 break;
@@ -243,6 +246,12 @@ define([
         });
         this._ddBranchStatus.setTitle('AHEAD[' + eventData.commitQueue.length + ']');
         this._ddBranchStatus.setColor(DropDownMenu.prototype.COLORS.LIGHT_BLUE);
+    };
+
+    BranchStatusWidget.prototype._branchMerging = function (eventData) {
+        this._ddBranchStatus.clear();
+        this._ddBranchStatus.setTitle('MERGING[' + eventData.commitQueue.length + ']');
+        this._ddBranchStatus.setColor(DropDownMenu.prototype.COLORS.BLUE);
     };
 
     BranchStatusWidget.prototype._branchPulling = function (eventData) {

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -62,9 +62,9 @@ define([
             });
 
         Q.all([
-                getRoot({project: parameters.project, core: core, id: parameters.branchOrCommitA}),
-                getRoot({project: parameters.project, core: core, id: parameters.branchOrCommitB})
-            ])
+            getRoot({project: parameters.project, core: core, id: parameters.branchOrCommitA}),
+            getRoot({project: parameters.project, core: core, id: parameters.branchOrCommitB})
+        ])
             .then(function (results) {
                 core.generateTreeDiff(results[0].root, results[1].root, function (err, diff) {
                     if (err) {
@@ -79,13 +79,25 @@ define([
         return deferred.promise.nodeify(callback);
     }
 
+    /**
+     *
+     * @param {object} parameters
+     * @param {object} parameters.gmeConfig
+     * @param {object} parameters.logger
+     * @param {object} parameters.project
+     * @param {string} parameters.branchOrCommit
+     * @param {string} [parameters.branchName]
+     * @param {boolean} [parameters.noUpdate=false]
+     * @param callback
+     * @returns {*}
+     */
     function apply(parameters, callback) {
         var core = new Core(parameters.project, {
                 globConf: parameters.gmeConfig,
                 logger: parameters.logger.fork('core')
             }),
             applyDeferred = Q.defer(),
-            branchName = null;
+            branchName = parameters.branchName;
 
         getRoot({project: parameters.project, core: core, id: parameters.branchOrCommit})
             .then(function (result) {
@@ -126,6 +138,12 @@ define([
         return applyDeferred.promise.nodeify(callback);
     }
 
+    /**
+     *
+     * @param parameters
+     * @param callback
+     * @returns {*}
+     */
     function merge(parameters, callback) {
         var deferred = Q.defer(),
             result = {},
@@ -135,109 +153,112 @@ define([
                 globConf: parameters.gmeConfig,
                 logger: parameters.logger.fork('core')
             }),
-            branchName = REGEXP.HASH.test(parameters.theirBranchOrCommit) ? null : parameters.theirBranchOrCommit,
-            updateBranch = function () {
-                var branchDeferred = Q.defer();
+            branchName;
 
-                parameters.project.setBranchHash(
-                    branchName,
-                    result.finalCommitHash,
-                    result.theirCommitHash,
-                    function (err) {
-                        if (!err) {
-                            result.updatedBranch = branchName;
-                        }
-                        branchDeferred.resolve();
+        // Allow to tie down commit and still update branch.
+        branchName = parameters.branchName ||
+        REGEXP.HASH.test(parameters.theirBranchOrCommit) ? null : parameters.theirBranchOrCommit;
+
+        function updateBranch() {
+            return parameters.project.setBranchHash(
+                branchName,
+                result.finalCommitHash,
+                result.theirCommitHash)
+                .then(function (result) {
+                    if (result.status !== 'FORKED') {
+                        // Branch was updated
+                        result.updatedBranch = branchName;
+                    } else {
+                        parameters.logger.debug('merged commit forked', result);
                     }
-                );
+                });
+        }
 
-                return branchDeferred.promise;
-            },
-            doMerge = function () {
-                var mergeDeferred = Q.defer(),
-                    noApply = false;
+        function doMerge() {
+            var mergeDeferred = Q.defer(),
+                noApply = false;
 
-                Q.allSettled([
-                        diff({
-                            gmeConfig: parameters.gmeConfig,
-                            logger: parameters.logger,
-                            project: parameters.project,
-                            branchOrCommitA: result.baseCommitHash,
-                            branchOrCommitB: parameters.myBranchOrCommit
-                        }),
-                        diff({
-                            gmeConfig: parameters.gmeConfig,
-                            logger: parameters.logger,
-                            project: parameters.project,
-                            branchOrCommitA: result.baseCommitHash,
-                            branchOrCommitB: parameters.theirBranchOrCommit
-                        })
-                    ])
-                    .then(function (diffs) {
-                        if (diffs[0].state === 'rejected') {
-                            parameters.logger.error('Initial diff generation failed (base->mine)', diffs[0].reason);
-                            throw diffs[0].reason;
-                        }
-                        if (diffs[1].state === 'rejected') {
-                            parameters.logger.error('Initial diff generation failed (base->theirs)', diffs[1].reason);
-                            throw diffs[1].reason;
-                        }
-                        result.diff = {
-                            mine: diffs[0].value,
-                            theirs: diffs[1].value
-                        };
+            Q.allSettled([
+                diff({
+                    gmeConfig: parameters.gmeConfig,
+                    logger: parameters.logger,
+                    project: parameters.project,
+                    branchOrCommitA: result.baseCommitHash,
+                    branchOrCommitB: parameters.myBranchOrCommit
+                }),
+                diff({
+                    gmeConfig: parameters.gmeConfig,
+                    logger: parameters.logger,
+                    project: parameters.project,
+                    branchOrCommitA: result.baseCommitHash,
+                    branchOrCommitB: parameters.theirBranchOrCommit
+                })
+            ])
+                .then(function (diffs) {
+                    if (diffs[0].state === 'rejected') {
+                        parameters.logger.error('Initial diff generation failed (base->mine)', diffs[0].reason);
+                        throw diffs[0].reason;
+                    }
+                    if (diffs[1].state === 'rejected') {
+                        parameters.logger.error('Initial diff generation failed (base->theirs)', diffs[1].reason);
+                        throw diffs[1].reason;
+                    }
+                    result.diff = {
+                        mine: diffs[0].value,
+                        theirs: diffs[1].value
+                    };
 
-                        result.conflict = core.tryToConcatChanges(result.diff.mine, result.diff.theirs);
-                        if (!parameters.auto) {
-                            noApply = true;
-                            return;
-                        }
+                    result.conflict = core.tryToConcatChanges(result.diff.mine, result.diff.theirs);
+                    if (!parameters.auto) {
+                        noApply = true;
+                        return;
+                    }
 
-                        if (!result.conflict) {
-                            parameters.logger.error('Initial diff concatenation failed');
-                            throw new Error('error during merged patch calculation');
-                        }
+                    if (!result.conflict) {
+                        parameters.logger.error('Initial diff concatenation failed');
+                        throw new Error('error during merged patch calculation');
+                    }
 
-                        if (result.conflict.items.length > 0) {
-                            //the user will find out that there were no update done
-                            if (branchName) {
-                                result.targetBranchName = branchName;
-                            }
-                            result.projectId = parameters.project.projectId;
-                            noApply = true;
-                            return;
-                        }
-
-                        return apply({
-                            gmeConfig: parameters.gmeConfig,
-                            logger: parameters.logger,
-                            project: parameters.project,
-                            branchOrCommit: result.baseCommitHash,
-                            noUpdate: true,
-                            patch: result.conflict.merge,
-                            parents: [result.theirCommitHash, result.myCommitHash]
-                        });
-                    })
-                    .then(function (applyResult) {
-                        if (noApply) {
-                            return;
-                        }
-                        //we made the commit, but now we also have try to update the branch of necessary
-                        result.finalCommitHash = applyResult.hash;
+                    if (result.conflict.items.length > 0) {
+                        //the user will find out that there were no update done
                         if (branchName) {
-                            return updateBranch();
+                            result.targetBranchName = branchName;
                         }
-                    })
-                    .then(mergeDeferred.resolve)
-                    .catch(mergeDeferred.reject);
+                        result.projectId = parameters.project.projectId;
+                        noApply = true;
+                        return;
+                    }
 
-                return mergeDeferred.promise;
-            };
+                    return apply({
+                        gmeConfig: parameters.gmeConfig,
+                        logger: parameters.logger,
+                        project: parameters.project,
+                        branchOrCommit: result.baseCommitHash,
+                        branchName: branchName,
+                        patch: result.conflict.merge,
+                        parents: [result.theirCommitHash, result.myCommitHash]
+                    });
+                })
+                .then(function (applyResult) {
+                    if (noApply) {
+                        return;
+                    }
+                    //we made the commit, but now we also have try to update the branch of necessary
+                    result.finalCommitHash = applyResult.hash;
+                    if (branchName) {
+                        return updateBranch();
+                    }
+                })
+                .then(mergeDeferred.resolve)
+                .catch(mergeDeferred.reject);
+
+            return mergeDeferred.promise;
+        }
 
         Q.allSettled([
-                getRoot({project: parameters.project, core: core, id: parameters.myBranchOrCommit}),
-                getRoot({project: parameters.project, core: core, id: parameters.theirBranchOrCommit})
-            ])
+            getRoot({project: parameters.project, core: core, id: parameters.myBranchOrCommit}),
+            getRoot({project: parameters.project, core: core, id: parameters.theirBranchOrCommit})
+        ])
             .then(function (results) {
                 myRoot = results[0].value.root;
                 theirRoot = results[1].value.root;

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -275,7 +275,7 @@ define([
                 var ms = Date.now() - startTime,
                     min = Math.floor(ms/1000/60),
                     sec = (ms/1000) % 60;
-                console.log('Merge exec time', min, 'min', sec, 'sec');
+                parameters.logger.debug('Merge exec time', min, 'min', sec, 'sec');
                 deferred.resolve(result);
             })
             .catch(deferred.reject);

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -222,7 +222,7 @@ define([
                     if (!noApply) {
                         // The result was applied in a new commit ..
                         result.finalCommitHash = applyResult.hash;
-                        if (branchName && applyResult.status !== 'FORKED') {
+                        if (branchName && applyResult.status !== CONSTANTS.FORKED) {
                             // and a branch was updated successfully.
                             result.updatedBranch = branchName;
                         }

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -144,7 +144,7 @@ define([
                 result.finalCommitHash,
                 result.theirCommitHash)
                 .then(function (commitResult) {
-                    if (commitResult.status !== 'FORKED') {
+                    if (commitResult.status !== CONSTANTS.FORKED) {
                         // Branch was updated
                         result.updatedBranch = branchName;
                     } else {

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -132,6 +132,7 @@ define([
                 globConf: parameters.gmeConfig,
                 logger: parameters.logger.fork('core')
             }),
+            startTime = Date.now(),
             branchName;
 
         // Allow to tie down commit and still update branch.
@@ -271,6 +272,10 @@ define([
                 return doMerge();
             })
             .then(function () {
+                var ms = Date.now() - startTime,
+                    min = Math.floor(ms/1000/60),
+                    sec = (ms/1000) % 60;
+                console.log('Merge exec time', min, 'min', sec, 'sec');
                 deferred.resolve(result);
             })
             .catch(deferred.reject);

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -213,23 +213,22 @@ define([
                         logger: parameters.logger,
                         project: parameters.project,
                         branchOrCommit: result.baseCommitHash,
-                        branchName: branchName,
                         patch: result.conflict.merge,
                         parents: [result.theirCommitHash, result.myCommitHash]
                     });
                 })
                 .then(function (applyResult) {
-                    if (!noApply) {
-                        // The result was applied in a new commit ..
-                        result.finalCommitHash = applyResult.hash;
-                        if (branchName && applyResult.status !== CONSTANTS.FORKED) {
-                            // and a branch was updated successfully.
-                            result.updatedBranch = branchName;
-                        }
+                    if (noApply) {
+                        return;
                     }
-
-                    mergeDeferred.resolve();
+                    //we made the commit, but now we also have try to update the branch of necessary
+                    result.finalCommitHash = applyResult.hash;
+                    if (branchName) {
+                        result.targetBranchName = branchName;
+                        return updateBranch();
+                    }
                 })
+                .then(mergeDeferred.resolve)
                 .catch(mergeDeferred.reject);
 
             return mergeDeferred.promise;

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -143,12 +143,12 @@ define([
                 branchName,
                 result.finalCommitHash,
                 result.theirCommitHash)
-                .then(function (result) {
-                    if (result.status !== 'FORKED') {
+                .then(function (commitResult) {
+                    if (commitResult.status !== 'FORKED') {
                         // Branch was updated
                         result.updatedBranch = branchName;
                     } else {
-                        parameters.logger.debug('merged commit forked', result);
+                        parameters.logger.debug('merged commit forked', commitResult);
                     }
                 });
         }
@@ -219,13 +219,13 @@ define([
                     });
                 })
                 .then(function (applyResult) {
-                    if (noApply) {
-                        return;
-                    }
-                    //we made the commit, but now we also have try to update the branch of necessary
-                    result.finalCommitHash = applyResult.hash;
-                    if (branchName && applyResult.status !== 'FORKED') {
-                        result.updatedBranch = branchName;
+                    if (!noApply) {
+                        // The result was applied in a new commit ..
+                        result.finalCommitHash = applyResult.hash;
+                        if (branchName && applyResult.status !== 'FORKED') {
+                            // and a branch was updated successfully.
+                            result.updatedBranch = branchName;
+                        }
                     }
 
                     mergeDeferred.resolve();

--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -96,6 +96,7 @@ define([], function () {
             AHEAD_SYNC: 'AHEAD_SYNC',
             AHEAD_NOT_SYNC: 'AHEAD_NOT_SYNC',
             PULLING: 'PULLING',
+            MERGING: 'MERGING',
             ERROR: 'ERROR'
         },
 

--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -89,7 +89,7 @@ define([], function () {
         SYNCED: 'SYNCED', // The commitData was inserted in the database and the branchHash updated.
         FORKED: 'FORKED', // The commitData was inserted in the database, but the branchHash NOT updated.
         CANCELED: 'CANCELED', // The commitData was never inserted to the database.
-        MERGED: 'MERGED', // This is currently not used
+        MERGED: 'MERGED', // The commit was initially forked, but successfully merged.
 
         BRANCH_STATUS: {
             SYNC: 'SYNC',

--- a/src/common/storage/project/branch.js
+++ b/src/common/storage/project/branch.js
@@ -94,18 +94,23 @@ define(['common/storage/constants'], function (CONSTANTS) {
             return commitData;
         };
 
-        this.getMergedCommit = function (theirHash, mergeHash) {
+        this.getMergedCommit = function (mergeHash) {
             var mergeCommit,
                 i = updateQueue.length;
 
             while (i) {
                 i -= 1;
                 if (updateQueue[i].commitObject[CONSTANTS.MONGO_ID] === mergeHash) {
-                    mergeCommit = updateQueue.splice(i, 1)[0];
-                } else if (updateQueue[i].commitObject[CONSTANTS.MONGO_ID] === theirHash) {
-                    updateQueue.splice(i, 1);
+                    mergeCommit = updateQueue[i];
+                    break;
                 }
             }
+
+            if (!mergeCommit) {
+                logger.error('mergeCommit not available in updateQueue', mergeHash, JSON.stringify(updateQueue, null, 2));
+            }
+
+            updateQueue = [];
 
             return mergeCommit;
         };

--- a/src/common/storage/project/branch.js
+++ b/src/common/storage/project/branch.js
@@ -94,6 +94,22 @@ define(['common/storage/constants'], function (CONSTANTS) {
             return commitData;
         };
 
+        this.getMergedCommit = function (theirHash, mergeHash) {
+            var mergeCommit,
+                i = updateQueue.length;
+
+            while (i) {
+                i -= 1;
+                if (updateQueue[i].commitObject[CONSTANTS.MONGO_ID] === mergeHash) {
+                    mergeCommit = updateQueue.splice(i, 1)[0];
+                } else if (updateQueue[i].commitObject[CONSTANTS.MONGO_ID] === theirHash) {
+                    updateQueue.splice(i, 1);
+                }
+            }
+
+            return mergeCommit;
+        };
+
         this.getCommitQueue = function () {
             return commitQueue;
         };

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -584,15 +584,9 @@ define([
                             branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.MERGING);
                             branch.updateHashes(null, result.mergeHash);
 
-                            // Finds the MERGED commit-data and the commit that made us merge.
-                            // These are removed from the update queue.
-                            mergeCommitData = branch.getMergedCommit(result.hash, result.mergeHash);
-
-                            if (!mergeCommitData) {
-                                console.log(JSON.stringify(branch.getUpdateQueue(), null, 2));
-                            }
-
                             if (branch.getCommitQueue().length === 1) {
+                                // Finds the MERGED commit-data and clears the update-queue.
+                                mergeCommitData = branch.getMergedCommit(result.mergeHash);
                                 branch.dispatchHashUpdate({commitData: mergeCommitData, local: false},
                                     function (err, proceed) {
                                         branch.getFirstCommit(true);

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -581,12 +581,12 @@ define([
                             }
                         } else if (result.status === CONSTANTS.MERGED) {
                             branch.inSync = true;
-                            branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.MERGING);
                             branch.updateHashes(null, result.mergeHash);
 
                             if (branch.getCommitQueue().length === 1) {
                                 // Finds the MERGED commit-data and clears the update-queue.
                                 mergeCommitData = branch.getMergedCommit(result.mergeHash);
+                                branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.MERGING);
                                 branch.dispatchHashUpdate({commitData: mergeCommitData, local: false},
                                     function (err, proceed) {
                                         branch.getFirstCommit(true);
@@ -608,6 +608,7 @@ define([
                                 );
                             } else {
                                 branch.getFirstCommit(true);
+                                branch.dispatchBranchStatus(CONSTANTS.BRANCH_STATUS.MERGING);
                                 self._pushNextQueuedCommit(projectId, branchName);
                             }
                         } else if (result.status === CONSTANTS.FORKED) {

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -454,6 +454,12 @@ define([
                             self.currentHash = commitResult.hash; // This is needed in case hash is randomly generated.
                             return self._createFork();
                         });
+                } else if (commitResult.status === STORAGE_CONSTANTS.MERGED) {
+                    self.currentHash = commitResult.mergeHash;
+                    self.addCommitToResult(STORAGE_CONSTANTS.MERGED);
+                    // N.B. If the plugin makes multiple saves, it should fast-forward after a merged commit.
+                    // Otherwise each new commit will have to be merge as well.
+                    return commitResult;
                 } else if (!self.branchName) {
                     self.currentHash = commitResult.hash;
                     self.addCommitToResult(null);

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -497,6 +497,9 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
                             workerManager.request(workerParameters, function (err, result) {
                                 if (err) {
+                                    logger.error('Merging failed', err);
+                                    // TODO: This should return FORKED and not mess up the user.
+                                    // TODO: Keeping it to detect these issues.
                                     callback(err);
                                 } else {
                                     if (result.conflict && result.conflict.items.length > 0) {
@@ -506,16 +509,14 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                     } else if (result.updatedBranch) {
                                         logger.info('Merge successful', commitStatus);
                                         // The auto-merge updated the branch.
-                                        process.nextTick(function () {
-                                            callback(null, {
-                                                status: CONSTANTS.MERGED,
-                                                hash: commitStatus.hash,
-                                                theirHash: result.theirCommitHash,
-                                                mergeHash: result.finalCommitHash
-                                            });
+                                        callback(null, {
+                                            status: CONSTANTS.MERGED,
+                                            hash: commitStatus.hash,
+                                            theirHash: result.theirCommitHash,
+                                            mergeHash: result.finalCommitHash
                                         });
                                     } else {
-                                        logger.info('This should be an option - otherwise all workers could be locked!');
+                                        logger.error('No conflict nor an updateBranch, something went wrong...');
                                     }
                                 }
                             });

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -485,7 +485,11 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         });
                     })
                     .then(function () {
-                        callback(null, commitStatus);
+                        if (commitStatus.status === 'FORKED' && gmeConfig.storage.autoMerge.enable) {
+                            workerManager.request(data, callback);
+                        } else {
+                            callback(null, commitStatus);
+                        }
                     })
                     .catch(function (err) {
                         if (gmeConfig.debug) {

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -281,7 +281,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                     userId: null,
                     serverVersion: PACKAGE_JSON.version
                 };
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         info.userId = userId;
                         callback(null, info);
@@ -293,7 +293,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             // watcher functions
             socket.on('watchDatabase', function (data, callback) {
                 logger.debug('watchDatabase', {metadata: data});
-                if (data.join) {
+                if (data && data.join) {
                     socket.join(CONSTANTS.DATABASE_ROOM);
                 } else {
                     socket.leave(CONSTANTS.DATABASE_ROOM);
@@ -303,7 +303,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             socket.on('watchProject', function (data, callback) {
                 logger.debug('watchProject', {metadata: data});
-
+                data = data || {};
                 projectAccess(socket, data.webgmeToken, data.projectId)
                     .then(function (access) {
                         if (data.join) {
@@ -333,6 +333,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             socket.on('watchBranch', function (data, callback) {
                 // This is emitted from clients that got disconnected while having branches open.
                 logger.debug('watchBranch', {metadata: data});
+                data = data || {};
                 projectAccess(socket, data.webgmeToken, data.projectId)
                     .then(function (access) {
                         if (data.join) {
@@ -400,7 +401,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             socket.on('closeProject', function (data, callback) {
                 logger.debug('closeProject', {metadata: data});
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         return metadataStorage.updateProjectInfo(data.projectId, {
                             viewedAt: (new Date()).toISOString(),
@@ -422,7 +423,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             socket.on('openBranch', function (data, callback) {
                 var latestCommitData;
                 logger.debug('openBranch', {metadata: data});
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         // This ensures read access.
@@ -449,6 +450,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             socket.on('closeBranch', function (data, callback) {
                 logger.debug('closeBranch', {metadata: data});
+                data = data || {};
                 leaveBranchRoom(socket, data.projectId, data.branchName)
                     .fail(function (err) {
                         logger.error(err);
@@ -459,7 +461,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             socket.on('makeCommit', function (data, callback) {
                 var commitStatus;
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         var roomName;
                         if (data.branchName) {
@@ -547,7 +549,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('loadObjects', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.loadObjects(data);
@@ -565,7 +567,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('loadPaths', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.loadPaths(data);
@@ -584,7 +586,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             socket.on('setBranchHash', function (data, callback) {
                 var status;
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         if (socket.rooms.hasOwnProperty(data.projectId)) {
                             data.socket = socket;
@@ -618,7 +620,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getBranchHash', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getBranchHash(data);
@@ -636,7 +638,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getProjects', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getProjects(data);
@@ -654,7 +656,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('deleteProject', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         if (socket.rooms.hasOwnProperty(CONSTANTS.DATABASE_ROOM)) {
                             data.socket = socket;
@@ -676,7 +678,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('createProject', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         if (socket.rooms.hasOwnProperty(CONSTANTS.DATABASE_ROOM)) {
                             data.socket = socket;
@@ -698,7 +700,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('transferProject', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         if (socket.rooms.hasOwnProperty(CONSTANTS.DATABASE_ROOM)) {
                             data.socket = socket;
@@ -720,7 +722,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('duplicateProject', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         if (socket.rooms.hasOwnProperty(CONSTANTS.DATABASE_ROOM)) {
                             data.socket = socket;
@@ -742,7 +744,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getBranches', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getBranches(data);
@@ -760,7 +762,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('createTag', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.createTag(data);
@@ -778,7 +780,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('deleteTag', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.deleteTag(data);
@@ -796,7 +798,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getTags', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getTags(data);
@@ -814,7 +816,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getCommits', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getCommits(data);
@@ -832,7 +834,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getHistory', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getHistory(data);
@@ -850,7 +852,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getLatestCommitData', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getLatestCommitData(data);
@@ -868,7 +870,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('getCommonAncestorCommit', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getCommonAncestorCommit(data);
@@ -887,7 +889,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
 
             //worker commands
             socket.on('simpleRequest', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.userId = userId;
                         data.socketId = socket.id;
@@ -943,7 +945,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on('notification', function (data, callback) {
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         logger.debug('Incoming notification from', userId, {metadata: data});
                         data.userId = userId;

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -486,7 +486,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                     })
                     .then(function () {
                         var workerParameters;
-                        if (commitStatus.status === storage.CONSTANTS.FORKED && gmeConfig.storage.autoMerge.enable) {
+                        if (commitStatus.status === CONSTANTS.FORKED && gmeConfig.storage.autoMerge.enable) {
                             workerParameters = {
                                 projectId: data.projectId,
                                 mine: commitStatus.hash,
@@ -504,8 +504,9 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                     } else if (result.branchName) {
                                         // The auto-merge updated the branch.
                                         callback(null, {
-                                            status: storage.CONSTANTS.MERGED,
+                                            status: CONSTANTS.MERGED,
                                             hash: commitStatus.hash,
+                                            theirHash: result.theirCommitHash,
                                             mergeHash: result.finalCommitHash
                                         });
                                     } else {

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -369,7 +369,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                 var branches,
                     access;
                 logger.debug('openProject', {metadata: data});
-                getUserIdFromToken(socket, data.webgmeToken)
+                getUserIdFromToken(socket, data && data.webgmeToken)
                     .then(function (userId) {
                         data.username = userId;
                         return storage.getBranches(data);

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -406,7 +406,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                             .then(function (result) {
                                 if (result.conflict && result.conflict.items.length > 0) {
                                     return result;
-                                } else if (result.targetBranchName && !result.updateBranch) {
+                                } else if (result.targetBranchName && !result.updatedBranch) {
                                     return mergeTillSyncOrConflict(result.finalCommitHash);
                                 } else {
                                     return result;

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -404,7 +404,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                             auto: true
                         })
                             .then(function (result) {
-                                if (result.conflict && result.conflict.items > 0) {
+                                if (result.conflict && result.conflict.items.length > 0) {
                                     return result;
                                 } else if (result.targetBranchName && !result.updateBranch) {
                                     return mergeTillSyncOrConflict(result.finalCommitHash);

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -388,19 +388,33 @@ function WorkerRequests(mainLogger, gmeConfig) {
                 storage = storage_;
 
                 storage.openProject(projectId, function (err, project /*, branches*/) {
+                    var mergeLogger = logger.fork('merge');
                     if (err) {
                         finish(err);
                         return;
                     }
 
-                    merger.merge({
+                    function mergeTillSyncOrConflict(currentMine) {
+                        return merger.merge({
                             project: project,
                             gmeConfig: gmeConfig,
-                            logger: logger.fork('merge'),
-                            myBranchOrCommit: mine,
+                            logger: mergeLogger,
+                            myBranchOrCommit: currentMine,
                             theirBranchOrCommit: theirs,
                             auto: true
                         })
+                            .then(function (result) {
+                                if (result.conflict && result.conflict.items > 0) {
+                                    return result;
+                                } else if (result.targetBranchName && !result.updateBranch) {
+                                    return mergeTillSyncOrConflict(result.finalCommitHash);
+                                } else {
+                                    return result;
+                                }
+                            });
+                    }
+
+                    mergeTillSyncOrConflict(mine)
                         .nodeify(finish);
                 });
             })

--- a/test/common/core/users/merge.spec.js
+++ b/test/common/core/users/merge.spec.js
@@ -160,7 +160,7 @@ describe('merge - library', function () {
             .catch(done);
     });
 
-    it.only('should return the conflict object if there are conflicting changes and resolve them', function (done) {
+    it('should return the conflict object if there are conflicting changes and resolve them', function (done) {
         var masterBranch = 'resolveMaster',
             otherBranch = 'resolveOther',
             masterContext,

--- a/test/common/core/users/merge.spec.js
+++ b/test/common/core/users/merge.spec.js
@@ -160,7 +160,7 @@ describe('merge - library', function () {
             .catch(done);
     });
 
-    it('should return the conflict object if there are conflicting changes and resolve them', function (done) {
+    it.only('should return the conflict object if there are conflicting changes and resolve them', function (done) {
         var masterBranch = 'resolveMaster',
             otherBranch = 'resolveOther',
             masterContext,

--- a/test/server/storage/websocket.spec.js
+++ b/test/server/storage/websocket.spec.js
@@ -561,7 +561,6 @@ describe('WebSocket', function () {
                 .then(function () {
                     var deferred = Q.defer();
                     middle.socket.on(CONSTANTS.NOTIFICATION, function (data) {
-                        //console.log('middle notification', data);
                         if (data.type === CONSTANTS.PLUGIN_NOTIFICATION) {
                             deferred.reject(new Error('Middle got plugin notification!'));
                         }
@@ -1476,7 +1475,6 @@ describe('WebSocket', function () {
                 },
                 newBranchHash,
                 eventHandler = function (resultData) {
-                    console.log('eHandle');
                     expect(resultData.projectId).to.equal(data.projectId);
                     expect(resultData.branchName).to.equal(data.branchName);
                     expect(resultData.newHash).to.equal(newBranchHash);

--- a/test/server/storage/websocket.spec.js
+++ b/test/server/storage/websocket.spec.js
@@ -62,6 +62,40 @@ describe('WebSocket', function () {
                 .nodeify(callback);
         };
 
+
+    function emitRangeWithData(socket, data) {
+        return Q.allSettled([
+            Q.ninvoke(socket, 'emit', 'getConnectionInfo', data),
+            Q.ninvoke(socket, 'emit', 'watchDatabase', data),
+            Q.ninvoke(socket, 'emit', 'watchProject', data),
+            Q.ninvoke(socket, 'emit', 'watchBranch', data),
+            Q.ninvoke(socket, 'emit', 'openProject', data),
+            Q.ninvoke(socket, 'emit', 'closeProject', data),
+            Q.ninvoke(socket, 'emit', 'openBranch', data),
+            Q.ninvoke(socket, 'emit', 'closeBranch', data),
+            Q.ninvoke(socket, 'emit', 'makeCommit', data),
+            Q.ninvoke(socket, 'emit', 'loadObjects', data),
+            Q.ninvoke(socket, 'emit', 'loadPaths', data),
+            Q.ninvoke(socket, 'emit', 'setBranchHash', data),
+            Q.ninvoke(socket, 'emit', 'getBranchHash', data),
+            Q.ninvoke(socket, 'emit', 'getProjects', data),
+            Q.ninvoke(socket, 'emit', 'deleteProject', data),
+            Q.ninvoke(socket, 'emit', 'createProject', data),
+            Q.ninvoke(socket, 'emit', 'transferProject', data),
+            Q.ninvoke(socket, 'emit', 'duplicateProject', data),
+            Q.ninvoke(socket, 'emit', 'getBranches', data),
+            Q.ninvoke(socket, 'emit', 'createTag', data),
+            Q.ninvoke(socket, 'emit', 'deleteTag', data),
+            Q.ninvoke(socket, 'emit', 'getTags', data),
+            Q.ninvoke(socket, 'emit', 'getCommits', data),
+            Q.ninvoke(socket, 'emit', 'getHistory', data),
+            Q.ninvoke(socket, 'emit', 'getLatestCommitData', data),
+            Q.ninvoke(socket, 'emit', 'getCommonAncestorCommit', data),
+            Q.ninvoke(socket, 'emit', 'simpleRequest', data),
+            Q.ninvoke(socket, 'emit', 'notification', data)
+        ]);
+    }
+
     describe('with valid token as a guest user, auth turned on', function () {
         before(function (done) {
             var gmeConfigWithAuth = testFixture.getGmeConfig();
@@ -128,6 +162,141 @@ describe('WebSocket', function () {
 
         beforeEach(function () {
             agent = superagent.agent();
+        });
+
+        it('should fail and not crash server when sending string data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = 'five';
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        if (i === 1 || i === 7) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending boolean data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = true;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        if (i === 1 || i === 7) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending number data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = 5;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        if (i === 1 || i === 7) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending null data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = null;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        if (i === 1 || i === 7) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending undefined data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        if (i === 1 || i === 7) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
         });
 
         it('should getConnectionInfo', function (done) {
@@ -739,25 +908,6 @@ describe('WebSocket', function () {
                 .catch(function (err) {
                     done(new Error(err));
                 });
-        });
-
-        it.skip('should fail to open an existing project if data is not an object', function (done) {
-            openSocketIo()
-                .then(function (socket) {
-                    var data = projectName;
-
-                    return Q.ninvoke(socket, 'emit', 'openProject', data);
-                })
-                .then(function () {
-                    throw new Error('should have failed to openProject');
-                })
-                .catch(function (err) {
-                    if (typeof err === 'string' && err.indexOf('Invalid argument') > -1) {
-                        return;
-                    }
-                    throw new Error('should have failed to openProject: ' + err);
-                })
-                .nodeify(done);
         });
 
         it('should fail to open a non-existent project', function (done) {

--- a/test/server/storage/websocket.spec.js
+++ b/test/server/storage/websocket.spec.js
@@ -753,6 +753,156 @@ describe('WebSocket', function () {
             agent = superagent.agent();
         });
 
+        it('should fail and not crash server when sending string data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = 'five';
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        var shouldSucceed = [
+                            0, 1, 2, 3, 7
+                        ];
+                        if (shouldSucceed.indexOf(i) > -1) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending boolean data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = true;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        var shouldSucceed = [
+                            0, 1, 2, 3, 7
+                        ];
+                        if (shouldSucceed.indexOf(i) > -1) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending number data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = 5;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        var shouldSucceed = [
+                            0, 1, 2, 3, 7
+                        ];
+                        if (shouldSucceed.indexOf(i) > -1) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending null data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data = null;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        var shouldSucceed = [
+                            0, 1, 2, 3, 7
+                        ];
+                        if (shouldSucceed.indexOf(i) > -1) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
+        it('should fail and not crash server when sending undefined data', function (done) {
+            var socket;
+
+            openSocketIo()
+                .then(function (socket_) {
+                    var data;
+                    socket = socket_;
+                    return emitRangeWithData(socket, data);
+                })
+                .then(function (result) {
+                    result.forEach(function (res, i) {
+                        var shouldSucceed = [
+                            0, 1, 2, 3, 7
+                        ];
+                        if (shouldSucceed.indexOf(i) > -1) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                        }
+                    });
+
+                    // Check that we can still e.g. openProject.
+                    return Q.ninvoke(socket, 'emit', 'getConnectionInfo', {webgmeToken: webgmeToken});
+                })
+                .then(function (result) {
+                    expect(result.userId).to.equal(gmeConfig.authentication.guestAccount);
+                })
+                .nodeify(done);
+        });
+
         it('should getConnectionInfo', function (done) {
             openSocketIo()
                 .then(function (socket) {


### PR DESCRIPTION
When the server receives an outdated commit into a branch - instead of directly returning the FORKED status, it will trigger a worker that attempts to merge the commit into the branch. If it succeeds, the client will get the MERGED status and the storage on the client side will handle it appropriately. If the merging returns with conflicts or with an unexpected error - the client will receive the FORKED status.

Although the clients do not have to wait for the the merges, there is a risk that the client builds up a large commit-queue.