### PR TITLE
Fixes potential relid collisions when creating children in bases

### DIFF
--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -17,6 +17,7 @@ define([], function () {
         BASE_POINTER: 'base',
         PATH_SEP: '/',
         MUTABLE_PROPERTY: '_mutable',
+        MINIMAL_RELID_LENGTH_PROPERTY: '_minlenrelid',
 
         NULLPTR_NAME: '_null_pointer',
         NULLPTR_RELID: '_nullptr',
@@ -59,6 +60,7 @@ define([], function () {
 
         MAX_AGE: 3,
         MAX_TICKS: 2000,
-        MAX_MUTATE: 30000
+        MAX_MUTATE: 30000,
+        MAXIMUM_STARTING_RELID_LENGTH: 5
     };
 });

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -553,13 +553,16 @@ define([
         };
 
         this.createChild = function (node, takenRelids) {
+            var minimumLength;
+
             node = self.normalize(node);
 
             if (typeof node.data !== 'object' || node.data === null) {
                 throw new Error('invalid node data');
             }
 
-            return self.getChild(node, RANDOM.generateRelid(takenRelids || node.data));
+            minimumLength = this.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
+            return self.getChild(node, RANDOM.generateRelid(takenRelids || node.data, minimumLength));
         };
 
         // ------- data manipulation

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -465,19 +465,6 @@ define([
             return result;
         }
 
-        function processRelidReservation(node, relid) {
-            var newLength = relid.length + 1 > CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH ?
-                CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH : relid.length + 1;
-
-            node = node.base;
-            while (node) {
-                if (innerCore.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY) >= newLength) {
-                    return;
-                }
-                innerCore.setProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY, newLength);
-            }
-        }
-
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
@@ -642,7 +629,7 @@ define([
             innerCore.setPointer(node, CONSTANTS.BASE_POINTER, base);
 
             if (parent) {
-                processRelidReservation(parent, this.getRelid(node));
+                this.processRelidReservation(parent, this.getRelid(node));
             }
 
             return node;
@@ -676,7 +663,7 @@ define([
             moved = innerCore.moveNode(node, parent, self.getChildrenRelids(parent, true));
             moved.base = base;
 
-            processRelidReservation(parent, this.getRelid(moved));
+            this.processRelidReservation(parent, this.getRelid(moved));
 
             return moved;
         };
@@ -689,7 +676,7 @@ define([
             newnode.base = base;
             innerCore.setPointer(newnode, CONSTANTS.BASE_POINTER, base);
 
-            processRelidReservation(parent, this.getRelid(newnode));
+            this.processRelidReservation(parent, this.getRelid(newnode));
 
             return newnode;
         };
@@ -744,7 +731,7 @@ define([
                     longestNewRelid = j;
                 }
             }
-            processRelidReservation(parent, longestNewRelid);
+            this.processRelidReservation(parent, longestNewRelid);
 
             return copiedNodes;
         };
@@ -1101,6 +1088,19 @@ define([
 
         this.getOwnChildrenPaths = function (node) {
             return innerCore.getChildrenPaths(node);
+        };
+
+        this.processRelidReservation = function(node, relid) {
+            var newLength = relid.length + 1 > CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH ?
+                CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH : relid.length + 1;
+
+            node = node.base;
+            while (node) {
+                if (innerCore.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY) >= newLength) {
+                    return;
+                }
+                innerCore.setProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY, newLength);
+            }
         };
         //</editor-fold>
     };

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -1180,6 +1180,7 @@ define([
                     checkResult = null,
                     key,
                     name,
+                    longestNewRelid = '',
                     reservedRelids = this.getChildrenRelids(parent, true),
                     newRelid;
 
@@ -1199,7 +1200,13 @@ define([
                     reservedRelids[newRelid] = true;
                     innerCore.setProperty(parent, newRelid, closureInformation.selection[key]);
                     closureInformation.relids[closureInformation.selection[key]] = newRelid;
+                    if (newRelid.length > longestNewRelid) {
+                        longestNewRelid = newRelid;
+                    }
                 }
+
+                // Now processing the new relid creations
+                innerCore.processRelidReservation(parent, longestNewRelid);
 
                 // Replacing the paths in the closure information with actual paths in the target project
                 computePaths(closureInformation);

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -1194,7 +1194,8 @@ define([
 
                 // Attaching the selected nodes under the parent node
                 for (key in closureInformation.selection) {
-                    newRelid = RANDOM.generateRelid(reservedRelids);
+                    newRelid = RANDOM.generateRelid(reservedRelids,
+                        innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY));
                     reservedRelids[newRelid] = true;
                     innerCore.setProperty(parent, newRelid, closureInformation.selection[key]);
                     closureInformation.relids[closureInformation.selection[key]] = newRelid;

--- a/src/common/util/jsonPatcher.js
+++ b/src/common/util/jsonPatcher.js
@@ -17,6 +17,8 @@ define([
 
     'use strict';
 
+    var MIN_RELID_LENGTH_PATH = CORE_CONSTANTS.PATH_SEP + CORE_CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY;
+
     function _strEncode(str) {
         //we should replace the '/' in the patch paths
         return str.replace(/\//g, '%2f');
@@ -327,7 +329,7 @@ define([
                     default:
                         throw new Error('Unexpected patch operation ' + nodePatches[i]);
                 }
-            } else {
+            } else if (patchPath !== MIN_RELID_LENGTH_PATH) {
                 ownChange = true;
             }
         }

--- a/src/common/util/random.js
+++ b/src/common/util/random.js
@@ -41,10 +41,10 @@ define(['chance'], function (ChanceJs) {
         return (S4() + S4() + '-' + S4() + '-' + S4() + '-' + S4() + '-' + S4() + S4() + S4());
     }
 
-    function generateRelid(object) {
+    function generateRelid(object, minimalLength) {
         var relid,
             i,
-            length = 1,
+            length = minimalLength || 1,
             tries = 0;
 
         do {

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2726,7 +2726,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(6);
+                    expect(events).to.have.length(10);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2811,7 +2811,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(6);
+                    expect(events).to.have.length(10);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2902,7 +2902,7 @@ describe('GME client', function () {
                     //events.forEach(function (e) {
                     //    console.log(e);
                     //});
-                    expect(events).to.have.length(7);
+                    expect(events).to.have.length(11);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2726,7 +2726,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(10);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2811,7 +2811,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(10);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2902,7 +2902,7 @@ describe('GME client', function () {
                     //events.forEach(function (e) {
                     //    console.log(e);
                     //});
-                    expect(events).to.have.length(11);
+                    expect(events).to.have.length(7);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -21,6 +21,7 @@ describe('coretype', function () {
         Tree = testFixture.requirejs('common/core/coretree'),
         NullPtr = testFixture.requirejs('common/core/nullpointercore'),
         TASYNC = testFixture.requirejs('common/core/tasync'),
+        CONSTANTS = testFixture.requirejs('common/core/constants'),
         Core = function (s, options) {
             return new NullPtr(
                 new Type(new NullPtr(new Rel(new Tree(s, options), options), options), options), options);
@@ -43,9 +44,9 @@ describe('coretype', function () {
 
     after(function (done) {
         Q.allDone([
-                storage.closeDatabase(),
-                gmeAuth.unload()
-            ])
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
             .nodeify(done);
     });
 
@@ -833,5 +834,36 @@ describe('coretype', function () {
         core.moveNode(child, node);
 
         expect(core.getChildrenRelids(node).length).to.equal(core.getChildrenRelids(ancestor).length + 1);
+    });
+
+    it('should generate length 2 relid for child if instance already has a child', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInsatnce'}),
+            child = core.createNode({parent: inst}),
+            protoChild = core.createNode({parent: proto});
+
+        expect(core.getRelid(child)).to.have.length(1);
+        expect(core.getRelid(protoChild)).to.have.length(2);
+    });
+
+    it('should generate longer relid for child if instance already has a child', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInsatnce'}),
+            child = core.createNode({parent: inst, relid: '123'}),
+            protoChild = core.createNode({parent: proto});
+
+        expect(core.getRelid(child)).to.have.length(3);
+        expect(core.getRelid(protoChild)).to.have.length(4);
+    });
+
+    it('should not generate longer relid than allowed even if instance has child with longer relid', function () {
+        var longrelid = 'thisIsWayTooLong',
+            proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInsatnce'}),
+            child = core.createNode({parent: inst, relid: longrelid}),
+            protoChild = core.createNode({parent: proto});
+
+        expect(core.getRelid(child)).to.have.length(longrelid.length);
+        expect(core.getRelid(protoChild)).to.have.length(CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH);
     });
 });


### PR DESCRIPTION
Given the following scenario - we have type **A** and its instance **a**, if we create a child for **a**, then we create a child for **A**, there is a possibility that the two child will have the same relid resulting in **a**'s child shadowing the 'inherited child of **A**'. With the introduction of shorter relids we increased the probability of a collision dramatically.

To overcome this, we introduce an integer property for every node that stores the longest relid created among its instances. In the scenario above, when a child is created in **a**, this property is increased in **A** and when a child is created in **A** the generated relid for the child will be enforced to be longer than the value store in the property. This way there is no risk that the relids would collide.
 