### PR TITLE
Inherited child relation removal

### DIFF
--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -18,6 +18,7 @@ define([], function () {
         PATH_SEP: '/',
         MUTABLE_PROPERTY: '_mutable',
         MINIMAL_RELID_LENGTH_PROPERTY: '_minlenrelid',
+        INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY: '_hasownrelation',
 
         NULLPTR_NAME: '_null_pointer',
         NULLPTR_RELID: '_nullptr',

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -465,19 +465,6 @@ define([
             return result;
         }
 
-        function processRelidReservation(node, relid) {
-            var newLength = relid.length + 1 > CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH ?
-                CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH : relid.length + 1;
-
-            node = node.base;
-            while (node) {
-                if (innerCore.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY) >= newLength) {
-                    return;
-                }
-                innerCore.setProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY, newLength);
-            }
-        }
-
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
@@ -744,7 +731,7 @@ define([
                     longestNewRelid = j;
                 }
             }
-            processRelidReservation(parent, longestNewRelid);
+            this.processRelidReservation(parent, longestNewRelid);
 
             //searching for the longest new relid and then process it towards the bases of the parent
             for (i = 0; i < copiedNodes.length; i += 1) {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -465,6 +465,19 @@ define([
             return result;
         }
 
+        function processRelidReservation(node, relid) {
+            var newLength = relid.length + 1 > CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH ?
+                CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH : relid.length + 1;
+
+            node = node.base;
+            while (node) {
+                if (innerCore.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY) >= newLength) {
+                    return;
+                }
+                innerCore.setProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY, newLength);
+            }
+        }
+
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
@@ -723,6 +736,15 @@ define([
                 copiedNodes[i].base = base;
                 innerCore.setPointer(copiedNodes[i], CONSTANTS.BASE_POINTER, base);
             }
+
+            //searching for the longest new relid and then process it towards the bases of the parent
+            for (i = 0; i < copiedNodes.length; i += 1) {
+                j = this.getRelid(copiedNodes[i]);
+                if (j.length > longestNewRelid) {
+                    longestNewRelid = j;
+                }
+            }
+            processRelidReservation(parent, longestNewRelid);
 
             //searching for the longest new relid and then process it towards the bases of the parent
             for (i = 0; i < copiedNodes.length; i += 1) {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -744,15 +744,6 @@ define([
             }
             this.processRelidReservation(parent, longestNewRelid);
 
-            //searching for the longest new relid and then process it towards the bases of the parent
-            for (i = 0; i < copiedNodes.length; i += 1) {
-                j = this.getRelid(copiedNodes[i]);
-                if (j.length > longestNewRelid) {
-                    longestNewRelid = j;
-                }
-            }
-            this.processRelidReservation(parent, longestNewRelid);
-
             return copiedNodes;
         };
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -570,6 +570,17 @@ define([
             }, TASYNC.lift(children));
         };
 
+        this.setPointer = function (node, name, target) {
+            innerCore.setPointer(node, name, target);
+            if (isInheritedChild(node)) {
+                this.setProperty(node, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+            }
+
+            if (isInheritedChild(target)) {
+                this.setProperty(target, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+            }
+        };
+
         this.getCollectionNames = function (node) {
             ASSERT(self.isValidNode(node));
             var ownNames = innerCore.getCollectionNames(node),
@@ -1099,7 +1110,7 @@ define([
             return innerCore.getChildrenPaths(node);
         };
 
-        this.processRelidReservation = function(node, relid) {
+        this.processRelidReservation = function (node, relid) {
             var newLength = relid.length + 1 > CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH ?
                 CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH : relid.length + 1;
 

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2726,7 +2726,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(6);
+                    expect(events).to.have.length(10);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2811,7 +2811,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(6);
+                    expect(events).to.have.length(10);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2902,7 +2902,7 @@ describe('GME client', function () {
                     //events.forEach(function (e) {
                     //    console.log(e);
                     //});
-                    expect(events).to.have.length(7);
+                    expect(events).to.have.length(11);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2726,7 +2726,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(10);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2811,7 +2811,7 @@ describe('GME client', function () {
                 if (testState === 'checking') {
                     //FIXME why the update events missing about the source nodes -
                     // it works correctly with single node copying
-                    expect(events).to.have.length(10);
+                    expect(events).to.have.length(6);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {
@@ -2902,7 +2902,7 @@ describe('GME client', function () {
                     //events.forEach(function (e) {
                     //    console.log(e);
                     //});
-                    expect(events).to.have.length(11);
+                    expect(events).to.have.length(7);
 
                     //find out the new node paths
                     for (i = 1; i < events.length; i++) {


### PR DESCRIPTION
Currently there is no data associated with a 'purely' inherited child as it would not hold any additional information. Also, because the relations of a node are stored in the common ancestor of the source and destination, if such node would have a relation that is not inherited, that would not result in actual data other than an entry in the common ancestor. Therefore if such node would be removed due to the removal of its base, the entry of the relation would remain in the ancestor potentially giving false results to relational inquiries.
To fix this issue, we reserve an actual data node for the inherited child whenever it is directly placed into a relation. That would cause in this scenario, that the node will be removed (and not just disappears) which would take care of the overlay entries as well.