### PR TITLE
Process the min_relid_length of parent of when inherited child modified.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -202,7 +202,7 @@ module.exports = function (config) {
         // to avoid DISCONNECTED messages
         browserDisconnectTimeout: 10000, // default 2000
         browserDisconnectTolerance: 1, // default 0
-        browserNoActivityTimeout: 60000, //default 10000
+        browserNoActivityTimeout: 600000, //default 10000
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -18,6 +18,10 @@ define([], function () {
         PATH_SEP: '/',
         MUTABLE_PROPERTY: '_mutable',
         MINIMAL_RELID_LENGTH_PROPERTY: '_minlenrelid',
+        DOES_NOT_HAVE_RELID_CHILDREN: {
+            ALL_SETS_PROPERTY: true,
+            META_NODE: true
+        },
         INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY: '_hasownrelation',
 
         NULLPTR_NAME: '_null_pointer',

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -19,8 +19,8 @@ define([], function () {
         MUTABLE_PROPERTY: '_mutable',
         MINIMAL_RELID_LENGTH_PROPERTY: '_minlenrelid',
         DOES_NOT_HAVE_RELID_CHILDREN: {
-            ALL_SETS_PROPERTY: true,
-            META_NODE: true
+            _sets: true, // ALL_SETS_PROPERTY
+            _meta: true  // META_NODE
         },
         INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY: '_hasownrelation',
 

--- a/src/common/core/constraintcore.js
+++ b/src/common/core/constraintcore.js
@@ -94,7 +94,7 @@ define(['common/util/assert', 'common/core/constants'], function (ASSERT, CONSTA
             if (constRelId) {
                 constraintNode = innerCore.getChild(constraintsNode, constRelId);
             } else {
-                constraintNode = innerCore.createChild(constraintsNode);
+                constraintNode = innerCore.createChild(constraintsNode, CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH + 1);
             }
 
             constraintObj.priority = constraintObj.priority || CONSTANTS.C_DEF_PRIORITY;

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -398,7 +398,7 @@ define([
             }
         };
 
-        this.createNode = function (parameters, takenRelids) {
+        this.createNode = function (parameters, takenRelids, relidLength) {
             parameters = parameters || {};
             var relid = parameters.relid,
                 parent = parameters.parent;
@@ -416,7 +416,7 @@ define([
                         parent.childrenRelids = null;
                     }
                 } else {
-                    node = self.createChild(parent, takenRelids);
+                    node = self.createChild(parent, takenRelids, relidLength);
                 }
 
                 innerCore.setHashed(node, true);
@@ -463,15 +463,15 @@ define([
             }
         };
 
-        this.createChild = function (parent, takenRelids) {
-            var child = innerCore.createChild(parent, takenRelids);
+        this.createChild = function (parent, takenRelids, relidLength) {
+            var child = innerCore.createChild(parent, takenRelids, relidLength);
 
             parent.childrenRelids = null;
 
             return child;
         };
 
-        this.copyNode = function (node, parent, takenRelids) {
+        this.copyNode = function (node, parent, takenRelids, relidLength) {
             ASSERT(self.isValidNode(node));
             ASSERT(!parent || self.isValidNode(parent));
             var newNode,
@@ -501,7 +501,7 @@ define([
                     return null;
                 }
 
-                newNode = self.createChild(parent, takenRelids);
+                newNode = self.createChild(parent, takenRelids, relidLength);
                 innerCore.setHashed(newNode, true);
                 innerCore.setData(newNode, innerCore.copyData(node));
 
@@ -571,7 +571,7 @@ define([
             return newNode;
         };
 
-        this.copyNodes = function (nodes, parent, takenRelids) {
+        this.copyNodes = function (nodes, parent, takenRelids, relidLength) {
             //copying multiple nodes at once for keeping their internal relations
             var paths = [],
                 i, j, index, names, pointer, newNode,
@@ -598,7 +598,7 @@ define([
 
             //now we use our simple copy
             for (i = 0; i < nodes.length; i++) {
-                newNode = self.copyNode(nodes[i], parent, takenRelids);
+                newNode = self.copyNode(nodes[i], parent, takenRelids, relidLength);
                 copiedNodes.push(newNode);
                 if (takenRelids) {
                     takenRelids[self.getRelid(newNode)] = true;
@@ -616,7 +616,7 @@ define([
             return copiedNodes;
         };
 
-        this.moveNode = function (node, parent, takenRelids) {
+        this.moveNode = function (node, parent, takenRelids, relidLength) {
             ASSERT(self.isValidNode(node) && self.isValidNode(parent));
 
             var ancestor,
@@ -649,7 +649,7 @@ define([
             var oldNode = node;
             if (takenRelids) {
                 if (takenRelids[innerCore.getRelid(oldNode)]) {
-                    node = innerCore.createChild(parent, takenRelids);
+                    node = innerCore.createChild(parent, takenRelids, relidLength);
                 } else {
                     node = innerCore.getChild(parent, innerCore.getRelid(oldNode));
                 }

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -561,16 +561,13 @@ define([
             return child;
         };
 
-        this.createChild = function (node, takenRelids) {
-            var minimumLength;
-
+        this.createChild = function (node, takenRelids, minimumLength) {
             node = self.normalize(node);
 
             if (typeof node.data !== 'object' || node.data === null) {
                 throw new Error('invalid node data');
             }
 
-            minimumLength = this.getProperty(node, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
             return self.getChild(node, RANDOM.generateRelid(takenRelids || node.data, minimumLength));
         };
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -604,13 +604,19 @@ define([
         };
 
         this.setPointer = function (node, name, target) {
+            var parent;
             innerCore.setPointer(node, name, target);
+
             if (isInheritedChild(node)) {
-                this.setProperty(node, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+                self.setProperty(node, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+                parent = self.getParent(node);
+                self.processRelidReservation(parent, self.getRelid(node));
             }
 
             if (isInheritedChild(target)) {
-                this.setProperty(target, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+                self.setProperty(target, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
+                parent = self.getParent(target);
+                self.processRelidReservation(parent, self.getRelid(target));
             }
         };
 
@@ -975,6 +981,35 @@ define([
 
             return relids;
         };
+
+        this.setAttribute = function (node, name, value) {
+            var parent;
+
+            innerCore.setAttribute(node, name, value);
+
+            if (isInheritedChild(node)) {
+                // If the node is an inherited child - data is now stored for it.
+                // And to prevent application of this data after deletion and creation of
+                // new nodes at the base - we process the relid.
+                parent = self.getParent(node);
+                self.processRelidReservation(parent, self.getRelid(node));
+            }
+        };
+
+        this.setRegistry = function (node, name, value) {
+            var parent;
+
+            innerCore.setRegistry(node, name, value);
+
+            if (isInheritedChild(node)) {
+                // If the node is an inherited child - data is now stored for it.
+                // And to prevent application of this data after deletion and creation of
+                // new nodes at the base - we process the relid.
+                parent = self.getParent(node);
+                self.processRelidReservation(parent, self.getRelid(node));
+            }
+        };
+
         //</editor-fold>
 
         //<editor-fold=Added Methods>

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -604,19 +604,19 @@ define([
         };
 
         this.setPointer = function (node, name, target) {
-            var parent;
             innerCore.setPointer(node, name, target);
 
             if (isInheritedChild(node)) {
                 self.setProperty(node, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
-                parent = self.getParent(node);
-                self.processRelidReservation(parent, self.getRelid(node));
+                // #1232
+
+                self.processRelidReservation(self.getParent(node), self.getRelid(node));
             }
 
             if (isInheritedChild(target)) {
                 self.setProperty(target, CONSTANTS.INHERITED_CHILD_HAS_OWN_RELATION_PROPERTY, true);
-                parent = self.getParent(target);
-                self.processRelidReservation(parent, self.getRelid(target));
+                // #1232
+                self.processRelidReservation(self.getParent(target), self.getRelid(target));
             }
         };
 
@@ -983,30 +983,20 @@ define([
         };
 
         this.setAttribute = function (node, name, value) {
-            var parent;
-
             innerCore.setAttribute(node, name, value);
 
+            // #1232
             if (isInheritedChild(node)) {
-                // If the node is an inherited child - data is now stored for it.
-                // And to prevent application of this data after deletion and creation of
-                // new nodes at the base - we process the relid.
-                parent = self.getParent(node);
-                self.processRelidReservation(parent, self.getRelid(node));
+                self.processRelidReservation(self.getParent(node), self.getRelid(node));
             }
         };
 
         this.setRegistry = function (node, name, value) {
-            var parent;
-
             innerCore.setRegistry(node, name, value);
 
+            // #1232
             if (isInheritedChild(node)) {
-                // If the node is an inherited child - data is now stored for it.
-                // And to prevent application of this data after deletion and creation of
-                // new nodes at the base - we process the relid.
-                parent = self.getParent(node);
-                self.processRelidReservation(parent, self.getRelid(node));
+                self.processRelidReservation(self.getParent(node), self.getRelid(node));
             }
         };
 
@@ -1197,7 +1187,10 @@ define([
         };
 
         this.processRelidReservation = function (node, relid) {
-            processNewRelidLength(node, relid.length + 1);
+            if (!CONSTANTS.DOES_NOT_HAVE_RELID_CHILDREN[self.getRelid(node)] && innerCore.isValidRelid(relid)) {
+                // We do not process relids for e.g. _sets and _meta.
+                processNewRelidLength(node, relid.length + 1);
+            }
         };
 
         this.getInstancePaths = function (node) {

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -300,11 +300,12 @@ define(['common/util/assert', 'common/core/constants'], function (ASSERT, CONSTA
 
             if (setMemberRelId === null) {
                 createSetOnDemand(node, setName);
-                setMemberNode = innerCore.createChild(setNode);
+                setMemberNode = innerCore.createChild(setNode, CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH + 1);
             } else if (!self.isFullyOverriddenMember(node, setName, self.getPath(member))) {
                 //it was an inherited member, now we override it
                 // TODO: We pin down the expected behavior here..
-                setMemberNode = innerCore.copyNode(innerCore.getChild(setNode, setMemberRelId), setNode);
+                setMemberNode = innerCore.copyNode(innerCore.getChild(setNode, setMemberRelId),
+                    setNode, CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH + 1);
                 innerCore.deleteNode(innerCore.getChild(setNode, setMemberRelId), true);
             }
 

--- a/src/common/util/jsonPatcher.js
+++ b/src/common/util/jsonPatcher.js
@@ -378,7 +378,7 @@ define([
                     default:
                         throw new Error('Unexpected patch operation ' + nodePatches[i]);
                 }
-            } else if (patchPath !== MIN_RELID_LENGTH_PATH) {
+            } else if (_endsWith(patchPath, MIN_RELID_LENGTH_PATH) === false) {
                 ownChange = true;
             }
         }

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -856,14 +856,28 @@ describe('coretype', function () {
         expect(core.getRelid(protoChild)).to.have.length(4);
     });
 
-    it('should not generate longer relid than allowed even if instance has child with longer relid', function () {
-        var longrelid = 'thisIsWayTooLong',
+    it('should not generate longer relid if instance has child with relid longer than max', function () {
+        var longrelid = 'HasSix',
             proto = core.createNode({parent: root, relid: 'theAncestor'}),
             inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
             child = core.createNode({parent: inst, relid: longrelid}),
             protoChild = core.createNode({parent: proto});
 
         expect(core.getRelid(child)).to.have.length(longrelid.length);
+        expect(core.getRelid(protoChild)).to.have.length(1);
+    });
+
+    it('should not generate longer relid than max if instance has child with relid longer than max', function () {
+        var longrelid = 'five',
+            evenLonger = 'HasSix',
+            proto = core.createNode({parent: root, relid: 'theAncestor'}),
+            inst = core.createNode({parent: root, base: proto, relid: 'theInstance'}),
+            child = core.createNode({parent: inst, relid: longrelid}),
+            child2 = core.createNode({parent: inst, relid: evenLonger}),
+            protoChild = core.createNode({parent: proto});
+
+        expect(core.getRelid(child)).to.have.length(longrelid.length);
+        expect(core.getRelid(child2)).to.have.length(evenLonger.length);
         expect(core.getRelid(protoChild)).to.have.length(CONSTANTS.MAXIMUM_STARTING_RELID_LENGTH);
     });
 

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -702,6 +702,41 @@ describe('coretype', function () {
         }, core.loadChildren(node, '/n'));
     });
 
+    it('new node should have relidLength when createNode with relidLength', function () {
+        var newNode = core.createNode({parent: root}, 7);
+        expect(core.getRelid(newNode)).to.have.length(7);
+    });
+
+    it('new node should have relidLength when createChild with relidLength', function () {
+        var parent = core.createNode({parent: root}),
+            newNode = core.createChild(parent, 7);
+        expect(core.getRelid(newNode)).to.have.length(7);
+    });
+
+    it('new node should have relidLength when copyNode with relidLength', function () {
+        var parent = core.createNode({parent: root}),
+            copy = core.createNode({parent: root}),
+            newNode = core.copyNode(copy, parent, 7);
+
+        expect(core.getRelid(newNode)).to.have.length(7);
+    });
+
+    it('new node should have relidLength when copyNodes with relidLength', function () {
+        var parent = core.createNode({parent: root}),
+            copy = core.createNode({parent: root}),
+            newNode = core.copyNodes([copy], parent, 7)[0];
+
+        expect(core.getRelid(newNode)).to.have.length(7);
+    });
+
+    it('moved node should have relidLength when moveNode with relidLength', function () {
+        var parent = core.createNode({parent: root}),
+            toMove = core.createNode({parent: root}),
+            movedNode = core.moveNode(toMove, parent, 7);
+
+        expect(core.getRelid(movedNode)).to.have.length(7);
+    });
+
     // Relids collision
     it('creating node with explicitly set relid should ASSERT if already exists', function () {
         core.createNode({parent: root, relid: 'taken'});

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -12,7 +12,7 @@ describe('coretype', function () {
         Q = testFixture.Q,
         logger = testFixture.logger.fork('coretype.spec'),
         storage,
-        // Has to be in sync with relidPool in util/random.js
+    // Has to be in sync with relidPool in util/random.js
         RELID_POOL = '0123456789qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM'.split(''),
         expect = testFixture.expect,
         __should = testFixture.should,
@@ -1009,6 +1009,76 @@ describe('coretype', function () {
 
         child = core.createNode({parent: proto});
         expect(core.getRelid(child)).to.have.length(2);
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting an attribute of inherited child', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'});
+
+        core.createNode({parent: proto, relid: 'c'});
+
+        TASYNC.call(function (children) {
+            var newChild;
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.setAttribute(children[0], 'someName', 'someVal');
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        }, core.loadChildren(derived));
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting a registry of inherited child', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'});
+
+        core.createNode({parent: proto, relid: 'c'});
+
+        TASYNC.call(function (children) {
+            var newChild;
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.setRegistry(children[0], 'someName', 'someVal');
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        }, core.loadChildren(derived));
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting pointer OF inherited child', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'}),
+            target = core.createNode({parent: root});
+
+        core.createNode({parent: proto, relid: 'c'});
+
+        TASYNC.call(function (children) {
+            var newChild;
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.setPointer(children[0], 'someName', target);
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        }, core.loadChildren(derived));
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting pointer TO inherited child', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'}),
+            pointer = core.createNode({parent: root});
+
+        core.createNode({parent: proto, relid: 'c'});
+
+        TASYNC.call(function (children) {
+            var newChild;
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.setPointer(pointer, 'someName', children[0]);
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        }, core.loadChildren(derived));
     });
 
     it('should only update MINIMAL_RELID_LENGTH_PROPERTY up to MAXIMUM_STARTING_RELID_LENGTH at setBase', function () {

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -61,6 +61,92 @@ describe('set core', function () {
             .nodeify(done);
     });
 
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when adding inherited child to a set', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'}),
+            setNode = core.createNode({parent: root});
+
+        core.createNode({parent: proto, relid: 'c'});
+        core.createSet(setNode, 'set');
+
+        core.loadChildren(derived, function (err, children) {
+            var newChild;
+            expect(err).to.equal(null);
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.addMember(setNode, 'set', children[0]);
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        });
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when adding set to inherited child', function (done) {
+        var proto = core.createNode({parent: root, relid: 'p'}),
+            derived = core.createNode({parent: root, base: proto, relid: 'd'});
+
+        core.createNode({parent: proto, relid: 'c'});
+
+        core.loadChildren(derived, function (err, children) {
+            var newChild;
+            expect(err).to.equal(null);
+            expect(children.length).to.equal(1);
+            expect(core.getRelid(children[0])).to.equal('c');
+            core.createSet(children[0], 'set');
+            newChild = core.createNode({parent: proto});
+            expect(core.getRelid(newChild).length > 1).to.equal(true);
+            done();
+        });
+    });
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting attribute of inherited member in inherited child',
+        function (done) {
+            var proto = core.createNode({parent: root, relid: 'p'}),
+                derived = core.createNode({parent: root, base: proto, relid: 'd'}),
+                child = core.createNode({parent: proto, relid: 'c'}),
+                member = core.createNode({parent: root});
+
+
+            core.createSet(child, 'set');
+            core.addMember(child, 'set', member);
+
+            core.loadChildren(derived, function (err, children) {
+                var newChild;
+                expect(err).to.equal(null);
+                expect(children.length).to.equal(1);
+                expect(core.getRelid(children[0])).to.equal('c');
+                core.setMemberAttribute(children[0], 'set', core.getPath(member), 'someName', 'someVal');
+                newChild = core.createNode({parent: proto});
+                expect(core.getRelid(newChild).length > 1).to.equal(true);
+                done();
+            });
+        }
+    );
+
+    it('should update MINIMAL_RELID_LENGTH_PROPERTY when setting registry of inherited member in inherited child',
+        function (done) {
+            var proto = core.createNode({parent: root, relid: 'p'}),
+                derived = core.createNode({parent: root, base: proto, relid: 'd'}),
+                child = core.createNode({parent: proto, relid: 'c'}),
+                member = core.createNode({parent: root});
+
+
+            core.createSet(child, 'set');
+            core.addMember(child, 'set', member);
+
+            core.loadChildren(derived, function (err, children) {
+                var newChild;
+                expect(err).to.equal(null);
+                expect(children.length).to.equal(1);
+                expect(core.getRelid(children[0])).to.equal('c');
+                core.setMemberRegistry(children[0], 'set', core.getPath(member), 'someName', 'someVal');
+                newChild = core.createNode({parent: proto});
+                expect(core.getRelid(newChild).length > 1).to.equal(true);
+                done();
+            });
+        }
+    );
+
     it('set members should be inherited as well', function () {
         var setType = core.createNode({parent: root}),
             setInstance = core.createNode({parent: root, base: setType}),


### PR DESCRIPTION
The potential issue here was that if we have a node `P` with a child `C` and an instance `P'` with the inherited child `C'`.
The following could lead to corrupt models:
1) we set an attribute of `C'`.
2) we delete `C`.
3) without reloading `C` create a new child that gets the same relid as `C` (and `C'`).
4) Now if we load `C'` it would have the attribute set at 1).

This applies to setting pointers, registries and adding sets, set-members and set-memberAttributes/Registries to the inherited child.

This PR also gets rid of generation of short relids for children (member entries) inside sets. These are set to have length 6 (MAXIMUM_STARTING_RELID_LENGTH + 1). Relid collisions are still checked among own entries and inherited ones. However since the relid is greater than MAXIMUM_STARTING_RELID_LENGTH, the propagation of MINIMAL_RELID_LENGTH_PROPERTY is not made. (This is important because otherwise the FCO would have this set for every single set defined in the model.)