### PR TITLE
In setBase only keep children data that have common origin.

### DIFF
--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1024,15 +1024,11 @@ define([
                         innerCore.setPointer(node, CONSTANTS.BASE_POINTER, base);
 
                         for (i = 0; i < nodeChildren.length; i += 1) {
-                            if (baseChildren[nodeChildren[i]]) {
-                                // Deal with relid collisions of the children of the node.
-                                if (childHasSameOrigin(node, base, nodeChildren[i]) === false) {
-                                    // 1. The child is defined in both the node(base chain) and new-base(base chain)
-                                    // -> remove the child.
-                                    innerCore.deleteChild(node, nodeChildren[i]);
-                                } else {
-                                    // 2. The child is defined at a common ancestor -> keep the data as is.
-                                }
+                            if (baseChildren[nodeChildren[i]] && childHasSameOrigin(node, base, nodeChildren[i])) {
+                                // Currently we only keep the children data for children with same origin.
+                                // Meaning we delete all other children (including those that were created in node).
+                            } else {
+                                innerCore.deleteChild(node, nodeChildren[i]);
                             }
                         }
                     } else {

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -650,7 +650,7 @@ describe('coretype', function () {
         expect(core.isValidNewBase(instance, node)).to.equal(false);
     });
 
-    it('setBase should keep children that are not colliding with children of new base', function () {
+    it('setBase should remove children that are not defined in common ancestor', function () {
         var newBase = core.createNode({parent: root}),
             node = core.createNode({parent: root});
 
@@ -658,7 +658,7 @@ describe('coretype', function () {
         core.createNode({parent: node, relid: 'b'});
 
         core.setBase(node, newBase);
-        expect(core.getChildrenRelids(node)).to.have.members(['a', 'b']);
+        expect(core.getChildrenRelids(node)).to.have.members(['a']);
     });
 
     it('setBase should remove children(data) that are colliding and NOT defined in common ancestor', function (done) {


### PR DESCRIPTION
To avoid ambiguous result (regarding children) when changing the base of a node - only children data applicable to children from a common-base between the previous and new base are kept.

The picture below shows which nodes are removed when switching base. In the previous implementation "e" would have been kept.

![image](https://cloud.githubusercontent.com/assets/6518904/19286499/99c65532-8fc3-11e6-912b-5cc9d11cae4b.png)
