### PR TITLE
Fixes for #1177 relid collisions from base class

### DIFF
--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -688,11 +688,15 @@ define([
             ASSERT(self.isValidNewParent(parent, node),
                 'New parent would create loop in containment/inheritance tree.');
             var base = node.base,
+                minRelidLength = innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY) || 0,
+                takenRelids = self.getChildrenRelids(parent, true),
                 moved;
 
-            // TODO: Should we stop trying to reuse the current path?
-            // TODO: Maybe check if it is longer than MINIMAL_RELID_LENGTH_PROPERTY
-            moved = innerCore.moveNode(node, parent, self.getChildrenRelids(parent, true));
+            if (this.getRelid(node).length < minRelidLength) {
+                takenRelids[this.getRelid(node)] = true;
+            }
+
+            moved = innerCore.moveNode(node, parent, takenRelids);
             moved.base = base;
 
             this.processRelidReservation(parent, this.getRelid(moved));

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -8,7 +8,7 @@
 define([
     'common/util/assert',
     'common/core/tasync',
-    'common/core/constants',
+    'common/core/constants'
 ], function (ASSERT, TASYNC, CONSTANTS) {
     'use strict';
 
@@ -690,6 +690,8 @@ define([
             var base = node.base,
                 moved;
 
+            // TODO: Should we stop trying to reuse the current path?
+            // TODO: Maybe check if it is longer than MINIMAL_RELID_LENGTH_PROPERTY
             moved = innerCore.moveNode(node, parent, self.getChildrenRelids(parent, true));
             moved.base = base;
 
@@ -705,6 +707,7 @@ define([
 
             newnode.base = base;
             innerCore.setPointer(newnode, CONSTANTS.BASE_POINTER, base);
+            innerCore.deleteProperty(newnode, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
 
             this.processRelidReservation(parent, this.getRelid(newnode));
 
@@ -752,6 +755,7 @@ define([
                 base = nodes[i].base;
                 copiedNodes[i].base = base;
                 innerCore.setPointer(copiedNodes[i], CONSTANTS.BASE_POINTER, base);
+                innerCore.deleteProperty(copiedNodes[i], CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
             }
 
             //searching for the longest new relid and then process it towards the bases of the parent
@@ -761,6 +765,7 @@ define([
                     longestNewRelid = j;
                 }
             }
+
             this.processRelidReservation(parent, longestNewRelid);
 
             return copiedNodes;
@@ -1038,8 +1043,11 @@ define([
 
                 // Handle the minimal new length propagation to the new base chain.
                 for (i = 0; i < nodeChildren.length; i += 1) {
-                    minRelidLength = nodeChildren[i].length + 1 > minRelidLength ?
-                    nodeChildren[i].length + 1 : minRelidLength;
+                    // Do not account for old relids..
+                    if (nodeChildren[i].length <= CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH) {
+                        minRelidLength = nodeChildren[i].length + 1 > minRelidLength ?
+                        nodeChildren[i].length + 1 : minRelidLength;
+                    }
                 }
 
                 if (minRelidLength >= 2) {

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -1177,7 +1177,7 @@ define([
             this.importClosure = function (parent, closureInformation) {
                 //at this point we can assume that the database has the necessary blobs
                 var allMetaNodes = this.getAllMetaNodes(parent),
-                    checkResult = null,
+                    checkResult,
                     key,
                     name,
                     longestNewRelid = '',
@@ -1200,7 +1200,7 @@ define([
                     reservedRelids[newRelid] = true;
                     innerCore.setProperty(parent, newRelid, closureInformation.selection[key]);
                     closureInformation.relids[closureInformation.selection[key]] = newRelid;
-                    if (newRelid.length > longestNewRelid) {
+                    if (newRelid.length > longestNewRelid.length) {
                         longestNewRelid = newRelid;
                     }
                 }

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -6,7 +6,7 @@
  */
 var testFixture = require('../../_globals.js');
 
-describe.only('coretype', function () {
+describe('coretype', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         Q = testFixture.Q,

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -867,6 +867,141 @@ describe('coretype', function () {
         expect(core.getRelid(protoChild)).to.have.length(CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH);
     });
 
+    it('should generate longer relid for copied child if instance already has a child 1', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            child = core.createNode({parent: inst, relid: '1'}),
+            cpyChild = core.createNode({parent: root, relid: '2'}),
+            copiedChild = core.copyNode(cpyChild, proto);
+
+        expect(core.getRelid(child)).to.have.length(1);
+        expect(core.getRelid(copiedChild)).to.have.length(2);
+    });
+
+    it('should generate longer relid for copied child if instance already has a child 2', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            child = core.createNode({parent: inst, relid: '1'}),
+            cpyChild = core.createNode({parent: root, relid: '1'}),
+            copiedChild = core.copyNode(cpyChild, proto);
+
+        expect(core.getRelid(child)).to.have.length(1);
+        expect(core.getRelid(copiedChild)).to.have.length(2);
+    });
+
+    it('should generate longer relid for moved child if instance already has a child 1', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            child = core.createNode({parent: inst, relid: '1'}),
+            moveChild = core.createNode({parent: root, relid: '2'}),
+            movedChild = core.moveNode(moveChild, proto);
+
+        expect(core.getRelid(child)).to.have.length(1);
+        expect(core.getRelid(movedChild)).to.have.length(2);
+    });
+
+    it('should generate longer relid for moved child if instance already has a child 2', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            child = core.createNode({parent: inst, relid: '1'}),
+            moveChild = core.createNode({parent: root, relid: '1'}),
+            movedChild = core.moveNode(moveChild, proto);
+
+        expect(core.getRelid(child)).to.have.length(1);
+        expect(core.getRelid(movedChild)).to.have.length(2);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY recursively through the inheritance chain at createdNOde 1', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            instInst = core.createNode({parent: root, base: inst, relid: 'theInstanceInstance'}),
+            child1 = core.createNode({parent: instInst, relid: '1'}),
+            child2 = core.createNode({parent: inst}),
+            child3 = core.createNode({parent: proto});
+
+        expect(core.getRelid(child1)).to.have.length(1);
+        expect(core.getRelid(child2)).to.have.length(2);
+        expect(core.getRelid(child3)).to.have.length(3);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY recursively through the inheritance chain at createdNode 2', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            instInst = core.createNode({parent: root, base: inst, relid: 'theInstanceInstance'}),
+            child1 = core.createNode({parent: instInst, relid: '1'}),
+            child2 = core.createNode({parent: inst}),
+            child3 = core.createNode({parent: proto});
+
+        expect(core.getRelid(child1)).to.have.length(1);
+        expect(core.getRelid(child2)).to.have.length(2);
+        expect(core.getRelid(child3)).to.have.length(3);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY recursively through the inheritance chain at createdNode 3', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            instInst = core.createNode({parent: root, base: inst, relid: 'theInstanceInstance'}),
+            child1 = core.createNode({parent: instInst, relid: '1'}),
+            child3 = core.createNode({parent: proto});
+
+        expect(core.getRelid(child1)).to.have.length(1);
+        expect(core.getRelid(child3)).to.have.length(2);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY at setBase', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            toBeInst = core.createNode({parent: root, relid: 'theInstance'}),
+            child = core.createNode({parent: toBeInst, relid: '1'});
+
+        expect(core.getRelid(child)).to.have.length(1);
+
+        core.setBase(toBeInst, proto);
+
+        child = core.createNode({parent: proto});
+        expect(core.getRelid(child)).to.have.length(2);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY recursively through the inheritance chain at setBase', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            toBeInst = core.createNode({parent: root, relid: 'theInstanceInstance'}),
+            child = core.createNode({parent: toBeInst, relid: '1'});
+
+        expect(core.getRelid(child)).to.have.length(1);
+
+        core.setBase(toBeInst, inst);
+
+        child = core.createNode({parent: proto});
+        expect(core.getRelid(child)).to.have.length(2);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY from property at setBase', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            toBeInst = core.createNode({parent: root, relid: 'i'}),
+            toBeInstInst = core.createNode({parent: root, base: toBeInst, relid: 'theInstanceInstance'}),
+            child = core.createNode({parent: toBeInstInst, relid: '1'});
+
+        expect(core.getRelid(child)).to.have.length(1);
+
+        core.setBase(toBeInst, proto);
+
+        child = core.createNode({parent: proto});
+        expect(core.getRelid(child)).to.have.length(2);
+    });
+
+    it('should only update MINIMAL_RELID_LENGTH_PROPERTY up to MAXIMUM_STARTING_RELID_LENGTH at setBase', function () {
+        var proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            toBeInst = core.createNode({parent: root, relid: 'i'}),
+            child = core.createNode({parent: toBeInst, relid: '123456789'});
+
+        expect(core.getRelid(child)).to.have.length(9);
+
+        core.setBase(toBeInst, proto);
+
+        child = core.createNode({parent: proto});
+        expect(core.getRelid(child)).to.have.length(CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH);
+    });
+
     it('should not leave any overlay residue as an instance child that only has relations deleted', function (done) {
         var proto = core.createNode({parent: root, relid: 'theAncestor'}),
             inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),


### PR DESCRIPTION
The property here means the newly introduced `MINIMAL_RELID_LENGTH_PROPERTY`

- The property should be propagated at setBase.
 - When checking the length of the children at the node getting a new base it neglects relids lengths > `MAXIMUM_STARTING_RELID_LENGTH`
- The property should be propagated recursively.
- The property should not be copied to copies of a node.
