### PR TITLE
Executor cancel implemented Closes #1071 and #1073

### DIFF
--- a/src/common/executor/ExecutorClient.js
+++ b/src/common/executor/ExecutorClient.js
@@ -224,7 +224,7 @@ define(['superagent', 'q'], function (superagent, Q) {
         var deferred = Q.defer(),
             self = this;
         this.logger.debug('getAllInfo');
-        this.sendHttpRequest('GET', this.getInfoURL(), function (err, response) {
+        this.sendHttpRequest('GET', this.executorUrl, function (err, response) {
             if (err) {
                 deferred.reject(err);
                 return;

--- a/src/common/executor/ExecutorClient.js
+++ b/src/common/executor/ExecutorClient.js
@@ -294,7 +294,7 @@ define(['superagent', 'q'], function (superagent, Q) {
         var deferred = Q.defer(),
             url = this.executorUrl + 'output/' + outputInfo.hash;
 
-        this.logger.debug('sendOuput', outputInfo._id);
+        this.logger.debug('sendOutput', outputInfo._id);
 
         this.sendHttpRequestWithData('POST', url, outputInfo, function (err) {
             if (err) {

--- a/src/common/executor/ExecutorClient.js
+++ b/src/common/executor/ExecutorClient.js
@@ -154,6 +154,28 @@ define(['superagent', 'q'], function (superagent, Q) {
         return deferred.promise.nodeify(callback);
     };
 
+    ExecutorClient.prototype.cancelJob = function (jobInfoOrHash, secret, callback) {
+        var deferred = Q.defer(),
+            hash = typeof jobInfoOrHash === 'string' ? jobInfoOrHash : jobInfoOrHash.hash,
+
+            self = this;
+
+        this.logger.debug('cancel', hash);
+        this.sendHttpRequestWithData('POST', this.executorUrl + 'cancel/' + hash, {secret: secret},
+            function (err, response) {
+                if (err) {
+                    deferred.reject(err);
+                    return;
+                }
+
+                self.logger.debug('cancel - result', response);
+                deferred.resolve(response);
+            }
+        );
+
+        return deferred.promise.nodeify(callback);
+    };
+
     ExecutorClient.prototype.updateJob = function (jobInfo, callback) {
         var deferred = Q.defer(),
             self = this;

--- a/src/common/executor/ExecutorWorker.js
+++ b/src/common/executor/ExecutorWorker.js
@@ -245,7 +245,7 @@ define([
                                     // normally self.saveJobResults(jobInfo, jobDir, executorConfig);
                                 };
 
-                                this.runningJobs[jobInfo.hash] = {
+                                self.runningJobs[jobInfo.hash] = {
                                     process: child,
                                     terminated: false
                                 };
@@ -475,7 +475,7 @@ define([
         var self = this;
         if (JobInfo.isFinishedStatus(jobInfo.status)) {
             this.availableProcessesContainer.availableProcesses += 1;
-            delete this.runningJobs[jobInfo.status];
+            delete this.runningJobs[jobInfo.hash];
         }
 
         this.executorClient.updateJob(jobInfo)

--- a/src/common/executor/ExecutorWorker.js
+++ b/src/common/executor/ExecutorWorker.js
@@ -532,7 +532,7 @@ define([
                     } else {
                         var response = JSON.parse(res.text);
                         //console.log(res.text)
-                        self.response.jobsToCancel.forEach(self.cancelJob);
+                        response.jobsToCancel.forEach(self.cancelJob);
                         var jobsToStart = response.jobsToStart;
                         for (var i = 0; i < jobsToStart.length; i++) {
                             self.executorClient.getInfo(jobsToStart[i], function (err, info) {

--- a/src/common/executor/ExecutorWorker.js
+++ b/src/common/executor/ExecutorWorker.js
@@ -531,8 +531,10 @@ define([
                         callback('Server returned ' + res.status);
                     } else {
                         var response = JSON.parse(res.text);
-                        //console.log(res.text)
-                        response.jobsToCancel.forEach(self.cancelJob);
+                        response.jobsToCancel.forEach(function (cHash) {
+                            self.cancelJob(cHash);
+                        });
+
                         var jobsToStart = response.jobsToStart;
                         for (var i = 0; i < jobsToStart.length; i++) {
                             self.executorClient.getInfo(jobsToStart[i], function (err, info) {

--- a/src/common/executor/JobInfo.js
+++ b/src/common/executor/JobInfo.js
@@ -89,6 +89,7 @@ define([], function () {
      */
     JobInfo.finishedStatuses = [
         'SUCCESS',
+        'CANCELED',
         'FAILED_TO_EXECUTE',
         'FAILED_TO_GET_SOURCE_METADATA',
         'FAILED_SOURCE_COULD_NOT_BE_OBTAINED',

--- a/src/common/executor/WorkerInfo.js
+++ b/src/common/executor/WorkerInfo.js
@@ -12,12 +12,14 @@ define([], function () {
         this.clientId = parameters.clientId || undefined;
         this.availableProcesses = parameters.availableProcesses || 0;
         this.labels = parameters.labels || [];
+        this.runningJobs = parameters.runningJobs || [];
     };
 
     var ServerResponse = function (parameters) {
         this.jobsToStart = parameters.jobsToStart || [];
         this.refreshPeriod = parameters.refreshPeriod || 30 * 1000;
         this.labelJobs = parameters.labelJobs;
+        this.jobsToCancel = parameters.jobsToCancel || [];
     };
 
     return {

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -208,10 +208,11 @@ function ExecutorServer(options) {
     function getCanceledJobs(hashes, callback) {
         var deferred = Q.defer(),
             query = {
-                $in: hashes,
+                hash: {
+                    $in: hashes
+                },
                 cancelRequested: true
             };
-
         if (hashes.length === 0) {
             deferred.resolve([]);
         } else {
@@ -382,13 +383,11 @@ function ExecutorServer(options) {
                             self.logger.error(err);
                             res.sendStatus(500);
                         } else {
-                            delete jobInfo._id;
-                            res.send(jobInfo);
+                            res.sendStatus(200);
                         }
                     });
                 } else {
-                    delete jobInfo._id;
-                    res.send(jobInfo);
+                    res.sendStatus(200);
                 }
             } else {
                 res.sendStatus(404);
@@ -512,11 +511,9 @@ function ExecutorServer(options) {
         serverResponse.labelJobs = self.labelJobs;
 
         function checkForCanceledJobs() {
-            console.log('clientRequest', JSON.stringify(clientRequest, null, 2));
-            getCanceledJobs(Object.keys(clientRequest.runningJobs))
+            getCanceledJobs(clientRequest.runningJobs)
                 .then(function (jobsToCancel) {
                     serverResponse.jobsToCancel = jobsToCancel;
-                    console.log('serverResponse', JSON.stringify(serverResponse, null, 2));
                     res.send(JSON.stringify(serverResponse));
                 })
                 .catch(function (err) {

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -305,6 +305,7 @@ function ExecutorServer(options) {
             for (var i = 0; i < docs.length; i += 1) {
                 jobList[docs[i].hash] = docs[i];
                 delete docs[i]._id;
+                delete docs[i].secret;
             }
             self.logger.debug('Found number of jobs matching status', docs.length, query.status);
             res.send(jobList);

--- a/src/server/middleware/executor/worker/node_worker.classes.build.js
+++ b/src/server/middleware/executor/worker/node_worker.classes.build.js
@@ -4208,7 +4208,7 @@ define('executor/ExecutorClient',['superagent', 'q'], function (superagent, Q) {
         var deferred = Q.defer(),
             self = this;
         this.logger.debug('getAllInfo');
-        this.sendHttpRequest('GET', this.getInfoURL(), function (err, response) {
+        this.sendHttpRequest('GET', this.executorUrl, function (err, response) {
             if (err) {
                 deferred.reject(err);
                 return;

--- a/src/server/middleware/executor/worker/node_worker.classes.build.js
+++ b/src/server/middleware/executor/worker/node_worker.classes.build.js
@@ -5233,7 +5233,7 @@ define('executor/ExecutorWorker',[
                     } else {
                         var response = JSON.parse(res.text);
                         //console.log(res.text)
-                        self.response.jobsToCancel.forEach(self.cancelJob);
+                        response.jobsToCancel.forEach(self.cancelJob);
                         var jobsToStart = response.jobsToStart;
                         for (var i = 0; i < jobsToStart.length; i++) {
                             self.executorClient.getInfo(jobsToStart[i], function (err, info) {

--- a/src/server/middleware/executor/worker/node_worker.classes.build.js
+++ b/src/server/middleware/executor/worker/node_worker.classes.build.js
@@ -4946,7 +4946,7 @@ define('executor/ExecutorWorker',[
                                     // normally self.saveJobResults(jobInfo, jobDir, executorConfig);
                                 };
 
-                                this.runningJobs[jobInfo.hash] = {
+                                self.runningJobs[jobInfo.hash] = {
                                     process: child,
                                     terminated: false
                                 };
@@ -5176,7 +5176,7 @@ define('executor/ExecutorWorker',[
         var self = this;
         if (JobInfo.isFinishedStatus(jobInfo.status)) {
             this.availableProcessesContainer.availableProcesses += 1;
-            delete this.runningJobs[jobInfo.status];
+            delete this.runningJobs[jobInfo.hash];
         }
 
         this.executorClient.updateJob(jobInfo)

--- a/src/server/middleware/executor/worker/node_worker.classes.build.js
+++ b/src/server/middleware/executor/worker/node_worker.classes.build.js
@@ -5232,8 +5232,10 @@ define('executor/ExecutorWorker',[
                         callback('Server returned ' + res.status);
                     } else {
                         var response = JSON.parse(res.text);
-                        //console.log(res.text)
-                        response.jobsToCancel.forEach(self.cancelJob);
+                        response.jobsToCancel.forEach(function (cHash) {
+                            self.cancelJob(cHash);
+                        });
+
                         var jobsToStart = response.jobsToStart;
                         for (var i = 0; i < jobsToStart.length; i++) {
                             self.executorClient.getInfo(jobsToStart[i], function (err, info) {

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -81,52 +81,6 @@ describe('ExecutorServer', function () {
         });
     });
 
-    it('should return 404 GET rest/executor/cancel', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/cancel').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
-            });
-        });
-    });
-
-    it('should return 404 POST rest/executor/cancel', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/cancel').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
-            });
-        });
-    });
-
-    it('should return 500 POST rest/executor/cancel/some_hash', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/cancel/some_hash').end(function (err, res) {
-                should.equal(res.status, 500, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
-            });
-        });
-    });
-
-
     it('should return 404 POST rest/executor/info', function (done) {
         gmeConfig.executor.enable = true;
         server = testFixture.WebGME.standaloneServer(gmeConfig);
@@ -264,17 +218,116 @@ describe('ExecutorServer', function () {
         });
     });
 
-    it('should return 200 POST rest/executor/create/new_element', function (done) {
+    it('should return 200 POST rest/executor/create/some_hash', function (done) {
         gmeConfig.executor.enable = true;
         server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/new_element').end(function (err, res) {
+            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
                 should.equal(res.status, 200, err);
+                should.equal(typeof res.body.secret, 'string', res.body);
                 server.stop(function (err) {
                     server = null;
                     done(err);
                 });
+            });
+        });
+    });
+
+    it('should return 200 POST rest/executor/create/some_hash but no secret on second create', function (done) {
+        gmeConfig.executor.enable = true;
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                should.equal(res.status, 200, err);
+                should.equal(typeof res.body.secret, 'string', res.body);
+                agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                    should.equal(res.status, 200, err);
+                    should.equal(typeof res.body.secret, 'undefined', res.body.secret);
+                    server.stop(function (err) {
+                        server = null;
+                        done(err);
+                    });
+                });
+            });
+        });
+    });
+
+    it('should return 404 POST rest/executor/cancel/hashDoesNotExist', function (done) {
+        gmeConfig.executor.enable = true;
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/cancel/hashDoesNotExist').end(function (err, res) {
+                should.equal(res.status, 404, err);
+                server.stop(function (err) {
+                    server = null;
+                    done(err);
+                });
+            });
+        });
+    });
+
+    it('should return 403 POST rest/executor/cancel/existingHash with no body', function (done) {
+        gmeConfig.executor.enable = true;
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                should.equal(res.status, 200, err);
+                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash').end(function (err, res) {
+                    should.equal(res.status, 403, err);
+                    server.stop(function (err) {
+                        server = null;
+                        done(err);
+                    });
+                });
+            });
+        });
+    });
+
+    it('should return 403 POST rest/executor/cancel/existingHash with wrong secret', function (done) {
+        gmeConfig.executor.enable = true;
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                should.equal(res.status, 200, err);
+                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
+                    .send({secret: 'bla_bla'})
+                    .end(function (err, res) {
+                    should.equal(res.status, 403, err);
+                    server.stop(function (err) {
+                        server = null;
+                        done(err);
+                    });
+                });
+            });
+        });
+    });
+
+    it('should return 200 POST rest/executor/cancel/existingHash with correct secret', function (done) {
+        gmeConfig.executor.enable = true;
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                should.equal(res.status, 200, err);
+                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
+                    .send({secret: res.body.secret})
+                    .end(function (err, res) {
+                        should.equal(res.status, 200, err);
+                        agent.get(serverBaseUrl + '/rest/executor/info/existingHash')
+                            .end(function (err, res) {
+                                should.equal(res.status, 200, err);
+                                should.equal(res.body.cancelRequested, true, res.body);
+                                server.stop(function (err) {
+                                    server = null;
+                                    done(err);
+                                });
+                            });
+                    });
             });
         });
     });

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -321,7 +321,6 @@ describe('ExecutorServer', function () {
                         agent.get(serverBaseUrl + '/rest/executor/info/existingHash')
                             .end(function (err, res) {
                                 should.equal(res.status, 200, err);
-                                should.equal(res.body.cancelRequested, true, res.body);
                                 server.stop(function (err) {
                                     server = null;
                                     done(err);

--- a/test/server/middleware/executor/worker/node_worker.spec.js
+++ b/test/server/middleware/executor/worker/node_worker.spec.js
@@ -116,7 +116,6 @@ describe('NodeWorker', function () {
                         {cwd: 'src/server/middleware/executor/worker'});
                     nodeWorkerProcess.stderr.on('data', function (data) {
                         stderr += data.toString();
-                        //console.log(stderr);
                     });
                     nodeWorkerProcess.stdout.on('data', function (data) {
                         var str = data.toString();
@@ -426,8 +425,6 @@ describe('NodeWorker', function () {
                         var deferred = Q.defer(),
                             intervalId;
 
-                        console.log(jobInfo);
-
                         intervalId = setInterval(function () {
                             executorClient.getInfo(jobInfo.hash, function (err, res) {
                                 if (err) {
@@ -457,8 +454,6 @@ describe('NodeWorker', function () {
                     .then(function (jobInfo) {
                         var deferred = Q.defer(),
                             intervalId;
-
-                        console.log(jobInfo);
 
                         intervalId = setInterval(function () {
                             executorClient.getInfo(jobInfo.hash, function (err, res) {

--- a/test/server/middleware/executor/worker/node_worker.spec.js
+++ b/test/server/middleware/executor/worker/node_worker.spec.js
@@ -240,6 +240,8 @@ describe('NodeWorker', function () {
                     });
                 });
             });
+
+
         });
 
         describe('[nonce match]', function () {


### PR DESCRIPTION
This PR adds a new status type `CANCELED` to the JobInfo which is part of the finished statuses.
When a client creates a job it receives a secret for the job, with which it can cancel the created job. The canceling of jobs work in the following way:
- Client posts a cancel and the job is tagged with `cancelRequested=true`.
- When the worker queries the server its send along the hashes of its `runningJobs`. If any of these jobs are tagged as `cancelRequested` the server responds with it in a list of `jobsToCancel`.
- When a worker receives a job in `jobsToCancel` and that job process is still alive, it will send a `'SIGINT'` to kill the process.
- When a process is terminated with `'SIGINT'` the worker will update the status to `CANCELED`

A canceled job can be "created" again (without knowing the secret), the user initiating the creation will get a new secret.
