### PR TITLE
Fixes #892 add better feedback and better handling of invalidly named pointers/sets

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Aspects.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Aspects.js
@@ -75,7 +75,10 @@ define([
         var client = this._control._client,
             objId = this._metaInfo[CONSTANTS.GME_ID],
             node = client.getNode(objId),
-            existingNames = [CONSTANTS.ASPECT_ALL].concat(node.getSetNames());
+            existingNames = [
+                CONSTANTS.ASPECT_ALL,
+                client.CONSTANTS.CORE.OVERLAYS_PROPERTY
+            ].concat(node.getValidSetNames()).concat(node.getOwnValidAspectNames());
 
         this._onNewClick(existingNames, this._skinParts.$aspectsContainer, this._skinParts.$addAspectContainer,
             this._skinParts.$aspectsTitle, this._onNewAspectCreate);

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -1240,46 +1240,71 @@ define(['js/logger',
     };
 
     MetaEditorControl.prototype._createPointerRelationship = function (sourceID, targetID, isSet) {
-        var sourceNode = this._client.getNode(sourceID),
-            targetNode = this._client.getNode(targetID),
+        var client = this._client,
+            sourceNode = client.getNode(sourceID),
+            targetNode = client.getNode(targetID),
+            metaNodes = client.getAllMetaNodes(true),
             pointerMetaDescriptor,
+            existingNames,
             existingPointerNames,
-            notAllowedPointerNames,
-            self = this;
+            notAllowedPointerNames;
+
+        function getExistingNames() {
+            var nodeObj = sourceNode,
+                lastMetaNode,
+                i,
+                instancePaths;
+
+            // Get the meta-node "last" in the inheritance chain
+            do {
+                instancePaths = nodeObj.getInstancePaths();
+
+                lastMetaNode = null;
+                for (i = 0; i < instancePaths.length; i += 1) {
+                    if (metaNodes[instancePaths[i]]) {
+                        lastMetaNode = metaNodes[instancePaths[i]];
+                        break;
+                    }
+                }
+
+                if (lastMetaNode) {
+                    nodeObj = lastMetaNode;
+                }
+            } while (lastMetaNode);
+
+            // TODO: Currently these contain mixins too
+            return {
+                pointers: nodeObj.getValidPointerNames() || [],
+                sets: nodeObj.getValidSetNames() || [],
+                aspects: nodeObj.getValidAspectNames() || []
+            };
+        }
 
         if (sourceNode && targetNode) {
-            notAllowedPointerNames = _.union(sourceNode.getSetNames(), sourceNode.getPointerNames());
+            existingNames = getExistingNames();
+
             if (isSet === true) {
-                //this is a pointer list
-                existingPointerNames = _.difference(sourceNode.getSetNames() || [],
-                    sourceNode.getValidAspectNames());
+                //this is a set
+                existingPointerNames = existingNames.sets;
+                notAllowedPointerNames = _.union(existingNames.pointers, existingNames.aspects);
             } else {
                 //this is a single pointer
-                //get the list of existing pointers and show them in a dialog so the user can choose
-                existingPointerNames = sourceNode.getPointerNames() || [];
-            }
-            notAllowedPointerNames = _.difference(notAllowedPointerNames, existingPointerNames);
-
-            //handle RESERVED pointer names
-            existingPointerNames = _.difference(existingPointerNames, MetaEditorConstants.RESERVED_POINTER_NAMES);
-            notAllowedPointerNames = notAllowedPointerNames.concat(MetaEditorConstants.RESERVED_POINTER_NAMES);
-
-            if (isSet !== true) {
-                // Only pointers cannot have the name member.
-                notAllowedPointerNames.push(CONSTANTS.CORE.MEMBER_RELATION);
+                existingPointerNames = existingNames.pointers;
+                notAllowedPointerNames = _.union(existingNames.sets, existingNames.aspects);
             }
 
+            // Reserved names are handled in the dialog.
             //query pointer name from user
             this.diagramDesigner.selectNewPointerName(existingPointerNames,
                 notAllowedPointerNames,
                 isSet,
                 function (userSelectedPointerName) {
-                    self._client.startTransaction();
-                    pointerMetaDescriptor = self._client.getOwnValidTargetItems(sourceID, userSelectedPointerName);
+                    client.startTransaction();
+                    pointerMetaDescriptor = client.getOwnValidTargetItems(sourceID, userSelectedPointerName);
                     if (!pointerMetaDescriptor) {
                         if (isSet !== true) {
                             //single pointer
-                            self._client.setPointerMeta(sourceID, userSelectedPointerName, {
+                            client.setPointerMeta(sourceID, userSelectedPointerName, {
                                 min: 1,
                                 max: 1,
                                 items: [
@@ -1289,29 +1314,29 @@ define(['js/logger',
                                     }
                                 ]
                             });
-                            self._client.setPointer(sourceID, userSelectedPointerName, null);
+                            client.setPointer(sourceID, userSelectedPointerName, null);
                         } else {
                             //pointer list
-                            self._client.setPointerMeta(sourceID, userSelectedPointerName, {
+                            client.setPointerMeta(sourceID, userSelectedPointerName, {
                                 items: [
                                     {
                                         id: targetID
                                     }
                                 ]
                             });
-                            self._client.createSet(sourceID, userSelectedPointerName);
+                            client.createSet(sourceID, userSelectedPointerName);
                         }
                     } else {
                         if (isSet !== true) {
                             //single pointer
-                            self._client.setPointerMetaTarget(sourceID,
+                            client.setPointerMetaTarget(sourceID,
                                 userSelectedPointerName,
                                 targetID,
                                 -1,
                                 1);
                         } else {
                             //pointer list
-                            self._client.setPointerMetaTarget(sourceID,
+                            client.setPointerMetaTarget(sourceID,
                                 userSelectedPointerName,
                                 targetID,
                                 -1,
@@ -1319,7 +1344,7 @@ define(['js/logger',
                         }
                     }
 
-                    self._client.completeTransaction();
+                    client.completeTransaction();
                 });
         }
     };

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -1243,40 +1243,18 @@ define(['js/logger',
         var client = this._client,
             sourceNode = client.getNode(sourceID),
             targetNode = client.getNode(targetID),
-            metaNodes = client.getAllMetaNodes(true),
             pointerMetaDescriptor,
             existingNames,
             existingPointerNames,
             notAllowedPointerNames;
 
         function getExistingNames() {
-            var nodeObj = sourceNode,
-                lastMetaNode,
-                i,
-                instancePaths;
-
-            // Get the meta-node "last" in the inheritance chain
-            do {
-                instancePaths = nodeObj.getInstancePaths();
-
-                lastMetaNode = null;
-                for (i = 0; i < instancePaths.length; i += 1) {
-                    if (metaNodes[instancePaths[i]]) {
-                        lastMetaNode = metaNodes[instancePaths[i]];
-                        break;
-                    }
-                }
-
-                if (lastMetaNode) {
-                    nodeObj = lastMetaNode;
-                }
-            } while (lastMetaNode);
-
-            // TODO: Currently these contain mixins too
+            // This does not include collision in the derived types,
+            // however that is being checked by the meta-rules checker.
             return {
-                pointers: nodeObj.getValidPointerNames() || [],
-                sets: nodeObj.getValidSetNames() || [],
-                aspects: nodeObj.getValidAspectNames() || []
+                pointers: sourceNode.getValidPointerNames() || [],
+                sets: sourceNode.getValidSetNames() || [],
+                aspects: sourceNode.getValidAspectNames() || []
             };
         }
 
@@ -1290,7 +1268,7 @@ define(['js/logger',
             } else {
                 //this is a single pointer
                 existingPointerNames = existingNames.pointers;
-                notAllowedPointerNames = _.union(existingNames.sets, existingNames.aspects);
+                notAllowedPointerNames = existingNames.sets;
             }
 
             // Reserved names are handled in the dialog.

--- a/src/client/js/Widgets/MetaEditor/MetaEditorPointerNamesDialog.js
+++ b/src/client/js/Widgets/MetaEditor/MetaEditorPointerNamesDialog.js
@@ -83,7 +83,7 @@ define([
             } else if (REGEXP.DOCUMENT_KEY.test(name) === false) {
                 result.hasViolation = true;
                 result.message = 'Name "' + name + '" contains illegal characters, it may not contain "." ' +
-                    'or start with "$".';
+                    'or start with "$" or "_".';
             } else if (!isSet) {
                 if (_endsWith(name, CONSTANTS.CORE.COLLECTION_NAME_SUFFIX)) {
                     result.hasViolation = true;
@@ -102,6 +102,9 @@ define([
                 if (name === 'src' || name === 'dst') {
                     result.hasViolation = true;
                     result.message = 'Name "' + name + '" can only be used for pointer names and not for sets.';
+                } else if (name === CONSTANTS.CORE.OVERLAYS_PROPERTY) {
+                    result.hasViolation = true;
+                    result.message = 'Name "' + name + '" is a reserved key word for sets.';
                 }
             }
 

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorPointerNamesDialog.css
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorPointerNamesDialog.css
@@ -1,3 +1,5 @@
 /**
- * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
+.meta-editor-pointer-names-dialog .modal-footer .message-badge {
+  text-align: left; }

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorPointerNamesDialog.scss
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorPointerNamesDialog.scss
@@ -1,3 +1,11 @@
 /**
- * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
+
+.meta-editor-pointer-names-dialog {
+  .modal-footer {
+    .message-badge {
+      text-align: left;
+    }
+  }
+}

--- a/src/client/js/Widgets/MetaEditor/templates/MetaEditorPointerNamesDialog.html
+++ b/src/client/js/Widgets/MetaEditor/templates/MetaEditorPointerNamesDialog.html
@@ -37,6 +37,7 @@
                         </div>
                     </div>
                 </div>
+                <div class="alert alert-danger message-badge" role="alert"></div>
             </div>
         </div>
     </div>

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -1687,21 +1687,25 @@ define([
             return getNode(nodePath, logger, state, storeNode);
         };
 
-        this.getAllMetaNodes = function () {
+        this.getAllMetaNodes = function (asObject) {
+            var result = asObject ? {} : [];
             if (state && state.core && state.nodes && state.nodes[ROOT_PATH]) {
                 var metaNodes = state.core.getAllMetaNodes(state.nodes[ROOT_PATH].node),
-                    gmeNodes = [],
+                    gmeNode,
                     keys = Object.keys(metaNodes || {}),
                     i;
 
                 for (i = 0; i < keys.length; i += 1) {
-                    gmeNodes.push(self.getNode(storeNode(metaNodes[keys[i]]), logger, state, storeNode));
+                    gmeNode = self.getNode(storeNode(metaNodes[keys[i]]), logger, state, storeNode);
+                    if (asObject) {
+                        result[keys[i]] = gmeNode;
+                    } else {
+                        result.push(gmeNode);
+                    }
                 }
-
-                return gmeNodes;
             }
 
-            return [];
+            return result;
         };
 
         this.checkMetaConsistency = function () {

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -370,7 +370,7 @@ define([
             }
 
             return list;
-        }
+        };
 
         this.overlayInsert = function (node, source, name, target) {
             ASSERT(self.isValidNode(node));

--- a/src/common/core/users/metarules.js
+++ b/src/common/core/users/metarules.js
@@ -478,7 +478,7 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
                         });
                     }
 
-                    if (key === 'base') {
+                    if (key === CONSTANTS.BASE_POINTER || key === CONSTANTS.MEMBER_RELATION) {
                         result.push(getReservedNameError(metaName, path, key, 'a pointer'));
                     }
                 } else {
@@ -504,7 +504,7 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
                         });
                     }
 
-                    if (key === 'ovr') {
+                    if (key === CONSTANTS.OVERLAYS_PROPERTY) {
                         result.push(getReservedNameError(metaName, path, key, 'a set'));
                     }
                 }
@@ -550,7 +550,7 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
                     });
                 }
 
-                if (key === 'ovr') {
+                if (key === CONSTANTS.OVERLAYS_PROPERTY) {
                     result.push(getReservedNameError(metaName, path, key, 'an aspect'));
                 }
 


### PR DESCRIPTION
Now it checks for all meta-definitions to avoid conflicts between set and pointer names.
It also ensures that there are no illegal characters or suffixes. 

With violations it also gives a descriptive message.

