### PR TITLE
Closes #1222, #1063 and various fixes for Set- and CrossCut-editor.

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -1162,7 +1162,6 @@ define(['js/logger',
                     setID: this._selectedMemberListID
                 }]);
 
-                console.log('Creating desingerItem');
                 uiComponent = this._widget.createDesignerItem(objDesc);
 
                 this._GMEID2ComponentID[gmeID] = this._GMEID2ComponentID[gmeID] || [];

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -42,6 +42,8 @@ define(['js/logger',
 
         this._client = options.client;
 
+        this.disableConnectionRendering = options.disableConnectionRendering;
+
         //initialize core collections and variables
         this._widget = options.widget;
 
@@ -417,7 +419,7 @@ define(['js/logger',
                 //only items are interesting since only those position is stored in the container's set's registry
                 //connections are interesting too since their color or segment points could have changed
                 // which is set specific
-                if (GMEConcepts.isConnection(diff[len]) === false) {
+                if (this.disableConnectionRendering || GMEConcepts.isConnection(diff[len]) === false) {
                     this._onUpdate(diff[len], {isConnection: false});
                 } else {
                     if (this._delayedConnectionsAsItems[diff[len]]) {
@@ -760,7 +762,9 @@ define(['js/logger',
 
                 obj = client.getNode(events[len].eid);
 
-                events[len].desc = {isConnection: GMEConcepts.isConnection(events[len].eid)};
+                events[len].desc = {
+                    isConnection: !this.disableConnectionRendering && GMEConcepts.isConnection(events[len].eid)
+                };
 
                 if (obj) {
                     //if it is a connection find src and dst and do not care about decorator
@@ -1124,9 +1128,10 @@ define(['js/logger',
             alreadySaved,
             len;
 
-        //component loaded
-        //we are interested in the load of member items and their custom territory involvement
-        if (this._selectedMemberListMembers.indexOf(gmeID) !== -1) {
+        // component loaded
+        // we are interested in the load of member items and their custom territory involvement
+        // check if the decorator is available before drawing
+        if (this._selectedMemberListMembers.indexOf(gmeID) !== -1 && desc.decorator) {
 
             if (desc.isConnection === false) {
 
@@ -1157,6 +1162,7 @@ define(['js/logger',
                     setID: this._selectedMemberListID
                 }]);
 
+                console.log('Creating desingerItem');
                 uiComponent = this._widget.createDesignerItem(objDesc);
 
                 this._GMEID2ComponentID[gmeID] = this._GMEID2ComponentID[gmeID] || [];

--- a/src/client/js/Panels/Header/HeaderPanel.js
+++ b/src/client/js/Panels/Header/HeaderPanel.js
@@ -36,19 +36,24 @@ define([
             'gme.ui.ProjectNavigator'
         ]).run(['$rootScope', '$location', function ($rootScope, $location) {
             // FIXME: this might not be the best place to put it...
+            var prevQuery;
             if (WebGMEGlobal && WebGMEGlobal.State) {
                 WebGMEGlobal.State.on('change', function () {
                     var searchQuery = WebGMEUrlManager.serializeStateToUrl();
+                    if (prevQuery !== searchQuery) {
+                        // set the state that gets pushed into the history
+                        $location.state(WebGMEGlobal.State.toJSON());
 
-                    // set the state that gets pushed into the history
-                    $location.state(WebGMEGlobal.State.toJSON());
+                        // setting the search query based on the state
+                        $location.search(searchQuery);
 
-                    // setting the search query based on the state
-                    $location.search(searchQuery);
+                        // store the previous for next update
+                        prevQuery = searchQuery;
 
-                    // forcing the update
-                    if (!$rootScope.$$phase) {
-                        $rootScope.$apply();
+                        // forcing the update
+                        if (!$rootScope.$$phase) {
+                            $rootScope.$apply();
+                        }
                     }
                 });
             } else {

--- a/src/client/js/Panels/SetEditor/SetEditorController.js
+++ b/src/client/js/Panels/SetEditor/SetEditorController.js
@@ -26,6 +26,9 @@ define(['js/Utils/GMEConcepts',
         options = options || {};
         options.loggerName = 'gme:Panels:SetEditor:SetEditorController';
 
+        // Set-editor should not render connections in a special way.
+        options.disableConnectionRendering = true;
+
         DiagramDesignerWidgetMultiTabMemberListControllerBase.call(this, options);
 
         this.logger.debug('SetEditorController ctor finished');

--- a/src/client/js/Panels/SetEditor/SetEditorPanel.js
+++ b/src/client/js/Panels/SetEditor/SetEditorPanel.js
@@ -96,6 +96,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         this.control.onActivate();
         WebGMEGlobal.KeyboardManager.setListener(this.widget);
         WebGMEGlobal.Toolbar.refresh();
+        console.log('active!');
     };
 
     /* override IActivePanel.prototype.onDeactivate */

--- a/src/client/js/Panels/SetEditor/SetEditorPanel.js
+++ b/src/client/js/Panels/SetEditor/SetEditorPanel.js
@@ -96,7 +96,6 @@ define(['js/PanelBase/PanelBaseWithHeader',
         this.control.onActivate();
         WebGMEGlobal.KeyboardManager.setListener(this.widget);
         WebGMEGlobal.Toolbar.refresh();
-        console.log('active!');
     };
 
     /* override IActivePanel.prototype.onDeactivate */

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -441,7 +441,9 @@ define(['js/logger',
                 delete this._ul2;
             }
 
-            WebGMEGlobal.State.registerActiveObject(this._currentNodeID);
+            if (typeof this._currentNodeID === 'string') {
+                WebGMEGlobal.State.registerActiveObject(this._currentNodeID);
+            }
         }
 
         this.updateContainerSize();

--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -620,7 +620,7 @@ define(['jquery',
         while (i--) {
             baseId = baseIdList[i];
             baseNode = client.getNode(baseId);
-            if (!baseNode || baseNode.isValidChildOf(parentId)) {
+            if (!baseNode || !baseNode.isValidChildOf(parentId)) {
                 result = false;
                 break;
             }
@@ -756,7 +756,7 @@ define(['jquery',
             parentNode,
             parentBaseNode;
 
-        if (!node.getBaseId() || node.getMetaTypeId() === node.getId()) {
+        if (!node || !node.getBaseId() || node.getMetaTypeId() === node.getId()) {
             // Root-node and FCO cannot be replaceable, nor can meta-nodes.
             result = false;
         } else {

--- a/src/client/js/Widgets/Crosscut/CrosscutWidget.js
+++ b/src/client/js/Widgets/Crosscut/CrosscutWidget.js
@@ -29,9 +29,10 @@ define([
         params.reorderTabs = true;
         params.lineStyleControls = false;
         params.defaultConnectionRouteManagerType = 'basic2';
+        params.disableAutoRouterOption = true;
 
         DiagramDesignerWidget.call(this, container, params);
-        this._onConnectionRouteManagerChanged('basic2');
+        //this._onConnectionRouteManagerChanged('basic2');
         this.logger.debug('CrosscutWidget ctor');
     };
 

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
@@ -57,34 +57,38 @@ define([
             this.toolbarItems.gridSeparator = toolbar.addSeparator();
 
             /************** ROUTING MANAGER SELECTION **************************/
-            this.toolbarItems.radioButtonGroupRouteManager = toolbar.addRadioButtonGroup(function (data) {
-                self._onConnectionRouteManagerChanged(data.type);
-            });
+            if (!this._disableConnectionRendering) {
+                this.toolbarItems.radioButtonGroupRouteManager = toolbar.addRadioButtonGroup(function (data) {
+                    self._onConnectionRouteManagerChanged(data.type);
+                });
 
 
-            this.toolbarItems.radioButtonGroupRouteManager.addButton({
-                title: 'Basic route manager',
-                icon: btnIconBase.clone().addClass('gme icon-gme_diagonal-arrow'),
-                selected: this._defaultConnectionRouteManagerType === 'basic',
-                data: {type: 'basic'}
-            });
+                this.toolbarItems.radioButtonGroupRouteManager.addButton({
+                    title: 'Basic route manager',
+                    icon: btnIconBase.clone().addClass('gme icon-gme_diagonal-arrow'),
+                    selected: this._defaultConnectionRouteManagerType === 'basic',
+                    data: {type: 'basic'}
+                });
 
-            this.toolbarItems.radioButtonGroupRouteManager.addButton({
-                title: 'Basic+ route manager',
-                icon: btnIconBase.clone().addClass('gme icon-gme_broken-arow'),
-                selected: this._defaultConnectionRouteManagerType === 'basic2',
-                data: {type: 'basic2'}
-            });
+                this.toolbarItems.radioButtonGroupRouteManager.addButton({
+                    title: 'Basic+ route manager',
+                    icon: btnIconBase.clone().addClass('gme icon-gme_broken-arow'),
+                    selected: this._defaultConnectionRouteManagerType === 'basic2',
+                    data: {type: 'basic2'}
+                });
 
-            this.toolbarItems.radioButtonGroupRouteManager.addButton({
-                title: 'AutoRouter',
-                icon: btnIconBase.clone().addClass('gme icon-gme_broken-arrow-with-box'),
-                selected: this._defaultConnectionRouteManagerType === 'basic3',
-                data: {type: 'basic3'}
-            });
+                if (!this._disableAutoRouterOption) {
+                    this.toolbarItems.radioButtonGroupRouteManager.addButton({
+                        title: 'AutoRouter',
+                        icon: btnIconBase.clone().addClass('gme icon-gme_broken-arrow-with-box'),
+                        selected: this._defaultConnectionRouteManagerType === 'basic3',
+                        data: {type: 'basic3'}
+                    });
+                }
+
+                this.toolbarItems.routingManagerSeparator = toolbar.addSeparator();
+            }
             /************** END OF - ROUTING MANAGER SELECTION **************************/
-
-            this.toolbarItems.routingManagerSeparator = toolbar.addSeparator();
 
             this.toolbarItems.radioButtonGroupOperatingMode = toolbar.addRadioButtonGroup(function (data) {
                 self.setOperatingMode(data.mode);
@@ -356,9 +360,9 @@ define([
         this._toolbarInitialized = true;
     };
 
-    DiagramDesignerWidgetToolbar.prototype._displayToolbarItems = function () {
+    DiagramDesignerWidgetToolbar.prototype._displayToolbarItems = function (options) {
         if (this._toolbarInitialized !== true) {
-            this._initializeToolbar();
+            this._initializeToolbar(options);
         } else {
             for (var i in this.toolbarItems) {
                 if (this.toolbarItems.hasOwnProperty(i)) {

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -119,15 +119,18 @@ define([
 
         //if the widget supports search functionality
         this._defaultSearchUI = true;
-        if (params && params.hasOwnProperty('defaultSearchUI')) {
+        if (params.hasOwnProperty('defaultSearchUI')) {
             this._defaultSearchUI = params.defaultSearchUI;
         }
 
         //if the widget needs lineStyleControls
         this._lineStyleControls = true;
-        if (params && params.hasOwnProperty('lineStyleControls')) {
+        if (params.hasOwnProperty('lineStyleControls')) {
             this._lineStyleControls = params.lineStyleControls;
         }
+
+        this._disableConnectionRendering = params.disableConnectionRendering;
+        this._disableAutoRouterOption = params.disableAutoRouterOption;
 
         //by default tabs are not enabled
         this._tabsEnabled = false;

--- a/src/client/js/Widgets/SetEditor/SetEditorWidget.js
+++ b/src/client/js/Widgets/SetEditor/SetEditorWidget.js
@@ -24,6 +24,8 @@ define(['js/DragDrop/DragHelper',
         params.reorderTabs = false;
         params.lineStyleControls = false;
         params.enableConnectionDrawing = false;
+        params.defaultConnectionRouteManagerType = 'basic';
+        params.disableConnectionRendering = true;
 
         DiagramDesignerWidget.call(this, container, params);
 


### PR DESCRIPTION
Fixes a bug introduced by #1217 that disabled adding new members to CrossCuts.

In addition connections are always rendered as boxes in the set-editor.

In CrossCuts - the autorouter option is disabled (until it supports connections to connections).