### PR TITLE
Get rid of undefined before calculating hashes.

### DIFF
--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -163,6 +163,7 @@ define([
 
         function __saveData(data, root, path) {
             ASSERT(__isMutableData(data));
+            var cleanData;
 
             var done = __getEmptyData(),
                 keys,
@@ -196,22 +197,24 @@ define([
 
                 if (hash === '') {
                     //TODO: This is a temporary fix. We should modify CANON.
-                    hash = '#' + GENKEY(JSON.parse(JSON.stringify(data)), gmeConfig);
+                    cleanData = JSON.parse(JSON.stringify(data));
+                    hash = '#' + GENKEY(cleanData, gmeConfig);
                     data[ID_NAME] = hash;
+                    cleanData[ID_NAME] = hash;
 
-                    done = data;
+                    done = cleanData;
 
-                    storage.insertObject(data, stackedObjects);
+                    storage.insertObject(cleanData, stackedObjects);
                     stackedObjects[hash] = {
                         newHash: hash,
-                        newData: data,
+                        newData: cleanData,
                         oldHash: root.initial[path] && root.initial[path].hash,
                         oldData: root.initial[path] && root.initial[path].data
                     };
 
                     root.initial[path] = {
                         hash: hash,
-                        data: data
+                        data: cleanData
                     };
                     //stackedObjects[hash] = data;
                 }

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -195,7 +195,8 @@ define([
                 ASSERT(hash === '' || hash === undefined);
 
                 if (hash === '') {
-                    hash = '#' + GENKEY(data, gmeConfig);
+                    //TODO: This is a temporary fix. We should modify CANON.
+                    hash = '#' + GENKEY(JSON.parse(JSON.stringify(data)), gmeConfig);
                     data[ID_NAME] = hash;
 
                     done = data;

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -4341,6 +4341,23 @@ describe('GME client', function () {
             });
         });
 
+        it('should setAttributeMeta with undefined and still persist correctly node', function (done) {
+            var branchStatusHandler = function (status/*, commitQueue, updateQueue*/) {
+                if (status === client.CONSTANTS.BRANCH_STATUS.SYNC) {
+                    done();
+                } else if (status === client.CONSTANTS.BRANCH_STATUS.AHEAD_SYNC) {
+                    //locally updating..
+                } else {
+                    done(new Error(status));
+                }
+            };
+            prepareBranchForTest('setMeta', branchStatusHandler, function (err) {
+                expect(err).to.equal(null);
+                var attrSchema = {type: 'string', min: undefined, max: undefined, regexp: undefined};
+                client.setAttributeMeta('/1730437907', 'newAttribute', attrSchema);
+            });
+        });
+
         it.skip('should return the \'children\' portion of the meta rules of the node', function () {
             // getChildrenMeta
 


### PR DESCRIPTION
When calculating the hash for the objects the entries with values set as undefined are part of the computation. However when the data is sent to the server - all such properties are stripped off. 

This manifested itself when setting the attributeMeta and passing in undefined for min, max or regex.

This fix strips away all such undefined value before calculating the data.