### PR TITLE
Closes #1092 Server crashes when wrong panel path sent.

### DIFF
--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -715,7 +715,7 @@ function StandAloneServer(gmeConfig) {
 
     // Panel paths
     logger.debug('creating path specific routing rules');
-    __app.get(/^\/panel\/.*/, webgmeUtils.getRouteFor('panel', gmeConfig.visualization.panelPaths, __baseDir));
+    __app.get(/^\/panel\/.*/, webgmeUtils.getRouteFor('panel', gmeConfig.visualization.panelPaths, __baseDir, logger));
 
     logger.debug('creating external library specific routing rules');
     gmeConfig.server.extlibExcludes.forEach(function (regExStr) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,7 +175,7 @@ function getGoodExtraAssetRouteFor(component, basePaths, logger, __baseDir) {
  * That is, there are examples of panels (such as SplitPanel) in which the
  * main file does not adhere to the format "NAME/NAME+'Panel'"
  */
-function getRouteFor(component, basePaths, __baseDir) {
+function getRouteFor(component, basePaths, __baseDir, logger) {
     //first we try to give back the common plugin/modules
     return function (req, res) {
         res.sendFile(path.join(__baseDir, req.path), function (err) {
@@ -197,7 +197,7 @@ function getRouteFor(component, basePaths, __baseDir) {
                 basePath = getBasePathByName(pluginName, basePaths);
 
                 if (typeof basePath === 'string' && typeof relPath === 'string') {
-                    expressFileSending(res, path.resolve(path.join(basePath, relPath)));
+                    expressFileSending(res, path.resolve(path.join(basePath, relPath)), logger);
                 } else {
                     res.sendStatus(404);
                 }

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -1,6 +1,7 @@
 /*jshint node:true, mocha:true*/
 /**
  * @author lattmann / https://github.com/lattmann
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 var testFixture = require('../_globals.js');
@@ -185,6 +186,7 @@ describe('standalone server', function () {
             {code: 200, url: '/docs/tutorial.html'},
             {code: 200, url: '/plugin/PluginBase.js'},
             {code: 200, url: '/plugin/PluginGenerator/PluginGenerator/PluginGenerator'},
+            {code: 404, url: '/plugin/PluginGenerator/PluginGenerator'},
             {code: 200, url: '/plugin/PluginGenerator/PluginGenerator/PluginGenerator.js'},
             {code: 200, url: '/plugin/PluginGenerator/PluginGenerator/Templates/plugin.js.ejs'},
             {code: 200, url: '/decorators/DefaultDecorator/DefaultDecorator.js'},
@@ -197,6 +199,12 @@ describe('standalone server', function () {
                 code: 200,
                 url: '/decorators/DefaultDecorator/DiagramDesigner/DefaultDecorator.DiagramDesignerWidget.js'
             },
+            {code: 200, url: '/panel/ModelEditor/ModelEditorControl.js'},
+            {code: 200, url: '/panel/ModelEditor/ModelEditorControl'},
+            {code: 200, url: '/panel/ModelEditor/ModelEditorControl'},
+            {code: 404, url: '/panel/ModelEditor/ModelEditorControlDoesNotExist'},
+            {code: 200, url: '/panel/SplitPanel/SplitPanel.js'},
+            {code: 404, url: '/panel/DoesNotExist/ModelEditorControl'},
             //{code: 200, url: '/rest/unknown'},
             //{code: 200, url: '/rest/does_not_exist'},
             //{code: 200, url: '/rest/help'},
@@ -228,8 +236,9 @@ describe('standalone server', function () {
             {code: 404, url: '/does_not_exist.js'},
             {code: 404, url: '/asdf'},
 
-            //excluded extlib paths.
             {code: 200, url: '/extlib/config/index.js'},
+            {code: 404, url: '/extlib/src'},
+            //excluded extlib paths.
             {code: 403, url: '/extlib/config/config.default.js'},
 
             //{code: 410, url: '/getToken'},


### PR DESCRIPTION
Make sure logger is passed to getRouteFor.
And that this function has test-coverage.