### PR TITLE
Restrict the usage of pointers named member

### DIFF
--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -179,14 +179,14 @@ define([
 
         /**
          * This function collects the inherited collection names.
-         * Although there is no collection inheritance, we know that if a model is instantiated it internal structure
+         * Although there is no collection inheritance, we know that if a model is instantiated its internal structure
          * is not duplicated or no new data will be created. This means that in a sense, to keep the prototypical
          * inheritance correct, we need to build the internal relations on the fly. This means that whenever the user
          * has a question about the inverse relations of an internal part of the instance, we have to check the
          * prototype for such 'internal' relations and provide them - like in case of inherited attributes.
          * The function goes up on the inheritance chain of the questioned node.
          * At every step, it searches the root of instantiation (the node that is the instance) and collect inverse
-         * relation names that are exists in the prototype structure and has purely internal endpoints.
+         * relation names that exist in the prototype structure and has purely internal endpoints.
          *
          * @param node - the node in question
          * @returns {Array} - the list of names of relations that has the node as target

--- a/src/common/core/metacore.js
+++ b/src/common/core/metacore.js
@@ -222,12 +222,14 @@ define([
         };
 
         this.getValidPointerNames = function (node) {
-            var validNames = self.getPointerNames(getMetaNode(node)) || [],
+            var metaDefNode = getMetaNode(node),
+                validNames = self.getPointerNames(metaDefNode) || [],
                 i,
                 validPointerNames = [],
                 metaPointerNode, max;
+
             for (i = 0; i < validNames.length; i++) {
-                metaPointerNode = getMetaPointerNode(node, validNames[i]);
+                metaPointerNode = self.getChild(metaDefNode, CONSTANTS.META_POINTER_PREFIX + validNames[i]);
                 max = self.getAttribute(metaPointerNode, CONSTANTS.SET_ITEMS_MAX);
                 if (max === 1) {
                     //TODO Specify what makes something a pointer and what a set???
@@ -240,13 +242,14 @@ define([
         };
 
         this.getOwnValidPointerNames = function (node) {
-            var validNames = self.getOwnPointerNames(getMetaNode(node)) || [],
+            var metaDefNode = getMetaNode(node),
+                validNames = self.getOwnPointerNames(metaDefNode) || [],
                 i,
                 validPointerNames = [],
                 metaPointerNode, max;
 
             for (i = 0; i < validNames.length; i++) {
-                metaPointerNode = getMetaPointerNode(node, validNames[i]);
+                metaPointerNode = self.getChild(metaDefNode, CONSTANTS.META_POINTER_PREFIX + validNames[i]);
                 max = self.getOwnAttribute(metaPointerNode, CONSTANTS.SET_ITEMS_MAX);
                 if (max === 1) {
                     //TODO Specify what makes something a pointer and what a set???
@@ -259,14 +262,17 @@ define([
         };
 
         this.getValidSetNames = function (node) {
-            var validNames = self.getPointerNames(getMetaNode(node)) || [],
+            var metaDefNode = getMetaNode(node),
+                validNames = self.getPointerNames(metaDefNode) || [],
                 i,
                 validSetNames = [],
                 metaPointerNode, max;
 
             for (i = 0; i < validNames.length; i++) {
-                metaPointerNode = getMetaPointerNode(node, validNames[i]);
+                metaPointerNode = self.getChild(metaDefNode, CONSTANTS.META_POINTER_PREFIX + validNames[i]);
                 max = self.getAttribute(metaPointerNode, CONSTANTS.SET_ITEMS_MAX);
+
+                // FIXME: max seems to always be undefined - there is no such attribute on the set definitions
                 if (max === undefined || max === -1 || max > 1) {
                     //TODO specify what makes something a pointer and what a set???
                     //TODO can you extend a pointer to a set????
@@ -278,14 +284,17 @@ define([
         };
 
         this.getOwnValidSetNames = function (node) {
-            var validNames = self.getOwnPointerNames(getMetaNode(node)) || [],
+            var metaDefNode = getMetaNode(node),
+                validNames = self.getOwnPointerNames(metaDefNode) || [],
                 i,
                 validSetNames = [],
                 metaPointerNode, max;
 
             for (i = 0; i < validNames.length; i++) {
-                metaPointerNode = getMetaPointerNode(node, validNames[i]);
+                metaPointerNode = self.getChild(metaDefNode, CONSTANTS.META_POINTER_PREFIX + validNames[i]);
                 max = self.getOwnAttribute(metaPointerNode, CONSTANTS.SET_ITEMS_MAX);
+
+                // FIXME: max seems to always be undefined - there is no such attribute on the set definitions
                 if (max === undefined || max === -1 || max > 1) {
                     //TODO specify what makes something a pointer and what a set???
                     //TODO can you extend a pointer to a set????

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -268,26 +268,19 @@ define(['common/util/assert', 'common/core/constants'], function (ASSERT, CONSTA
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
-        this.getPointerNames = function (node) {
-            var sorted = [],
-                raw = innerCore.getPointerNames(node);
-            for (var i = 0; i < raw.length; i++) {
-                if (raw[i].indexOf(CONSTANTS.MEMBER_RELATION) === -1) {
-                    sorted.push(raw[i]);
-                }
-            }
-            return sorted;
-        };
-
         this.getCollectionNames = function (node) {
-            var sorted = [],
-                raw = innerCore.getCollectionNames(node);
-            for (var i = 0; i < raw.length; i++) {
-                if (raw[i].indexOf(CONSTANTS.MEMBER_RELATION) === -1) {
-                    sorted.push(raw[i]);
+            var result = innerCore.getCollectionNames(node),
+                i;
+
+            for (i = 0; i < result.length; i++) {
+                // The member collection is coming from being a member of a set and is not a defined relationship.
+                if (result[i] === CONSTANTS.MEMBER_RELATION) {
+                    result.splice(i, 1);
+                    break;
                 }
             }
-            return sorted;
+
+            return result;
         };
         //</editor-fold>
 


### PR DESCRIPTION
Fixes:
- Restricts users from naming pointers 'member'
- Allow the look-up of sets named 'member'
- Fixes bug in meta-editor that removed/edit all set relationships between two meta-nodes.
- Improve the look-up in validPointers/Sets-getters in metacore