### PR TITLE
Register active visualizer at panel switch in split panel view.

### DIFF
--- a/src/client/js/Constants.js
+++ b/src/client/js/Constants.js
@@ -104,7 +104,11 @@ define([
         PROPERTY_GROUP_POINTERS: 'Pointers',
 
         /* Visualizer */
-        DEFAULT_VISUALIZER: 'ModelEditor'
+        DEFAULT_VISUALIZER: 'ModelEditor',
+
+        // This is assigned by the VisualizerPanel onto the visualizer instance on the fly and is set to
+        // the id defined in Visualizers.json.
+        VISUALIZER_PANEL_IDENTIFIER: 'VISUALIZER_PANEL_IDENTIFIER'
     });
 
     clientConstants.CLIENT = CLIENT_CONSTANTS;

--- a/src/client/js/PanelManager/PanelManager.js
+++ b/src/client/js/PanelManager/PanelManager.js
@@ -33,6 +33,8 @@ define(['js/logger', 'js/Constants'], function (Logger, CONSTANTS) {
                 this._activePanel = p;
                 this._activePanel.setActive(true);
             }
+
+            WebGMEGlobal.State.registerActiveVisualizer(this._activePanel[CONSTANTS.VISUALIZER_PANEL_IDENTIFIER]);
         }
 
         WebGMEGlobal.KeyboardManager.captureFocus();

--- a/src/client/js/PanelManager/PanelManager.js
+++ b/src/client/js/PanelManager/PanelManager.js
@@ -4,7 +4,7 @@
  * @author rkereskenyi / https://github.com/rkereskenyi
  */
 
-define(['js/logger'], function (Logger) {
+define(['js/logger', 'js/Constants'], function (Logger, CONSTANTS) {
 
     'use strict';
 

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -124,8 +124,7 @@ define(['js/logger',
 
         WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_VISUALIZER, function (model, activeVisualizer) {
             if (self._settingVisualizer !== true) {
-                if (self._splitPanel)
-                self._setActiveVisualizer(activeVisualizer, self._ul1);
+                self.setActiveVisualizer(activeVisualizer);
             }
         });
 

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -124,6 +124,7 @@ define(['js/logger',
 
         WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_VISUALIZER, function (model, activeVisualizer) {
             if (self._settingVisualizer !== true) {
+                if (self._splitPanel)
                 self._setActiveVisualizer(activeVisualizer, self._ul1);
             }
         });
@@ -173,6 +174,7 @@ define(['js/logger',
                 PanelClass = this._visualizers[visualizer].panel;
                 if (PanelClass) {
                     this._activePanel[panel] = new PanelClass(this._layoutManager, {client: this._client});
+                    this._activePanel[panel][CONSTANTS.VISUALIZER_PANEL_IDENTIFIER] = this._visualizers[visualizer].id;
                     this._splitPanel.setPanel(this._activePanel[panel], panel);
                 }
 
@@ -356,7 +358,7 @@ define(['js/logger',
                 require([menuDesc.panel],
                     function (panelClass) {
                         self.logger.debug('downloaded: ' + menuDesc.panel);
-                        self._visualizers[menuDesc.id] = {panel: panelClass};
+                        self._visualizers[menuDesc.id] = {panel: panelClass, id: menuDesc.id};
                         self._removeLoader(li, loaderDiv);
                         doCallBack();
                     },


### PR DESCRIPTION
This fixes the issue of the PartBrowser not displaying the correct nodes.