### PR TITLE
Allow for safe deletion of users and organization

### DIFF
--- a/src/bin/usermanager.js
+++ b/src/bin/usermanager.js
@@ -152,7 +152,7 @@ main = function (argv) {
             setupGMEAuth(options.parent.db, function (/*err*/) {
 
                 if (username) {
-                    auth.deleteUser(username)
+                    auth.deleteUser(username, true)
                         .then(mainDeferred.resolve)
                         .catch(mainDeferred.reject)
                         .finally(auth.unload);
@@ -199,7 +199,7 @@ main = function (argv) {
 
             setupGMEAuth(options.parent.db, function (/*err*/) {
                 if (organizationname) {
-                    auth.removeOrganizationByOrgId(organizationname)
+                    auth.removeOrganizationByOrgId(organizationname, true)
                         .then(mainDeferred.resolve)
                         .catch(mainDeferred.reject)
                         .finally(auth.unload);

--- a/src/bin/usermanager.js
+++ b/src/bin/usermanager.js
@@ -148,11 +148,12 @@ main = function (argv) {
     program
         .command('userdel <username>')
         .description('deletes a user')
+        .option('-f, --force', 'removes the entry from the database', false)
         .action(function (username, options) {
             setupGMEAuth(options.parent.db, function (/*err*/) {
 
                 if (username) {
-                    auth.deleteUser(username, true)
+                    auth.deleteUser(username, options.force)
                         .then(mainDeferred.resolve)
                         .catch(mainDeferred.reject)
                         .finally(auth.unload);
@@ -165,6 +166,7 @@ main = function (argv) {
             console.log('  Examples:');
             console.log();
             console.log('    $ node usermanager.js userdel brubble');
+            console.log('    $ node usermanager.js userdel brubble -f');
             console.log();
         });
 
@@ -195,11 +197,12 @@ main = function (argv) {
     program
         .command('organizationdel <organizationname>')
         .description('deletes an existing organization')
+        .option('-f, --force', 'removes the entry from the database', false)
         .action(function (organizationname, options) {
 
             setupGMEAuth(options.parent.db, function (/*err*/) {
                 if (organizationname) {
-                    auth.removeOrganizationByOrgId(organizationname, true)
+                    auth.removeOrganizationByOrgId(organizationname, options.force)
                         .then(mainDeferred.resolve)
                         .catch(mainDeferred.reject)
                         .finally(auth.unload);

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -309,7 +309,7 @@ function createAPI(app, mountPath, middlewareOpts) {
     router.delete('/user', function (req, res/*, next*/) {
         var userId = getUserId(req);
 
-        gmeAuth.deleteUser(userId, function (err) {
+        gmeAuth.deleteUser(userId, false, function (err) {
             if (err) {
                 res.status(404);
                 res.json({
@@ -614,15 +614,11 @@ function createAPI(app, mountPath, middlewareOpts) {
             .then(function () {
                 return gmeAuth.deleteUser(req.params.username);
             })
-            .then(function (nbrOfUpdates) {
-                if (nbrOfUpdates !== 1) {
-                    throw new Error('User not found');
-                } else {
-                    res.sendStatus(204);
-                }
+            .then(function () {
+                res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message === 'User not found') {
+                if (err.message.indexOf('no such user') > -1) {
                     res.status(404);
                 }
 
@@ -900,7 +896,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.json(data);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -916,7 +912,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -932,8 +928,8 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1 ||
-                    err.message.indexOf('No such user [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1 ||
+                    err.message.indexOf('no such user [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -949,7 +945,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -965,8 +961,8 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1 ||
-                    err.message.indexOf('No such user [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1 ||
+                    err.message.indexOf('no such user [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -982,8 +978,8 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such organization [') > -1 ||
-                    err.message.indexOf('No such user [') > -1) {
+                if (err.message.indexOf('no such organization [') > -1 ||
+                    err.message.indexOf('no such user [') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -1195,7 +1191,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such user or org') > -1 || err.message.indexOf('no such project') > -1) {
+                if (err.message.indexOf('no such user or org') > -1 || err.message.indexOf('no such project') > -1) {
                     res.status(404);
                 }
                 next(err);
@@ -1225,7 +1221,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 res.sendStatus(204);
             })
             .catch(function (err) {
-                if (err.message.indexOf('No such user or org') > -1 || err.message.indexOf('no such project') > -1) {
+                if (err.message.indexOf('no such user or org') > -1 || err.message.indexOf('no such project') > -1) {
                     res.status(404);
                 }
                 next(err);

--- a/src/server/middleware/auth/defaultauthorizer.js
+++ b/src/server/middleware/auth/defaultauthorizer.js
@@ -33,7 +33,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
         }, _getProjection('siteAdmin', 'orgs', 'projects.' + projectId))
             .then(function (userData) {
                 if (!userData) {
-                    return Q.reject(new Error('No such user [' + userId + ']'));
+                    return Q.reject(new Error('no such user [' + userId + ']'));
                 }
                 userData.orgs = userData.orgs || [];
 
@@ -99,7 +99,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
             {admins: 1})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
                 return org.admins;
             })
@@ -123,7 +123,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
             return self.collection.update({_id: userOrOrgId, disabled: {$ne: true}}, update)
                 .spread(function (numUpdated) {
                     if (numUpdated !== 1) {
-                        return Q.reject(new Error('No such user or org [' + userOrOrgId + ']'));
+                        return Q.reject(new Error('no such user or org [' + userOrOrgId + ']'));
                     }
                 })
                 .nodeify(callback);

--- a/src/server/middleware/auth/defaultauthorizer.js
+++ b/src/server/middleware/auth/defaultauthorizer.js
@@ -27,7 +27,10 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
 
     function getProjectAuthorizationByUserOrOrgId(userId, projectId, callback) {
         var ops = ['read', 'write', 'delete'];
-        return self.collection.findOne({_id: userId}, _getProjection('siteAdmin', 'orgs', 'projects.' + projectId))
+        return self.collection.findOne({
+            _id: userId,
+            disabled: {$ne: true}
+        }, _getProjection('siteAdmin', 'orgs', 'projects.' + projectId))
             .then(function (userData) {
                 if (!userData) {
                     return Q.reject(new Error('No such user [' + userId + ']'));
@@ -43,7 +46,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
                             if ((userData.projects[projectId] || {})[op]) {
                                 return 1;
                             }
-                            query = {_id: {$in: userData.orgs}};
+                            query = {_id: {$in: userData.orgs}, disabled: {$ne: true}};
                             query['projects.' + projectId + '.' + op] = true;
                             return self.collection.findOne(query, {_id: 1});
                         }))];
@@ -72,7 +75,11 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
      * @returns {*}
      */
     function getUser(userId, callback) {
-        return self.collection.findOne({_id: userId, type: {$ne: GME_AUTH_CONSTANTS.ORGANIZATION}})
+        return self.collection.findOne({
+            _id: userId,
+            type: {$ne: GME_AUTH_CONSTANTS.ORGANIZATION},
+            disabled: {$ne: true}
+        })
             .then(function (userData) {
                 if (!userData) {
                     return Q.reject(new Error('no such user [' + userId + ']'));
@@ -88,7 +95,8 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
     }
 
     function getAdminsInOrganization(orgId, callback) {
-        return self.collection.findOne({_id: orgId, type: GME_AUTH_CONSTANTS.ORGANIZATION}, {admins: 1})
+        return self.collection.findOne({_id: orgId, type: GME_AUTH_CONSTANTS.ORGANIZATION, disabled: {$ne: true}},
+            {admins: 1})
             .then(function (org) {
                 if (!org) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));
@@ -112,7 +120,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
         if (type === 'set') {
             update = {$set: {}};
             update.$set['projects.' + projectId] = rights;
-            return self.collection.update({_id: userOrOrgId}, update)
+            return self.collection.update({_id: userOrOrgId, disabled: {$ne: true}}, update)
                 .spread(function (numUpdated) {
                     if (numUpdated !== 1) {
                         return Q.reject(new Error('No such user or org [' + userOrOrgId + ']'));
@@ -122,7 +130,7 @@ function DefaultAuthorizer(mainLogger, gmeConfig) {
         } else if (type === 'delete') {
             update = {$unset: {}};
             update.$unset['projects.' + projectId] = '';
-            return self.collection.update({_id: userOrOrgId}, update)
+            return self.collection.update({_id: userOrOrgId, disabled: {$ne: true}}, update)
                 .spread(function (numUpdated) {
                     // FIXME this is always true. Try findAndUpdate instead
                     return numUpdated === 1;

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -338,7 +338,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function deleteUser(userId, callback) {
-        return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$set: {disabled: true}})
+        return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}}, {$set: {disabled: true}})
             .then(function (count) {
                 if (count instanceof Array ? count[0] === 0 : count === 0) {
                     return Q.reject(new Error('no such user [' + userId + ']'));
@@ -614,7 +614,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
                 return [org, collection.find({orgs: orgId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}},
                     {_id: 1})];
@@ -669,10 +669,11 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function removeOrganizationByOrgId(orgId, callback) {
-        return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION}, {$set: {disabled: true}})
+        return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}},
+            {$set: {disabled: true}})
             .then(function (count) {
                 if (count instanceof Array ? count[0] === 0 : count === 0) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
                 return collection.update({orgs: orgId}, {$pull: {orgs: orgId}}, {multi: true});
             })
@@ -690,7 +691,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
@@ -698,7 +699,7 @@ function GMEAuth(session, gmeConfig) {
                     {$addToSet: {orgs: orgId}})
                     .spread(function (count) {
                         if (count === 0) {
-                            return Q.reject(new Error('No such user [' + userId + ']'));
+                            return Q.reject(new Error('no such user [' + userId + ']'));
                         }
                     });
             })
@@ -716,7 +717,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
@@ -744,7 +745,7 @@ function GMEAuth(session, gmeConfig) {
             .then(function (user) {
                 if (makeAdmin) {
                     if (!user) {
-                        return Q.reject(new Error('No such user [' + userId + ']'));
+                        return Q.reject(new Error('no such user [' + userId + ']'));
                     }
                     return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}},
                         {$addToSet: {admins: userId}});
@@ -762,7 +763,7 @@ function GMEAuth(session, gmeConfig) {
         return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}}, {admins: 1})
             .then(function (org) {
                 if (!org) {
-                    return Q.reject(new Error('No such organization [' + orgId + ']'));
+                    return Q.reject(new Error('no such organization [' + orgId + ']'));
                 }
                 return org.admins;
             })

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -339,6 +339,12 @@ function GMEAuth(session, gmeConfig) {
      */
     function deleteUser(userId, callback) {
         return collection.remove({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+            .then(function (count) {
+                if (count === 0) {
+                    return Q.reject(new Error('no such user [' + userId + ']'));
+                }
+                return collection.update({admins: userId}, {$pull: {admins: userId}}, {multi: true});
+            })
             .nodeify(callback);
     }
 

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -212,7 +212,7 @@ function GMEAuth(session, gmeConfig) {
 
     function authenticateUser(userId, password, callback) {
         var userData;
-        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (userData_) {
                 userData = userData_;
 
@@ -256,7 +256,7 @@ function GMEAuth(session, gmeConfig) {
         var deferred = Q.defer();
         logger.debug('Generating token for user:', userId, '..');
 
-        collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (userData) {
                 if (!userData) {
                     throw new Error('no such user [' + userId + ']');
@@ -316,7 +316,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function getUser(userId, callback) {
-        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (userData) {
                 if (!userData) {
                     return Q.reject(new Error('no such user [' + userId + ']'));
@@ -338,11 +338,12 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function deleteUser(userId, callback) {
-        return collection.remove({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$set: {disabled: true}})
             .then(function (count) {
-                if (count === 0) {
+                if (count instanceof Array ? count[0] === 0 : count === 0) {
                     return Q.reject(new Error('no such user [' + userId + ']'));
                 }
+
                 return collection.update({admins: userId}, {$pull: {admins: userId}}, {multi: true});
             })
             .nodeify(callback);
@@ -356,7 +357,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function updateUser(userId, userData, callback) {
-        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (oldUserData) {
                 if (!oldUserData) {
                     return Q.reject(new Error('no such user [' + userId + ']'));
@@ -405,7 +406,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     function _updateUserObjectField(userId, keys, newValue, overwrite) {
-        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (userData) {
                 var currentValue,
                     update = {$set: {}},
@@ -494,7 +495,7 @@ function GMEAuth(session, gmeConfig) {
      */
     function listUsers(query, callback) {
         // FIXME: query can paginate, or filter users
-        return collection.find({type: {$ne: CONSTANTS.ORGANIZATION}})
+        return collection.find({type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})
             .then(function (users) {
                 return Q.ninvoke(users, 'toArray');
             })
@@ -610,12 +611,13 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function getOrganization(orgId, callback) {
-        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
+        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
-                return [org, collection.find({orgs: orgId, type: {$ne: CONSTANTS.ORGANIZATION}}, {_id: 1})];
+                return [org, collection.find({orgs: orgId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}},
+                    {_id: 1})];
             })
             .spread(function (org, users) {
                 return [org, Q.ninvoke(users, 'toArray')];
@@ -636,14 +638,15 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function listOrganizations(query, callback) {
-        return collection.find({type: CONSTANTS.ORGANIZATION})
+        return collection.find({type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (orgs) {
                 return Q.ninvoke(orgs, 'toArray');
             })
             .then(function (organizationArray) {
                 //TODO: See if there is a smarter query here (this sends one for each org).
                 return Q.all(organizationArray.map(function (org) {
-                    return collection.find({orgs: org._id, type: {$ne: CONSTANTS.ORGANIZATION}}, {_id: 1})
+                    return collection.find({orgs: org._id, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}},
+                        {_id: 1})
                         .then(function (users) {
                             return Q.ninvoke(users, 'toArray');
                         })
@@ -666,9 +669,9 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function removeOrganizationByOrgId(orgId, callback) {
-        return collection.remove({_id: orgId, type: CONSTANTS.ORGANIZATION})
+        return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION}, {$set: {disabled: true}})
             .then(function (count) {
-                if (count === 0) {
+                if (count instanceof Array ? count[0] === 0 : count === 0) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
                 return collection.update({orgs: orgId}, {$pull: {orgs: orgId}}, {multi: true});
@@ -684,14 +687,15 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function addUserToOrganization(userId, orgId, callback) {
-        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
+        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
-                return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$addToSet: {orgs: orgId}})
+                return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}},
+                    {$addToSet: {orgs: orgId}})
                     .spread(function (count) {
                         if (count === 0) {
                             return Q.reject(new Error('No such user [' + userId + ']'));
@@ -709,14 +713,15 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function removeUserFromOrganization(userId, orgId, callback) {
-        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION})
+        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}})
             .then(function (org) {
                 if (!org) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));
                 }
             })
             .then(function () {
-                return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}}, {$pull: {orgs: orgId}});
+                return collection.update({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}},
+                    {$pull: {orgs: orgId}});
             })
             .nodeify(callback);
     }
@@ -734,17 +739,19 @@ function GMEAuth(session, gmeConfig) {
         return getAdminsInOrganization(orgId)
             .then(function (admins_) {
                 admins = admins_;
-                return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}});
+                return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}});
             })
             .then(function (user) {
                 if (makeAdmin) {
                     if (!user) {
                         return Q.reject(new Error('No such user [' + userId + ']'));
                     }
-                    return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION}, {$addToSet: {admins: userId}});
+                    return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}},
+                        {$addToSet: {admins: userId}});
                 } else {
                     if (admins.indexOf(userId) > -1) {
-                        return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION}, {$pull: {admins: userId}});
+                        return collection.update({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}},
+                            {$pull: {admins: userId}});
                     }
                 }
             })
@@ -752,7 +759,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     function getAdminsInOrganization(orgId, callback) {
-        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION}, {admins: 1})
+        return collection.findOne({_id: orgId, type: CONSTANTS.ORGANIZATION, disabled: {$ne: true}}, {admins: 1})
             .then(function (org) {
                 if (!org) {
                     return Q.reject(new Error('No such organization [' + orgId + ']'));

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -438,6 +438,11 @@ function importProject(storage, parameters, callback) {
         data.username = parameters.username;
     }
 
+    if (parameters.hasOwnProperty('ownerId')) {
+        exports.expect(typeof parameters.ownerId).to.equal('string');
+        data.ownerId = parameters.ownerId;
+    }
+
     if (typeof parameters.projectSeed === 'string' && parameters.projectSeed.toLowerCase().indexOf('.webgmex')) {
         BC = require('../src/server/middleware/blob/BlobClientWithFSBackend');
         blobClient = new BC(parameters.gmeConfig, parameters.logger);

--- a/test/bin/clean_up.spec.js
+++ b/test/bin/clean_up.spec.js
@@ -133,7 +133,7 @@ describe('Clean UP CLI tests', function () {
                 throw new Error('should have failed!');
             })
             .catch(function (err) {
-                expect(err.message).to.contain('No such user');
+                expect(err.message).to.contain('no such user');
             })
             .nodeify(done);
     });

--- a/test/bin/usermanager.spec.js
+++ b/test/bin/usermanager.spec.js
@@ -417,6 +417,46 @@ describe('User manager command line interface (CLI)', function () {
                 });
         });
 
+        it('should force delete user', function (done) {
+            suppressLogAndExit();
+
+            userManager.main(['node',
+                filename,
+                '--db',
+                mongoUri,
+                'useradd',
+                'user_to_delete_force',
+                'user@example.com',
+                'plaintext']
+            )
+                .then(function () {
+                    return userManager.main(['node', filename, '--db', mongoUri, 'userdel', 'user_to_delete', '-f']);
+                })
+                .then(function () {
+                    return userManager.main(['node',
+                        filename,
+                        '--db',
+                        mongoUri,
+                        'useradd',
+                        'user_to_delete_force',
+                        'updatedEmail',
+                        'plaintext']
+                    );
+                })
+                .then(function () {
+                    return auth.getUser('user_to_delete_force');
+                })
+                .then(function (userInfo) {
+                    expect(userInfo.email).to.equal('updatedEmail');
+                    restoreLogAndExit();
+                    done();
+                })
+                .catch(function (err) {
+                    restoreLogAndExit();
+                    done(err);
+                });
+        });
+
         it('adds organization', function (done) {
             suppressLogAndExit();
 
@@ -438,6 +478,27 @@ describe('User manager command line interface (CLI)', function () {
             userManager.main(['node', filename, '--db', mongoUri, 'organizationadd', 'org2'])
                 .then(function () {
                     return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org2']);
+                })
+                .then(function () {
+                    restoreLogAndExit();
+                    done();
+                })
+                .catch(function (err) {
+                    restoreLogAndExit();
+                    done(err);
+                });
+        });
+
+        it('deletes an existing organization with force', function (done) {
+            suppressLogAndExit();
+
+            userManager.main(['node', filename, '--db', mongoUri, 'organizationadd', 'org_force_del'])
+                .then(function () {
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org_force_del',
+                        '-f']);
+                })
+                .then(function () {
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationadd', 'org_force_del']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -512,7 +573,7 @@ describe('User manager command line interface (CLI)', function () {
                     return userManager.main(['node', filename, '--db', mongoUri, 'orgmod_auth', 'org11', 'project11']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -533,7 +594,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'orgmod_auth', 'org11', 'project11', '-a', 'rw']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -554,7 +615,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'orgmod_auth', 'org11', 'project11', '-d']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -579,7 +640,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'usermod_organization_add', 'user', 'org11']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -604,7 +665,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'usermod_organization_add', 'user', 'org11', '--makeAdmin']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -633,7 +694,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'usermod_organization_del', 'user', 'org11']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();
@@ -654,7 +715,7 @@ describe('User manager command line interface (CLI)', function () {
                         filename, '--db', mongoUri, 'organizationlist']);
                 })
                 .then(function () {
-                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11']);
+                    return userManager.main(['node', filename, '--db', mongoUri, 'organizationdel', 'org11', '-f']);
                 })
                 .then(function () {
                     restoreLogAndExit();

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -8,7 +8,7 @@
 var testFixture = require('../../../_globals.js');
 
 
-describe.only('GME authentication', function () {
+describe('GME authentication', function () {
     'use strict';
 
     var gmeConfig = testFixture.getGmeConfig(),
@@ -1200,6 +1200,7 @@ describe.only('GME authentication', function () {
             })
             .nodeify(done);
     });
+
 
     it('should remove with force organization and be able to add it again', function (done) {
         var orgName = 'org_remove_can_add';

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -1044,8 +1044,62 @@ describe('GME authentication', function () {
             .nodeify(done);
     });
 
-    it('should fail to remove organization twice', function (done) {
-        var orgName = 'org1';
+    it('should remove from user.orgs when removing organization', function (done) {
+        var orgId = 'checkRemovedFromUserOrg',
+            userId = 'checkRemovedFromUserUser';
+
+        auth.addUser(userId, 'mail', 'pass', true, {})
+            .then(function () {
+                return auth.addOrganization(orgId);
+            })
+            .then(function () {
+                return auth.addUserToOrganization(userId, orgId);
+            })
+            .then(function () {
+                return auth.getUser(userId);
+            })
+            .then(function (userData) {
+                expect(userData.orgs).to.deep.equal([orgId]);
+                return auth.removeOrganizationByOrgId(orgId);
+            })
+            .then(function () {
+                return auth.getUser(userId);
+            })
+            .then(function (userData) {
+                expect(userData.orgs).to.deep.equal([]);
+            })
+            .nodeify(done);
+    });
+
+    it('should remove from org.admins when removing user', function (done) {
+        var orgId = 'checkRemovedFromOrgOrg',
+            userId = 'checkRemovedFromOrgUser';
+
+        auth.addUser(userId, 'mail', 'pass', true, {})
+            .then(function () {
+                return auth.addOrganization(orgId);
+            })
+            .then(function () {
+                return auth.setAdminForUserInOrganization(userId, orgId, true);
+            })
+            .then(function () {
+                return auth.getOrganization(orgId);
+            })
+            .then(function (orgData) {
+                expect(orgData.admins).to.deep.equal([userId]);
+                return auth.deleteUser(userId);
+            })
+            .then(function () {
+                return auth.getOrganization(orgId);
+            })
+            .then(function (orgData) {
+                expect(orgData.admins).to.deep.equal([]);
+            })
+            .nodeify(done);
+    });
+
+    it('should fail to remove organization that does not exist', function (done) {
+        var orgName = 'orgDoesNotExist';
         auth.removeOrganizationByOrgId(orgName)
             .then(function () {
                 done(new Error('should have been rejected'));

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -1039,8 +1039,55 @@ describe('GME authentication', function () {
     });
 
     it('should remove organization', function (done) {
-        var orgName = 'org1';
-        auth.removeOrganizationByOrgId(orgName)
+        var orgName = 'org_removed';
+        auth.addOrganization(orgName)
+            .then(function () {
+                return auth.listOrganizations();
+            })
+            .then(function (orgs) {
+                var hadOrg = false;
+                orgs.forEach(function (org) {
+                    if (org._id === orgName) {
+                        hadOrg = true;
+                    }
+                });
+
+                expect(hadOrg).to.equal(true);
+
+                return auth.removeOrganizationByOrgId(orgName);
+            })
+            .then(function () {
+                return auth.listOrganizations();
+            })
+            .then(function (orgs) {
+                var hadOrg = false;
+                orgs.forEach(function (org) {
+                    if (org._id === orgName) {
+                        hadOrg = true;
+                    }
+                });
+
+                expect(hadOrg).to.equal(false);
+            })
+            .nodeify(done);
+    });
+
+    it('should remove/disable organization and fail to add it again', function (done) {
+        var orgName = 'org_remove_fail_to_add';
+
+        auth.addOrganization(orgName)
+            .then(function () {
+                return auth.removeOrganizationByOrgId(orgName);
+            })
+            .then(function () {
+                return auth.addOrganization(orgName);
+            })
+            .then(function () {
+                throw new Error('Should have failed!');
+            })
+            .catch(function (err) {
+                expect(err.message).to.include('user or org already exists');
+            })
             .nodeify(done);
     });
 


### PR DESCRIPTION
When deleting a user or organization the document is still kept in the `_users` collection of the mongo database. The removed entity is only tagged with `disabled: true` and filtered out in all auth queries. This approach prevents:
- A new user being created with the same id and thus inheriting ownership of projects.
- Old id tokens enabling access to newly created users.

This PR also fixes a bug of not cleaning up admins in organizations after user deletion.