### PR TITLE
Fixes #1218 Error: tried to insert existing hash - the two objects were NOT equal

### DIFF
--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -165,18 +165,19 @@ define([
             ASSERT(__isMutableData(data));
 
             var done = __getEmptyData(),
-                keys = Object.keys(data),
+                keys,
                 key,
                 i, child, sub, hash;
 
             delete data[CONSTANTS.MUTABLE_PROPERTY];
+            keys = Object.keys(data);
 
             for (i = 0; i < keys.length; i++) {
                 key = keys[i];
                 child = data[key];
                 if (__isMutableData(child)) {
                     sub = __saveData(child, root, path + '/' + key);
-                    if (sub === __getEmptyData()) {
+                    if (JSON.stringify(sub) === JSON.stringify(__getEmptyData())) {
                         delete data[key];
                     } else {
                         done = sub;

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1150,7 +1150,7 @@ describe('coretype', function () {
                 TASYNC.call(function (instances) {
                     expect(instances).to.have.length(1);
                     expect(core.getPath(instances[0])).to.equal('/instance/child');
-                    if(--neededChecks === 0){
+                    if (--neededChecks === 0) {
                         done();
                     }
                 }, core.loadInstances(newChild));
@@ -1161,14 +1161,14 @@ describe('coretype', function () {
                     paths.push(core.getPath(instances[0]));
                     paths.push(core.getPath(instances[1]));
                     expect(paths).to.have.members(['/template', '/template/child']);
-                    if(--neededChecks === 0){
+                    if (--neededChecks === 0) {
                         done();
                     }
                 }, core.loadInstances(core.getBase(newChild)));
             }, core.loadByPath(newRoot, '/template/child'));
         }, core.loadRoot(core.getHash(root)));
     });
-    
+
     it('should remove atr and reg field of an instance during persist', function (done) {
         var ancestor = core.createNode({parent: root, relid: 'theAncestor'}),
             node = core.createNode({parent: root, base: ancestor, relid: 'theNode'});

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1168,4 +1168,23 @@ describe('coretype', function () {
             }, core.loadByPath(newRoot, '/template/child'));
         }, core.loadRoot(core.getHash(root)));
     });
+    
+    it('should remove atr and reg field of an instance during persist', function (done) {
+        var ancestor = core.createNode({parent: root, relid: 'theAncestor'}),
+            node = core.createNode({parent: root, base: ancestor, relid: 'theNode'});
+
+        core.persist(root);
+        TASYNC.call(function (newRoot) {
+            TASYNC.call(function (newNode) {
+                core.setAttribute(newNode, 'one', 'value');
+                core.delAttribute(newNode, 'one');
+                core.setRegistry(newNode, 'two', 'values');
+                core.delRegistry(newNode, 'two');
+                core.persist(newRoot);
+                expect(newNode.data).not.to.have.keys(['atr', 'reg']);
+                done();
+            }, core.loadByPath(newRoot, '/theNode'));
+        }, core.loadRoot(core.getHash(root)));
+    });
+
 });

--- a/test/perf/core.perf.js
+++ b/test/perf/core.perf.js
@@ -7,8 +7,7 @@
 var testFixture = require('../_globals.js'),
     PROJECT_FILE = '../projects/Hakan132k.webgmex',
     jsonPatcher = testFixture.requirejs('common/util/jsonPatcher'),
-    getPatchObject = testFixture.requirejs('common/storage/util').getPatchObject,
-    MetaUser = testFixture.requirejs('common/core/users/meta');
+    getPatchObject = testFixture.requirejs('common/storage/util').getPatchObject;
 //"C:\\Users\\Zsolt\\Downloads\\Nagx3.json"
 //"C:\GIT\projects\HakansBigOne.webgmex"
 
@@ -377,11 +376,7 @@ describe.skip('Core Performance test', function () {
                 .then(function (root) {
                     var allMetaNodes = core.getAllMetaNodes(root),
                         i,
-                        meta,
-                        metaUser = new MetaUser();
-
-                    metaUser.initialize(core, {nodes: allMetaNodes}, function () {
-                    });
+                        meta;
 
                     console.time('getJsonMeta');
                     for (i in allMetaNodes) {
@@ -394,13 +389,6 @@ describe.skip('Core Performance test', function () {
                         meta = core.getOwnJsonMeta(allMetaNodes[i]);
                     }
                     console.timeEnd('getOwnJsonMeta');
-
-                    console.time('getMeta');
-                    for (i in allMetaNodes) {
-                        meta = metaUser.getMeta(i);
-                    }
-                    console.timeEnd('getMeta');
-
                 })
                 .nodeify(done);
         });


### PR DESCRIPTION
The collision of hashes was the result of a faulty persist operation (that contained empty object(s)).
Now there is no empty object possible as the result of persist, so no faulty 'no-op' json patch will be generated that would lead to this unusual error.