### PR TITLE
Fixes #1116 Clicking "show more" in the project history sets scroll to top

### DIFF
--- a/src/client/js/Widgets/ProjectRepository/ProjectRepositoryWidgetControl.js
+++ b/src/client/js/Widgets/ProjectRepository/ProjectRepositoryWidgetControl.js
@@ -110,7 +110,8 @@ define(['js/logger'], function (Logger) {
         var self = this,
             commits = null,
             com,
-            commitsLoaded;
+            commitsLoaded,
+            scrollPos = self._view._el.scrollTop() || 0;
 
         commitsLoaded = function (err, data) {
             var i,
@@ -168,6 +169,8 @@ define(['js/logger'], function (Logger) {
                 if (cLen < num) {
                     self._view.noMoreCommitsToDisplay();
                 }
+
+                self._view._el.scrollTop(scrollPos);
             }
         };
 


### PR DESCRIPTION
when pressing the 'show more' button, the position of the scrollbar should remain untouched after the load of the new commits.