### PR TITLE
Fixes #1189 Standardized export file name

### DIFF
--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -1997,7 +1997,6 @@ define([
             command.branchName = branchName;
             command.commitHash = commitHash;
             command.withAssets = withAssets;
-            //command.fileName = fileName || projectId + '__' + (branchName || commitHash);
             logger.debug('exportProjectToFile, command', command);
             if (command.projectId && (command.branchName || commitHash)) {
                 storage.simpleRequest(command, function (err, result) {

--- a/src/common/blob/util.js
+++ b/src/common/blob/util.js
@@ -175,7 +175,7 @@ define(['q', './BlobMetadata'], function (Q, BlobMetadata) {
             deferred = Q.defer();
 
         artie.descriptor.name = filename || (jsonExport.projectId +
-            '_' + (jsonExport.branchName || jsonExport.commitHash) + '.webgmex');
+            '_' + jsonExport.commitHash.substr(1, 6) + '.webgmex');
 
         if (!addAssets) {
             assets = [];

--- a/src/common/blob/util.js
+++ b/src/common/blob/util.js
@@ -175,7 +175,7 @@ define(['q', './BlobMetadata'], function (Q, BlobMetadata) {
             deferred = Q.defer();
 
         artie.descriptor.name = filename || (jsonExport.projectId +
-            '_' + jsonExport.commitHash.substr(1, 6) + '.webgmex');
+            '_' + (jsonExport.commitHash || '').substr(1, 6) + '.webgmex');
 
         if (!addAssets) {
             assets = [];

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -610,7 +610,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                 var output = rawJson,
                     blobClient = getBlobClient(webgmeToken),
                     deferred = Q.defer(),
-                    filename = output.projectId + '_' + output.commitHash.substr(1, 6) + '.webgmex';
+                    filename = output.projectId + '_' + (output.commitHash || '').substr(1, 6) + '.webgmex';
 
                 blobUtil.buildProjectPackage(logger.fork('blobUtil'),
                     blobClient,
@@ -684,7 +684,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                     },
                     blobClient = getBlobClient(webgmeToken),
                     deferred = Q.defer(),
-                    filename = output.projectId + '_' + output.commitHash.substr(1, 6) + '.webgmexm',
+                    filename = output.projectId + '_' + (output.commitHash || '').substr(1, 6) + '.webgmexm',
                     i;
 
                 for (i = 0; i < rawJsons.length; i += 1) {

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -610,7 +610,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                 var output = rawJson,
                     blobClient = getBlobClient(webgmeToken),
                     deferred = Q.defer(),
-                    filename = output.projectId + '_' + (output.branchName || output.commitHash) + '.webgmex';
+                    filename = output.projectId + '_' + output.commitHash.substr(1, 6) + '.webgmex';
 
                 blobUtil.buildProjectPackage(logger.fork('blobUtil'),
                     blobClient,


### PR DESCRIPTION
The standard file name is 'ownerId+projectName_commitInfo[6].webgmex(m)'.
If the extension contains 'm', then it is model export, otherwise it is a full project export.
The commit information is always the first 6 characters of the commit hash as that should be unique enough, but keep the filename length relatively short. 
