### PR TITLE
Nodes unloaded/loaded need to be potential updates too.

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -1542,6 +1542,12 @@ define([
             delete state.users[guid];
         };
 
+        this._removeAllUIs = function () {
+            // This is mainly intended for clean up during testing.
+            logger.debug('_removeAllUIs called');
+            state.users = {};
+        };
+
         function reLaunchUsers() {
             var i;
             for (i in state.users) {


### PR DESCRIPTION
Currently if an inherited child is 'removed' there is no update event triggered since the raw data only contains a remove.
And since the node still exists (you can't remove inherited children) there is no event regarding this node.

The solution is to add removed/added nodes to the list of update nodes. When triggering the events, if there weren't any load or unload event triggered - fire an update event for the node in question.