### PR TITLE
Fixes #1241 Importing Models fails due to reverse relations stored in reverse-overlay.

### DIFF
--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -422,26 +422,13 @@ define([
 
             function addRelation(parent, from, to, name) {
                 var commonAncestor = getAncestor(parent, from, to),
-                    overlay,
-                    collectionName = name + CONSTANTS.COLLECTION_NAME_SUFFIX,
-                    relFrom, relTo,
-                    newEntry;
+                    relFrom, relTo;
 
                 if (commonAncestor) {
-                    overlay = self.getChild(commonAncestor, CONSTANTS.OVERLAYS_PROPERTY);
                     relFrom = from.substr(self.getPath(commonAncestor).length);
                     relTo = to.substr(self.getPath(commonAncestor).length);
 
-                    // First we set the forward direction
-                    newEntry = JSON.parse(JSON.stringify(self.getProperty(overlay, relFrom) || {}));
-                    newEntry[name] = relTo;
-                    self.setProperty(overlay, relFrom, newEntry);
-
-                    // Then the backward direction
-                    newEntry = JSON.parse(JSON.stringify(self.getProperty(overlay, relTo) || {}));
-                    newEntry[collectionName] = newEntry[collectionName] || [];
-                    newEntry[collectionName].push(relFrom);
-                    self.setProperty(overlay, relTo, newEntry);
+                    self.overlayInsert(commonAncestor, relFrom, name, relTo);
                 } else {
                     logger.error('unable to add relation: ' + name + '(' + from + '->' + to + ')');
                 }

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -1226,7 +1226,10 @@ describe('Library core ', function () {
 
     it('should import if closure base matches only by originGuid', function (done) {
         var closure,
-            paths = [];
+            paths = [],
+            names,
+            i;
+
         Q.all([
             shareContext.core.loadByPath(shareContext.rootNode, '/E'),
             shareContext.core.loadByPath(shareContext.rootNode, '/Q'),
@@ -1262,6 +1265,13 @@ describe('Library core ', function () {
                 expect(shareContext.core.getChildrenRelids(newNodes[1])).to.have.members([
                     'P', 'T', 'X', 'W', 'g', 'C', 'M', 'm'
                 ]);
+
+                //checking the relations, they all should be valid
+                var names = shareContext.core.getPointerNames(newNodes[0])
+                for (i = 0; i < names.length; i += 1) {
+                    expect(shareContext.core.getPointerPath(newNodes[0], names[i])).not.to.eql(null);
+                    expect(shareContext.core.getPointerPath(newNodes[0], names[i])).not.to.eql(undefined);
+                }
             })
             .nodeify(done);
     });
@@ -1311,7 +1321,7 @@ describe('Library core ', function () {
                 shareContext.core.addMember(shareContext.rootNode, 'MetaAspectSet', exampleMachine);
                 return shareContext.core.setGuid(exampleMachine, '5f55234d-5975-19c3-063e-318b0fc93a17');
             })
-            .then(function(){
+            .then(function () {
                 shareContext.core.persist(shareContext.rootNode);
 
                 return shareContext.core.loadRoot(shareContext.core.getHash(shareContext.rootNode));


### PR DESCRIPTION
With the removal of the inverse overlays, every low-level manipulation should be done with the provided overlay functions.
Now the model import works with this update