### PR TITLE
Collect instances

### DIFF
--- a/src/client/js/Panels/ObjectBrowser/InheritanceBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/InheritanceBrowserControl.js
@@ -149,7 +149,7 @@ define(['js/logger',
             parentNode = this._nodes[nodeId].treeNode;
 
             //get the children IDs of the parent
-            inheritedIDs = parent.getInstancesPaths();
+            inheritedIDs = parent.getInstancePaths();
 
             this._treeBrowser.enableUpdate(false);
 
@@ -168,12 +168,12 @@ define(['js/logger',
                     childrenDescriptors.push({
                         id: currentChildId,
                         name: childNode.getFullyQualifiedName(),
-                        hasChildren: (childNode.getInstancesPaths()).length > 0,
+                        hasChildren: (childNode.getInstancePaths()).length > 0,
                         class: this._getNodeClass(childNode, metaTypeInfo.isMetaNode),
                         icon: this.getIcon(childNode),
                         // Data used locally here.
                         STATE: STATE_LOADED,
-                        INHERITANCE: childNode.getInstancesPaths(),
+                        INHERITANCE: childNode.getInstancePaths(),
                     });
                 } else {
                     //the node is not present on the client side, render a loading node instead
@@ -347,7 +347,7 @@ define(['js/logger',
                         //create the node's descriptor for the tree-browser widget
                         nodeDescriptor = {
                             name: updatedObject.getFullyQualifiedName(),
-                            hasChildren: (updatedObject.getInstancesPaths()).length > 0,
+                            hasChildren: (updatedObject.getInstancePaths()).length > 0,
                             class: objType,
                             icon: self.getIcon(updatedObject)
                         };
@@ -356,7 +356,7 @@ define(['js/logger',
                         this._treeBrowser.updateNode(this._nodes[objectId].treeNode, nodeDescriptor);
 
                         //update the object's children list in the local hashmap
-                        this._nodes[objectId].inheritance = updatedObject.getInstancesPaths();
+                        this._nodes[objectId].inheritance = updatedObject.getInstancePaths();
 
                         //finally update the object's state showing loaded
                         this._nodes[objectId].state = STATE_LOADED;
@@ -370,13 +370,13 @@ define(['js/logger',
                         //create the node's descriptor for the treebrowser widget
                         nodeDescriptor = {
                             name: updatedObject.getFullyQualifiedName(),
-                            hasChildren: (updatedObject.getInstancesPaths()).length > 0,
+                            hasChildren: (updatedObject.getInstancePaths()).length > 0,
                             class: objType,
                             icon: self.getIcon(updatedObject)
                         };
 
                         oldInheritance = this._nodes[objectId].inheritance;
-                        currentInheritance = updatedObject.getInstancesPaths();
+                        currentInheritance = updatedObject.getInstancePaths();
 
                         //the concrete child deletion is important only if the node is open in the tree
                         if (this._treeBrowser.isExpanded(this._nodes[objectId].treeNode)) {
@@ -443,7 +443,7 @@ define(['js/logger',
                                     childTreeNode = this._treeBrowser.createNode(this._nodes[objectId].treeNode, {
                                         id: currentChildId,
                                         name: childNode.getFullyQualifiedName(),
-                                        hasChildren: (childNode.getInstancesPaths()).length > 0,
+                                        hasChildren: (childNode.getInstancePaths()).length > 0,
                                         class: objType,
                                         icon: this.getIcon(childNode)
                                     });
@@ -451,7 +451,7 @@ define(['js/logger',
                                     //store the node's info in the local hashmap
                                     this._nodes[currentChildId] = {
                                         treeNode: childTreeNode,
-                                        inheritance: childNode.getInstancesPaths(),
+                                        inheritance: childNode.getInstancePaths(),
                                         state: STATE_LOADED
                                     };
                                 } else {
@@ -474,7 +474,7 @@ define(['js/logger',
                             }
                         }
 
-                        this._nodes[objectId].inheritance = updatedObject.getInstancesPaths();
+                        this._nodes[objectId].inheritance = updatedObject.getInstancePaths();
 
                         //update the node's representation in the tree
                         this._treeBrowser.updateNode(this._nodes[objectId].treeNode, nodeDescriptor);

--- a/src/client/js/Panels/ObjectBrowser/InheritanceBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/InheritanceBrowserControl.js
@@ -149,7 +149,7 @@ define(['js/logger',
             parentNode = this._nodes[nodeId].treeNode;
 
             //get the children IDs of the parent
-            inheritedIDs = parent.getCollectionPaths(CONSTANTS.POINTER_BASE);
+            inheritedIDs = parent.getInstancesPaths();
 
             this._treeBrowser.enableUpdate(false);
 
@@ -168,12 +168,12 @@ define(['js/logger',
                     childrenDescriptors.push({
                         id: currentChildId,
                         name: childNode.getFullyQualifiedName(),
-                        hasChildren: (childNode.getCollectionPaths(CONSTANTS.POINTER_BASE)).length > 0,
+                        hasChildren: (childNode.getInstancesPaths()).length > 0,
                         class: this._getNodeClass(childNode, metaTypeInfo.isMetaNode),
                         icon: this.getIcon(childNode),
                         // Data used locally here.
                         STATE: STATE_LOADED,
-                        INHERITANCE: childNode.getCollectionPaths(CONSTANTS.POINTER_BASE),
+                        INHERITANCE: childNode.getInstancesPaths(),
                     });
                 } else {
                     //the node is not present on the client side, render a loading node instead
@@ -347,7 +347,7 @@ define(['js/logger',
                         //create the node's descriptor for the tree-browser widget
                         nodeDescriptor = {
                             name: updatedObject.getFullyQualifiedName(),
-                            hasChildren: (updatedObject.getCollectionPaths(CONSTANTS.POINTER_BASE)).length > 0,
+                            hasChildren: (updatedObject.getInstancesPaths()).length > 0,
                             class: objType,
                             icon: self.getIcon(updatedObject)
                         };
@@ -356,7 +356,7 @@ define(['js/logger',
                         this._treeBrowser.updateNode(this._nodes[objectId].treeNode, nodeDescriptor);
 
                         //update the object's children list in the local hashmap
-                        this._nodes[objectId].inheritance = updatedObject.getCollectionPaths(CONSTANTS.POINTER_BASE);
+                        this._nodes[objectId].inheritance = updatedObject.getInstancesPaths();
 
                         //finally update the object's state showing loaded
                         this._nodes[objectId].state = STATE_LOADED;
@@ -370,13 +370,13 @@ define(['js/logger',
                         //create the node's descriptor for the treebrowser widget
                         nodeDescriptor = {
                             name: updatedObject.getFullyQualifiedName(),
-                            hasChildren: (updatedObject.getCollectionPaths(CONSTANTS.POINTER_BASE)).length > 0,
+                            hasChildren: (updatedObject.getInstancesPaths()).length > 0,
                             class: objType,
                             icon: self.getIcon(updatedObject)
                         };
 
                         oldInheritance = this._nodes[objectId].inheritance;
-                        currentInheritance = updatedObject.getCollectionPaths(CONSTANTS.POINTER_BASE);
+                        currentInheritance = updatedObject.getInstancesPaths();
 
                         //the concrete child deletion is important only if the node is open in the tree
                         if (this._treeBrowser.isExpanded(this._nodes[objectId].treeNode)) {
@@ -443,7 +443,7 @@ define(['js/logger',
                                     childTreeNode = this._treeBrowser.createNode(this._nodes[objectId].treeNode, {
                                         id: currentChildId,
                                         name: childNode.getFullyQualifiedName(),
-                                        hasChildren: (childNode.getCollectionPaths(CONSTANTS.POINTER_BASE)).length > 0,
+                                        hasChildren: (childNode.getInstancesPaths()).length > 0,
                                         class: objType,
                                         icon: this.getIcon(childNode)
                                     });
@@ -451,7 +451,7 @@ define(['js/logger',
                                     //store the node's info in the local hashmap
                                     this._nodes[currentChildId] = {
                                         treeNode: childTreeNode,
-                                        inheritance: childNode.getCollectionPaths(CONSTANTS.POINTER_BASE),
+                                        inheritance: childNode.getInstancesPaths(),
                                         state: STATE_LOADED
                                     };
                                 } else {
@@ -474,7 +474,7 @@ define(['js/logger',
                             }
                         }
 
-                        this._nodes[objectId].inheritance = updatedObject.getCollectionPaths(CONSTANTS.POINTER_BASE);
+                        this._nodes[objectId].inheritance = updatedObject.getInstancesPaths();
 
                         //update the node's representation in the tree
                         this._treeBrowser.updateNode(this._nodes[objectId].treeNode, nodeDescriptor);

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -274,7 +274,7 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     GMENode.prototype.getInstancesPaths = function () {
         return this._state.core.getInstancesPaths(this._state.nodes[this._id].node);
     };
-    
+
     //adding functionality to get rid of GMEConcepts
     GMENode.prototype.isConnection = function () {
         return this._state.core.isConnection(this._state.nodes[this._id].node);

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -150,7 +150,7 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         }
         return {to: this._state.core.getPointerPath(this._state.nodes[this._id].node, name), from: []};
     };
-    
+
     GMENode.prototype.getPointerId = function (name) {
         return this.getPointer(name).to;
     };
@@ -158,7 +158,7 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     GMENode.prototype.getOwnPointer = function (name) {
         return {to: this._state.core.getOwnPointerPath(this._state.nodes[this._id].node, name), from: []};
     };
-    
+
     GMENode.prototype.getOwnPointerId = function (name) {
         return this.getOwnPointer(name).to;
     };
@@ -271,6 +271,10 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         return this._state.core.getCollectionPaths(this._state.nodes[this._id].node, name);
     };
 
+    GMENode.prototype.getInstancesPaths = function () {
+        return this._state.core.getInstancesPaths(this._state.nodes[this._id].node);
+    };
+    
     //adding functionality to get rid of GMEConcepts
     GMENode.prototype.isConnection = function () {
         return this._state.core.isConnection(this._state.nodes[this._id].node);

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -271,8 +271,8 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         return this._state.core.getCollectionPaths(this._state.nodes[this._id].node, name);
     };
 
-    GMENode.prototype.getInstancesPaths = function () {
-        return this._state.core.getInstancesPaths(this._state.nodes[this._id].node);
+    GMENode.prototype.getInstancePaths = function () {
+        return this._state.core.getInstancePaths(this._state.nodes[this._id].node);
     };
 
     //adding functionality to get rid of GMEConcepts

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -2019,7 +2019,7 @@ define([
          *
          * @func
          */
-        this.getInstancesPaths = core.getInstancesPaths;
+        this.getInstancePaths = core.getInstancePaths;
 
         /**
          * Loads all the instances of the given node.

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -2010,6 +2010,25 @@ define([
 
         this.getClosureInformation = core.getClosureInformation;
         this.importClosure = core.importClosure;
+
+        /**
+         * Collects the paths of all the instances of the given node.
+         * @param {module:Core~Node} node - the node in question.
+         *
+         *@return {string[]} The function returns an array of the absolute paths of the instances.
+         *
+         * @func
+         */
+        this.getInstancesPaths = core.getInstancesPaths;
+
+        /**
+         * Loads all the instances of the given node.
+         * @param {module:Core~Node} node - the node in question.
+         * @param {function(string, module:Core~Node[])} callback
+         *
+         * @func
+         */
+        this.loadInstances = core.loadInstances;
     }
 
     return Core;

--- a/src/common/core/coreQ.js
+++ b/src/common/core/coreQ.js
@@ -212,7 +212,7 @@ define(['common/core/core', 'q'], function (Core, Q) {
             });
 
             return deferred.promise.nodeify(callback);
-        }
+        };
 
         var traverseOrg = this.traverse;
         this.traverse = function (node, options, visitFn, callback) {
@@ -225,7 +225,21 @@ define(['common/core/core', 'q'], function (Core, Q) {
                 }
             });
             return deferred.promise.nodeify(callback);
-        }
+        };
+
+        var loadInstancesOrg = this.loadInstances;
+        this.loadInstances = function (node, callback) {
+            var deferred = Q.defer();
+            loadInstancesOrg(node, function (err, res) {
+                if (err) {
+                    deferred.reject(err instanceof Error ? err : new Error(err));
+                } else {
+                    deferred.resolve(res);
+                }
+            });
+
+            return deferred.promise.nodeify(callback);
+        };
     }
 
     CoreQ.prototype = Object.create(Core.prototype);

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1214,6 +1214,21 @@ define([
 
             return instances;
         };
+
+        this.loadInstances = function (node) {
+            ASSERT(self.isValidNode(node));
+
+            var instancesPaths = self.getInstancesPaths(node),
+                instances,
+                root = self.getRoot(node),
+                i;
+
+            for (i = 0; i < instancesPaths.length; i += 1) {
+                instances[i] = self.loadByPath(root, instancesPaths[i]);
+            }
+
+            return TASYNC.lift(instances);
+        };
         //</editor-fold>
     };
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -50,29 +50,6 @@ define([
             return node;
         }
 
-        function refreshChildrenRelids(node) {
-            // We have just loaded the node, we want to update relid informations
-            var relids = self.getChildrenRelids(node, true),
-                ownRelids = self.getOwnChildrenRelids(node),
-                base = self.getBase(node),
-                basePath,
-                relid;
-            for (relid in relids) {
-                if (ownRelids.indexOf(relid) !== -1) {
-                    // Own child, has to have a base pointer
-                    basePath = self.getPointerPathFrom(node,
-                        CONSTANTS.PATH_SEP + relid, CONSTANTS.BASE_POINTER);
-                    if (basePath === undefined || basePath === null) {
-                        innerCore.deleteChild(node, relid);
-                    }
-                } else {
-                    if (base && self.getChildrenRelids(base, true)[relid] !== true) {
-                        innerCore.deleteChild(node, relid);
-                    }
-                }
-            }
-        }
-
         function loadChild(node, relid) {
             var child = null,
                 base = self.getBase(node),
@@ -90,14 +67,12 @@ define([
                         if (c) {
                             child = c;
                             child.base = b;
-                            refreshChildrenRelids(child);
                             return child;
                         } else {
                             child = innerCore.getChild(n, r);
                             self.setHashed(child, true, true);
                             child.base = b;
 
-                            refreshChildrenRelids(child);
                             return child;
                         }
                     }, basechild, child, node, relid);
@@ -120,14 +95,14 @@ define([
                     //empty nodes do not have a base
                     node.base = null;
                     return node;
-                    /*} else if (isFalseNode(node)) {
-                     innerCore.deleteNode(node);
-                     //core.persist(core.getRoot(node));
-                     //TODO a notification should be generated towards the user
-                     logger.warn('node [' + path + '] removed due to missing base');
+                } else if (isFalseNode(node)) {
+                    innerCore.deleteNode(node);
+                    //core.persist(core.getRoot(node));
+                    //TODO a notification should be generated towards the user
+                    logger.warn('node [' + path + '] removed due to missing base');
 
-                     //TODO check if some identification can be passed
-                     return null;*/
+                    //TODO check if some identification can be passed
+                    return null;
                 } else {
                     var basePath = innerCore.getPointerPath(node, CONSTANTS.BASE_POINTER);
                     ASSERT(basePath !== undefined);
@@ -154,7 +129,6 @@ define([
             if (typeof node.base !== null && typeof node.base === 'object' &&
                 (innerCore.getPath(node.base) === innerCore.getPath(target))) {
                 //TODO somehow the object already loaded properly and we do no know about it!!!
-                refreshChildrenRelids(node);
                 return node;
             } else {
                 ASSERT(node.base === undefined || node.base === null); //kecso
@@ -170,7 +144,6 @@ define([
 
                 node.base = target;
 
-                refreshChildrenRelids(node);
                 return node;
             }
         }

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1169,17 +1169,12 @@ define([
             var instances = [],
                 directCollectionPaths,
                 relPath = '',
-                path,
                 i;
 
             while (node) {
                 directCollectionPaths = innerCore.getCollectionPaths(node, CONSTANTS.BASE_POINTER);
                 for (i = 0; i < directCollectionPaths.length; i += 1) {
-                    path = directCollectionPaths[i] + relPath;
-                    //TODO it should not be necessary as it is very unlikely to have two
-                    if (instances.indexOf(path) === -1) {
-                        instances.push(path);
-                    }
+                    instances.push(directCollectionPaths[i] + relPath);
                 }
                 relPath = CONSTANTS.PATH_SEP + innerCore.getRelid(node) + relPath;
                 node = innerCore.getParent(node);
@@ -1192,7 +1187,7 @@ define([
             ASSERT(self.isValidNode(node));
 
             var instancesPaths = self.getInstancesPaths(node),
-                instances,
+                instances = [],
                 root = self.getRoot(node),
                 i;
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1165,7 +1165,7 @@ define([
             processNewRelidLength(node, relid.length + 1);
         };
 
-        this.getInstancesPaths = function (node) {
+        this.getInstancePaths = function (node) {
             var instances = [],
                 directCollectionPaths,
                 relPath = '',
@@ -1186,13 +1186,13 @@ define([
         this.loadInstances = function (node) {
             ASSERT(self.isValidNode(node));
 
-            var instancesPaths = self.getInstancesPaths(node),
+            var instancePaths = self.getInstancePaths(node),
                 instances = [],
                 root = self.getRoot(node),
                 i;
 
-            for (i = 0; i < instancesPaths.length; i += 1) {
-                instances[i] = self.loadByPath(root, instancesPaths[i]);
+            for (i = 0; i < instancePaths.length; i += 1) {
+                instances[i] = self.loadByPath(root, instancePaths[i]);
             }
 
             return TASYNC.lift(instances);

--- a/src/common/core/coreunwrap.js
+++ b/src/common/core/coreunwrap.js
@@ -94,6 +94,12 @@ define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
         core.addLibrary = TASYNC.unwrap(innercore.addLibrary);
         core.updateLibrary = TASYNC.unwrap(innercore.updateLibrary);
 
+        // core.loadInstances = TASYNC.unwrap(oldcore.loadInstances);
+        core.loadInstances = TASYNC.unwrap(function (node) {
+            return TASYNC.call(checkNodes, innercore.loadInstances(node));
+        });
+
+
         return core;
     };
 

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -727,7 +727,6 @@ exports.logIn = logIn;
 exports.openSocketIo = openSocketIo;
 exports.loadRootNodeFromCommit = loadRootNodeFromCommit;
 exports.loadNode = loadNode;
-exports.loadNode = loadNode;
 
 exports.compareWebgmexFiles = compareWebgmexFiles;
 

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1129,10 +1129,10 @@ describe('coretype', function () {
             child = core.createNode({parent: container, base: base, relid: 'child'}),
             instance = core.createNode({parent: root, base: container, relid: 'instance'});
 
-        expect(core.getInstancesPaths(root)).to.have.length(0);
-        expect(core.getInstancesPaths(base)).to.have.members(['/template', '/template/child']);
-        expect(core.getInstancesPaths(container)).to.have.members(['/instance']);
-        expect(core.getInstancesPaths(child)).to.have.members(['/instance/child']);
+        expect(core.getInstancePaths(root)).to.have.length(0);
+        expect(core.getInstancePaths(base)).to.have.members(['/template', '/template/child']);
+        expect(core.getInstancePaths(container)).to.have.members(['/instance']);
+        expect(core.getInstancePaths(child)).to.have.members(['/instance/child']);
 
     });
 

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1121,4 +1121,51 @@ describe('coretype', function () {
 
         }, core.loadChildren(inst));
     });
+
+    it('should gather correctly all instances', function () {
+        var root = core.createNode({}),
+            base = core.createNode({parent: root, relid: 'base'}),
+            container = core.createNode({parent: root, base: base, relid: 'template'}),
+            child = core.createNode({parent: container, base: base, relid: 'child'}),
+            instance = core.createNode({parent: root, base: container, relid: 'instance'});
+
+        expect(core.getInstancesPaths(root)).to.have.length(0);
+        expect(core.getInstancesPaths(base)).to.have.members(['/template', '/template/child']);
+        expect(core.getInstancesPaths(container)).to.have.members(['/instance']);
+        expect(core.getInstancesPaths(child)).to.have.members(['/instance/child']);
+
+    });
+
+    it('should load all instances correctly', function (done) {
+        var root = core.createNode({}),
+            base = core.createNode({parent: root, relid: 'base'}),
+            container = core.createNode({parent: root, base: base, relid: 'template'}),
+            child = core.createNode({parent: container, base: base, relid: 'child'}),
+            instance = core.createNode({parent: root, base: container, relid: 'instance'}),
+            neededChecks = 2;
+
+        core.persist(root);
+        TASYNC.call(function (newRoot) {
+            TASYNC.call(function (newChild) {
+                TASYNC.call(function (instances) {
+                    expect(instances).to.have.length(1);
+                    expect(core.getPath(instances[0])).to.equal('/instance/child');
+                    if(--neededChecks === 0){
+                        done();
+                    }
+                }, core.loadInstances(newChild));
+                TASYNC.call(function (instances) {
+                    var paths = [];
+                    expect(instances).to.have.length(2);
+
+                    paths.push(core.getPath(instances[0]));
+                    paths.push(core.getPath(instances[1]));
+                    expect(paths).to.have.members(['/template', '/template/child']);
+                    if(--neededChecks === 0){
+                        done();
+                    }
+                }, core.loadInstances(core.getBase(newChild)));
+            }, core.loadByPath(newRoot, '/template/child'));
+        }, core.loadRoot(core.getHash(root)));
+    });
 });

--- a/test/common/core/metacachecore.spec.js
+++ b/test/common/core/metacachecore.spec.js
@@ -58,9 +58,9 @@ describe('meta cache core', function () {
 
     after(function (done) {
         Q.allDone([
-                storage.closeDatabase(),
-                gmeAuth.unload()
-            ])
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
             .nodeify(done);
     });
 
@@ -250,7 +250,7 @@ describe('meta cache core', function () {
 
                 return core.loadRoot(core.getHash(root_));
             })
-            .then(function(root_){
+            .then(function (root_) {
                 expect(Object.keys(core.getAllMetaNodes(root_))).to.have.length(1);
             })
             .nodeify(done);


### PR DESCRIPTION
With the new functionality it will be possible to collect instances paths even if we are approaching instances that are inherited children. Also the loadInstances shortcut to access instances could speed up some future functions.
