### PR TITLE
Provide entrypoint for checking consistency of meta-model.

### DIFF
--- a/config/componentsGenericUIDefaults.json
+++ b/config/componentsGenericUIDefaults.json
@@ -58,6 +58,9 @@
   "GenericUIDiagramDesignerWidget": {
     "zoomValues": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.4, 1.6, 1.8, 2.0, 2.5, 3.0, 3.5, 4.0]
   },
+  "GenericUIMetaEditorControl": {
+    "autoCheckMetaConsistency": true
+  },
   "GenericUIGraphVizWidget": {
     "zoomValues": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.4, 1.6, 1.8, 2.0, 2.5, 3.0, 3.5, 4.0]
   },

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/AspectDetailsDialog.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/AspectDetailsDialog.js
@@ -42,21 +42,17 @@ define([
 
     AspectDetailsDialog.prototype._initDialog = function (aspectDesc, aspectNames, saveCallBack, deleteCallBack) {
         var self = this,
-            closeSave,
-            closeDelete,
-            isValidAspectName,
             aDesc = {},
             i,
             typeEl,
             typeInfo,
             displayName,
-            chb,
-            checkSelected;
+            chb;
 
         _.extend(aDesc, ASPECT_DESC_BASE);
         _.extend(aDesc, aspectDesc);
 
-        closeSave = function () {
+        function closeSave() {
             var saveDesc = {},
                 checked = typesContainer.find('input[type=checkbox]:checked');
 
@@ -75,23 +71,23 @@ define([
             if (saveCallBack) {
                 saveCallBack.call(self, saveDesc);
             }
-        };
+        }
 
-        closeDelete = function () {
+        function closeDelete() {
             self._dialog.modal('hide');
 
             if (deleteCallBack) {
                 deleteCallBack.call(self);
             }
-        };
+        }
 
-        isValidAspectName = function (name) {
+        function isValidAspectName(name) {
             return !(name === '' || aspectNames.indexOf(name) !== -1 ||
             name.toLowerCase() === CONSTANTS.ASPECT_ALL.toLowerCase() ||
             REGEXP.DOCUMENT_KEY.test(name) === false);
-        };
+        }
 
-        checkSelected = function () {
+        function checkSelected() {
             var checked = typesContainer.find('input[type=checkbox]:checked');
 
             if (checked.length > 0 && isValidAspectName(self._inputName.val())) {
@@ -99,7 +95,7 @@ define([
             } else {
                 self._btnSave.disable(true);
             }
-        };
+        }
 
         this._dialog = $(aspectDetailsDialogTemplate);
 
@@ -192,12 +188,32 @@ define([
 
             if (aDesc.items.indexOf(typeInfo.id) !== -1) {
                 chb.prop('checked', true);
+                aDesc.items.splice(aDesc.items.indexOf(typeInfo.id), 1);
             }
 
             typesContainer.append(typeEl);
         }
 
+        //Checked ones without containment definition
+        for (i = 0; i < aDesc.items.length; i += 1) {
+            typeEl = TYPE_EL_BASE.clone();
+            typeEl.append('[' + aDesc.items[i] + '] - cannot be contained! Uncheck to clean up..');
+
+            chb = typeEl.find('input[type=checkbox]');
+            chb.data(DATA_TYPE_ID, typeInfo.id);
+            typeEl.addClass('invalid-aspect-member-label');
+            chb.addClass('invalid-aspect-member-cb');
+            chb.prop('checked', true);
+
+            typesContainer.append(typeEl);
+        }
+
         this._pTypes.on('change', 'input[type=checkbox]', function () {
+            var cb = $(this);
+            if (cb.hasClass('invalid-aspect-member-cb')) {
+                cb.prop('disabled', true);
+            }
+
             checkSelected();
         });
 

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/AspectDetailsDialog.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/AspectDetailsDialog.js
@@ -200,7 +200,7 @@ define([
             typeEl.append('[' + aDesc.items[i] + '] - cannot be contained! Uncheck to clean up..');
 
             chb = typeEl.find('input[type=checkbox]');
-            chb.data(DATA_TYPE_ID, typeInfo.id);
+            chb.data(DATA_TYPE_ID, aDesc.items[i]);
             typeEl.addClass('invalid-aspect-member-label');
             chb.addClass('invalid-aspect-member-cb');
             chb.prop('checked', true);

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/AspectDetailsDialog.css
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/AspectDetailsDialog.css
@@ -3,3 +3,7 @@
  */
 .aspect-details-dialog .modal-body {
   max-height: 500px; }
+  .aspect-details-dialog .modal-body label.checkbox.invalid-aspect-member-label {
+    color: red; }
+  .aspect-details-dialog .modal-body label.checkbox input {
+    margin-top: 2px; }

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/AspectDetailsDialog.scss
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/AspectDetailsDialog.scss
@@ -5,5 +5,13 @@
 .aspect-details-dialog {
   .modal-body {
     max-height: 500px;
+    label.checkbox {
+      &.invalid-aspect-member-label {
+        color: red;
+      }
+      input {
+        margin-top: 2px;
+      }
+    }
   }
 }

--- a/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
+++ b/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
@@ -58,7 +58,7 @@ define(['js/util',
         this._dialog.modal('show');
     };
 
-    ConstraintCheckResultsDialog.prototype._initDialog = function (pluginResults) {
+    ConstraintCheckResultsDialog.prototype._initDialog = function (results) {
         var dialog = this._dialog,
             client = this._client,
             self = this,
@@ -80,8 +80,8 @@ define(['js/util',
             j,
             k;
 
-        for (i = 0; i < pluginResults.length; i += 1) {
-            result = pluginResults[i];
+        for (i = 0; i < results.length; i += 1) {
+            result = results[i];
 
             resultEntry = PLUGIN_RESULT_ENTRY_BASE.clone();
 
@@ -173,7 +173,7 @@ define(['js/util',
 
         dialog.find('.btn-clear').on('click', function () {
             body.empty();
-            pluginResults.splice(0, pluginResults.length);
+            results.splice(0, results.length);
         });
 
         dialog.on('click', '.btn-details', function (event) {
@@ -199,6 +199,8 @@ define(['js/util',
                         }
                     });
 
+                    client.removeUI(territoryId);
+
                     if (nodeLoaded) {
                         WebGMEGlobal.State.registerActiveObject(nodeId);
                         WebGMEGlobal.State.registerActiveSelection([]);
@@ -206,8 +208,6 @@ define(['js/util',
                     } else {
                         self.logger.error('Could not load the linked node at path', nodeId);
                     }
-
-                    client.removeUI(territoryId);
                 });
 
             patterns[nodeId] = {children: 0};

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -228,6 +228,10 @@ define(['js/logger',
             self._onAlignSelection(selectedIds, type);
         };
 
+        this.diagramDesigner.onInconsistencyLinkClicked = function (gmeId) {
+            return self._onInconsistencyLinkClicked(gmeId);
+        };
+
         this.logger.debug('attachDesignerCanvasEventHandlers finished');
     };
 
@@ -1028,6 +1032,17 @@ define(['js/logger',
         if (params.coordinates) {
             this._alignMenu.alignSetSelection(params, selectedIds, type);
         }
+    };
+
+    MetaEditorControlDiagramDesignerWidgetEventHandlers.prototype._onInconsistencyLinkClicked = function (gmeId) {
+        var componentId = this._GMEID2ComponentID[gmeId],
+            result = false;
+        if (componentId) {
+            this.diagramDesigner.select([componentId]);
+            result = true;
+        }
+
+        return result;
     };
 
     return MetaEditorControlDiagramDesignerWidgetEventHandlers;

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -233,6 +233,8 @@ define(['js/logger',
             aspectNode = this._client.getNode(aspectNodeID),
             metaAspectSetMembers = aspectNode.getMemberIds(MetaEditorConstants.META_ASPECT_SET_NAME),
             territoryChanged = false,
+            metaInconsistencies,
+            i,
             len,
             diff,
             objDesc,
@@ -303,6 +305,12 @@ define(['js/logger',
         this._selectedMetaAspectSheetMembers = selectedSheetMembers.slice(0);
 
         this._processMetaDocItems();
+
+        metaInconsistencies = this._client.checkMetaConsistency();
+
+        for (i = 0; i < metaInconsistencies.length; i += 1) {
+            this._client.dispatchEvent(this._client.CONSTANTS.NOTIFICATION, metaInconsistencies[i]);
+        }
 
         //there was change in the territory
         if (territoryChanged === true) {

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -8,6 +8,7 @@ define(['js/logger',
     'js/util',
     'js/Constants',
     'js/Utils/GMEConcepts',
+    'js/Utils/ComponentSettings',
     'js/NodePropertyNames',
     'js/RegistryKeys',
     'js/Widgets/DiagramDesigner/DiagramDesignerWidget.Constants',
@@ -21,6 +22,7 @@ define(['js/logger',
              util,
              CONSTANTS,
              GMEConcepts,
+             ComponentSettings,
              nodePropertyNames,
              REGISTRY_KEYS,
              DiagramDesignerWidgetConstants,
@@ -46,6 +48,8 @@ define(['js/logger',
                 WebGMEGlobal.gmeConfig.client.log);
 
         this._client = options.client;
+        this._config = MetaEditorControl.getDefaultConfig();
+        ComponentSettings.resolveWithWebGMEGlobal(this._config, MetaEditorControl.getComponentId());
 
         //initialize core collections and variables
         this.diagramDesigner = options.widget;
@@ -306,7 +310,7 @@ define(['js/logger',
 
         this._processMetaDocItems();
 
-        metaInconsistencies = this._client.checkMetaConsistency();
+        metaInconsistencies = this._config.autoCheckMetaConsistency ? this._client.checkMetaConsistency() : [];
 
         for (i = 0; i < metaInconsistencies.length; i += 1) {
             this._client.dispatchEvent(this._client.CONSTANTS.NOTIFICATION, metaInconsistencies[i]);
@@ -1819,6 +1823,15 @@ define(['js/logger',
             }
         }));
 
+        this._toolbarItems.push(toolBar.addButton({
+            icon: 'fa fa-check-circle-o',
+            title: 'Check consistency of Meta',
+            clickFn: function () {
+                var results = self._client.checkMetaConsistency();
+                self.diagramDesigner.showMetaConsistencyResults(results);
+            }
+        }));
+
         /************** END OF - CREATE META RELATION CONNECTION TYPES *****************/
 
         /************** PRINT NODE DATA *****************/
@@ -2090,6 +2103,16 @@ define(['js/logger',
 
     MetaEditorControl.prototype.setReadOnly = function (isReadOnly) {
         this._radioButtonGroupMetaRelationType.enabled(!isReadOnly);
+    };
+
+    MetaEditorControl.getDefaultConfig = function () {
+        return {
+            autoCheckMetaConsistency: true
+        };
+    };
+
+    MetaEditorControl.getComponentId = function () {
+        return 'GenericUIMetaEditorControl';
     };
 
     //attach MetaEditorControl - DiagramDesigner event handler functions

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -1829,6 +1829,12 @@ define(['js/logger',
             clickFn: function () {
                 var results = self._client.checkMetaConsistency();
                 self.diagramDesigner.showMetaConsistencyResults(results);
+                if (results.length === 0) {
+                    self._client.dispatchEvent(self._client.CONSTANTS.NOTIFICATION, {
+                        severity: 'success',
+                        message: 'No inconsistencies found in meta-model.'
+                    });
+                }
             }
         }));
 

--- a/src/client/js/Widgets/MetaEditor/MetaEditorWidget.js
+++ b/src/client/js/Widgets/MetaEditor/MetaEditorWidget.js
@@ -94,7 +94,8 @@ define([
     };
 
     MetaEditorWidget.prototype.showMetaConsistencyResults = function (results) {
-        var hadInconsistencies = false,
+        var self = this,
+            hadInconsistencies = false,
             resEl,
             dl,
             i,j;
@@ -108,6 +109,9 @@ define([
 
             return 0;
         });
+
+        this.$metaConsistencyResults.find('dd.path-link').off('click');
+        this.$metaConsistencyResults.find('i.close-result').off('click');
 
         this.$metaConsistencyResults.empty();
 
@@ -131,12 +135,15 @@ define([
             dl.append($('<dd>', {text: results[i].hint}));
 
             dl.append($('<dt>', {text: 'Node path'}));
-            dl.append($('<dd>', {text: results[i].path}));
+            dl.append($('<dd>', {text: results[i].path, class: 'path-link'}).data('gme-id', results[i].path));
 
             if (results[i].relatedPaths.length > 0) {
                 dl.append($('<dt>', {text: 'Related paths'}));
                 for (j = 0; j < results[i].relatedPaths.length; j += 1) {
-                    dl.append($('<dd>', {text: results[i].relatedPaths[j]}));
+                    dl.append($('<dd>', {
+                        text: results[i].relatedPaths[j],
+                        class: 'path-link'
+                    }).data('gme-id', results[i].relatedPaths[j]));
                 }
             }
 
@@ -145,15 +152,29 @@ define([
         }
 
         if (hadInconsistencies === true) {
+            this.$metaConsistencyResults.find('dd.path-link').on('click', function () {
+                var path = $(this).data('gme-id');
+                self.onInconsistencyLinkClicked(path);
+            });
+
             this.$metaConsistencyResults.prepend($('<h3>', {
-                text: 'Meta-model has inconsistencies',
+                text: 'Meta-model Inconsistencies',
                 class: 'meta-inconsistency-header'
-            }));
+            }).append($('<i/>', {
+                class: 'fa fa-check-circle-o close-result pull-left',
+                title: 'Close result view'
+            }).on('click', function () {
+                self.showMetaConsistencyResults([]);
+            })));
             this.$metaConsistencyResults.append($('<div>', {class: 'meta-inconsistency-divider'}));
             this.$el.parent().addClass('show-meta-consistency-results');
         } else {
             this.$el.parent().removeClass('show-meta-consistency-results');
         }
+    };
+
+    MetaEditorWidget.prototype.onInconsistencyLinkClicked = function (gmeId) {
+        this.logger.warn('MetaEditorWidget.onInconsistencyLinkClicked not overwritten in controller, gmeId:', gmeId);
     };
 
     MetaEditorWidget.prototype.addFilterItem = function (text, value, iconEl) {

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
@@ -9,10 +9,14 @@
     width: 50%; }
   .meta-editor-widget.show-meta-consistency-results .meta-consistency-results {
     width: 50%;
+    overflow-y: scroll;
     margin-top: 30px;
     border-left: 1px gray solid; }
     .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-header {
       margin-left: 8px; }
+      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-header i {
+        margin-left: 10px;
+        cursor: pointer; }
     .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-divider {
       border-top: 3px lightgray solid;
       margin: 20px 20px 20px 20px; }
@@ -23,6 +27,11 @@
         width: 100px; }
       .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd {
         margin-left: 120px; }
+        .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd.path-link {
+          cursor: pointer;
+          color: blue; }
+          .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd.path-link:hover {
+            color: orange; }
 
 div.filterPanel {
   position: absolute;

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
@@ -3,6 +3,26 @@
  */
 .meta-editor-widget.w-tabs .diagram-designer-zoom-container {
   top: 45px; }
+.meta-editor-widget.show-meta-consistency-results {
+  display: inline-flex; }
+  .meta-editor-widget.show-meta-consistency-results .panel-body {
+    width: 50%; }
+  .meta-editor-widget.show-meta-consistency-results .meta-consistency-results {
+    width: 50%;
+    margin-top: 30px;
+    border-left: 1px gray solid; }
+    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-header {
+      margin-left: 8px; }
+    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-divider {
+      border-top: 3px lightgray solid;
+      margin: 20px 20px 20px 20px; }
+    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency {
+      margin-left: 10px;
+      margin-right: 10px; }
+      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dt {
+        width: 100px; }
+      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd {
+        margin-left: 120px; }
 
 div.filterPanel {
   position: absolute;

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
@@ -25,10 +25,15 @@ $filterPanel-header-min-width: 100px;
 
     .meta-consistency-results {
       width: 50%;
+      overflow-y: scroll;
       margin-top: 30px;
       border-left: 1px gray solid;
       .meta-inconsistency-header {
         margin-left: 8px;
+        i {
+          margin-left: 10px;
+          cursor: pointer;
+        }
       }
       .meta-inconsistency-divider {
         border-top: 3px lightgray solid;
@@ -42,6 +47,13 @@ $filterPanel-header-min-width: 100px;
         }
         dd {
           margin-left: 120px;
+          &.path-link {
+            cursor: pointer;
+            color: blue;
+            &:hover {
+              color: orange;
+            }
+          }
         }
       }
     }

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
@@ -10,10 +10,42 @@ $filterPanel-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 $filterPanel-header-min-width: 100px;
 
 
-.meta-editor-widget.w-tabs {
+.meta-editor-widget {
+  &.w-tabs {
     .diagram-designer-zoom-container {
       top: 45px;
     }
+  }
+
+  &.show-meta-consistency-results {
+    display: inline-flex;
+    .panel-body {
+      width: 50%;
+    }
+
+    .meta-consistency-results {
+      width: 50%;
+      margin-top: 30px;
+      border-left: 1px gray solid;
+      .meta-inconsistency-header {
+        margin-left: 8px;
+      }
+      .meta-inconsistency-divider {
+        border-top: 3px lightgray solid;
+        margin: 20px 20px 20px 20px;
+      }
+      .meta-inconsistency {
+        margin-left: 10px;
+        margin-right: 10px;
+        dt {
+          width: 100px;
+        }
+        dd {
+          margin-left: 120px;
+        }
+      }
+    }
+  }
 }
 
 div.filterPanel {

--- a/src/client/js/Widgets/Notification/styles/NotificationWidget.css
+++ b/src/client/js/Widgets/Notification/styles/NotificationWidget.css
@@ -16,6 +16,10 @@
   background-color: #ffffcc; }
   .notification-widget a.notification-drop-down-menu-item.notification-drop-down-menu-item-warn:hover {
     background-color: #ffff99; }
+.notification-widget a.notification-drop-down-menu-item.notification-drop-down-menu-item-warning {
+  background-color: #ffffcc; }
+  .notification-widget a.notification-drop-down-menu-item.notification-drop-down-menu-item-warning:hover {
+    background-color: #ffff99; }
 .notification-widget a.notification-drop-down-menu-item.notification-drop-down-menu-item-error {
   background-color: #ffcccc; }
   .notification-widget a.notification-drop-down-menu-item.notification-drop-down-menu-item-error:hover {

--- a/src/client/js/Widgets/Notification/styles/NotificationWidget.scss
+++ b/src/client/js/Widgets/Notification/styles/NotificationWidget.scss
@@ -28,6 +28,12 @@
         background-color: #ffff99;
       }
     }
+    &.notification-drop-down-menu-item-warning {
+      background-color: #ffffcc;
+      &:hover {
+        background-color: #ffff99;
+      }
+    }
     &.notification-drop-down-menu-item-error {
       background-color: #ffcccc;
       &:hover {

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -2100,6 +2100,11 @@ define([
 
         this.gmeConfig = gmeConfig;
 
+        this.getUserId = function () {
+            throw new Error('Deprecated! Username is not stored in a cookie anymore. If available, use ' +
+                'WebGMEGlobal.userInfo, if not the user info is available at GET /api/user');
+        };
+
         window.addEventListener('error', function (evt) {
             state.exception = {};
             if (evt.error) {

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -14,6 +14,7 @@ define([
     'common/core/tasync',
     'common/util/guid',
     'common/util/url',
+    'common/core/users/metarules',
     'js/client/gmeNodeGetter',
     'js/client/gmeNodeSetter',
     'js/client/libraries',
@@ -30,6 +31,7 @@ define([
              TASYNC,
              GUID,
              URL,
+             metaRules,
              getNode,
              getNodeSetters,
              getLibraryFunctions,
@@ -490,6 +492,8 @@ define([
             //it is safe now to move the loadNodes into nodes,
             // refresh the metaNodes and generate events - all in a synchronous manner!!!
             var modifiedPaths,
+                metaInconsistencies,
+                key,
                 i;
 
             //console.time('switchStates');
@@ -511,12 +515,13 @@ define([
             state.commitHash = state.loading.commitHash;
             state.loading.commitHash = null;
 
-            checkMetaNameCollision(state.core, state.nodes[ROOT_PATH].node);
-            checkMixinErrors(state.core, state.nodes[ROOT_PATH].node);
+            //checkMetaNameCollision(state.core, state.nodes[ROOT_PATH].node);
+            //checkMixinErrors(state.core, state.nodes[ROOT_PATH].node);
+            // These are checked by the meta-editor..
 
-            for (i in state.users) {
-                if (state.users.hasOwnProperty(i)) {
-                    userEvents(i, modifiedPaths);
+            for (key in state.users) {
+                if (state.users.hasOwnProperty(key)) {
+                    userEvents(key, modifiedPaths);
                 }
             }
 
@@ -1699,6 +1704,18 @@ define([
             return [];
         };
 
+        this.checkMetaConsistency = function () {
+            var result;
+
+            if (state && state.core && state.nodes && state.nodes[ROOT_PATH]) {
+                result = metaRules.checkMetaConsistency(state.core, state.nodes[ROOT_PATH].node);
+            } else {
+                result = [];
+            }
+
+            return result;
+        };
+
         this.startTransaction = function (msg) {
             if (state.inTransaction) {
                 logger.error('Already in transaction, will proceed though..');
@@ -1708,7 +1725,7 @@ define([
                 msg = msg || '[';
                 saveRoot(msg);
             } else {
-                logger.error('Can not start transaction with no core avaliable.');
+                logger.error('Can not start transaction with no core available.');
             }
         };
 

--- a/src/common/core/metacore.js
+++ b/src/common/core/metacore.js
@@ -531,8 +531,8 @@ define([
                     pointer = {};
 
                     pointer.items = self.getOwnMemberPaths(tempNode, CONSTANTS.SET_ITEMS);
-                    pointer.min = self.getAttribute(tempNode, CONSTANTS.SET_ITEMS_MIN);
-                    pointer.max = self.getAttribute(tempNode, CONSTANTS.SET_ITEMS_MAX);
+                    pointer.min = self.getOwnAttribute(tempNode, CONSTANTS.SET_ITEMS_MIN);
+                    pointer.max = self.getOwnAttribute(tempNode, CONSTANTS.SET_ITEMS_MAX);
                     pointer.minItems = [];
                     pointer.maxItems = [];
 

--- a/src/common/core/users/constraintchecker.js
+++ b/src/common/core/users/constraintchecker.js
@@ -81,7 +81,7 @@ define(['common/core/users/metarules', 'q'], function (metaRules, Q) {
             };
 
         if (self.type === CONSTRAINT_TYPES.META) {
-            promises.push(metaRules(self.core, node));
+            promises.push(metaRules.checkNode(self.core, node));
             customNames = [];
         } else if (self.type === CONSTRAINT_TYPES.CUSTOM) {
             customNames = self.core.getConstraintNames(node);
@@ -89,7 +89,7 @@ define(['common/core/users/metarules', 'q'], function (metaRules, Q) {
         } else if (self.type === CONSTRAINT_TYPES.BOTH) {
             customNames = self.core.getConstraintNames(node);
             promises = customNames.map(checkCustom);
-            promises.push(metaRules(self.core, node));
+            promises.push(metaRules.checkNode(self.core, node));
         } else {
             deferred.reject(new Error('Unknown CONSTRAINT_TYPE: ' + self.type));
         }

--- a/src/common/core/users/metarules.js
+++ b/src/common/core/users/metarules.js
@@ -346,6 +346,7 @@ define(['q'], function (Q) {
             metaName,
             setNames,
             pointerNames,
+            childPaths,
             ownMetaJson;
 
         for (path in metaNodes) {
@@ -354,6 +355,7 @@ define(['q'], function (Q) {
             ownMetaJson = core.getOwnJsonMeta(metaNode);
             setNames = core.getValidSetNames(metaNode);
             pointerNames = core.getPointerNames(metaNode);
+            childPaths = core.getValidChildrenPaths(metaNode);
 
             //Patch the ownMetaJson
             ownMetaJson.attributes = ownMetaJson.attributes || {};
@@ -365,7 +367,7 @@ define(['q'], function (Q) {
             if (names[metaName]) {
                 result.push({
                     severity: 'error',
-                    message: 'Duplicate name on META level: \'' + metaName + '\'',
+                    message: 'Duplicate name on META level [' + metaName + ']',
                     hint: 'Rename one of the objects',
                     path: path
                 });
@@ -438,16 +440,15 @@ define(['q'], function (Q) {
                 for (i = 0; i < ownMetaJson.aspects[key].length; i += 1) {
                     if (!metaNodes[ownMetaJson.aspects[key][i]]) {
                         result.push({
-                            severity: 'error',
+                            severity: 'warning',
                             message: metaName + ' defines an aspect [' + key + '] where a member is not part of' +
                             ' the meta.',
                             hint: 'Remove the item from the aspect.',
                             path: path
                         });
-                    } else if (!(ownMetaJson.children.items &&
-                        ownMetaJson.children.items.indexOf(ownMetaJson.aspects[key][i]))) {
+                    } else if (childPaths.indexOf(ownMetaJson.aspects[key][i]) === -1) {
                         result.push({
-                            severity: 'error',
+                            severity: 'warning',
                             message: metaName + ' defines an aspect [' + key + '] where a member does not have a ' +
                             'containment definition.',
                             hint: 'Remove the item from the aspect.',

--- a/src/common/core/users/metarules.js
+++ b/src/common/core/users/metarules.js
@@ -383,7 +383,7 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
             if (typeof names[metaName] === 'string') {
                 result.push({
                     severity: 'error',
-                    message: 'Duplicate name on META level [' + metaName + ']',
+                    message: 'Duplicate name among meta-nodes [' + metaName + ']',
                     description: 'Non-unique meta names makes it hard to reason about the meta-model',
                     hint: 'Rename one of the objects',
                     path: path,
@@ -427,8 +427,8 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
                     if (!metaNodes[ownMetaJson.pointers[key].items[i]]) {
                         result.push({
                             severity: 'error',
-                            message: metaName + ' defines a ' + (isPointer ? 'pointer' : 'set') + '[' + key + '] ' +
-                            'where the ' + (isPointer ? 'pointer' : 'set') + ' is not part of the meta.',
+                            message: metaName + ' defines a ' + (isPointer ? 'pointer' : 'set') + ' [' + key + '] ' +
+                            'where the ' + (isPointer ? 'target' : 'member') + ' is not part of the meta.',
                             description: 'All defined meta-relations should be between meta-nodes.',
                             hint: 'Locate the related node, add it to the meta and remove the ' +
                             (isPointer ? 'pointer' : 'set') + ' definition.',

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -489,6 +489,7 @@ describe('Meta Rules', function () {
                 .nodeify(done);
         });
 
+        // Name collisions sets/pointers/aspects.
         it('should return error when pointer name overrides set name', function (done) {
             getContext()
                 .then(function (c) {
@@ -511,7 +512,7 @@ describe('Meta Rules', function () {
                 .nodeify(done);
         });
 
-        it.skip('should return error when set name overrides pointer name', function (done) {
+        it('should return error when set name overrides pointer name', function (done) {
             getContext()
                 .then(function (c) {
                     var n = c.core.createNode({parent: c.root, base: c.fco}),
@@ -523,7 +524,7 @@ describe('Meta Rules', function () {
                     c.core.setPointerMetaTarget(c.fco, 'ptrAndSet', c.fco, 1, 1);
                     c.core.setPointerMetaLimits(c.fco, 'ptrAndSet', 1, 1);
 
-                    c.core.setPointerMetaTarget(n, 'ptrAndSet', c.fco, -1, -1);
+                    c.core.setPointerMetaTarget(n, 'ptrAndSet', n, -1, -1);
 
                     result = checkMetaConsistency(c.core, c.root);
                     expect(result.length).to.equal(1);
@@ -534,6 +535,91 @@ describe('Meta Rules', function () {
                 .nodeify(done);
         });
 
+        it('should return error when aspect name overrides set name', function (done) {
+            getContext()
+                .then(function (c) {
+                    var n = c.core.createNode({parent: c.root, base: c.fco}),
+                        result;
+
+                    c.core.setAttribute(n, 'name', 'Node');
+                    c.core.addMember(c.root, 'MetaAspectSet', n);
+                    c.core.setPointerMetaTarget(c.fco, 'setAndAspect', c.fco, -1, -1);
+
+                    c.core.setChildMeta(n, c.fco, -1, -1);
+                    c.core.setAspectMetaTarget(n, 'setAndAspect', c.fco);
+
+                    result = checkMetaConsistency(c.core, c.root);
+                    expect(result.length).to.equal(1);
+                    expect(result[0].message).to.include('defines an aspect [setAndAspect] colliding' +
+                        ' with a set definition');
+                    expect(result[0].severity).to.include('error');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when set name overrides aspect name', function (done) {
+            getContext()
+                .then(function (c) {
+                    var n = c.core.createNode({parent: c.root, base: c.fco}),
+                        result;
+
+                    c.core.setAttribute(n, 'name', 'Node');
+                    c.core.addMember(c.root, 'MetaAspectSet', n);
+                    c.core.setChildMeta(c.fco, c.fco, -1, -1);
+                    c.core.setAspectMetaTarget(c.fco, 'aspectAndSet', c.fco);
+
+                    c.core.setPointerMetaTarget(n, 'aspectAndSet', c.fco, -1, -1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+                    expect(result.length).to.equal(1);
+                    expect(result[0].message).to.include('defines a set [aspectAndSet] colliding' +
+                        ' with an aspect definition');
+                    expect(result[0].severity).to.include('error');
+                })
+                .nodeify(done);
+        });
+
+        // Aspects
+        it('should return error when an aspect member is not a meta-node', function (done) {
+            getContext()
+                .then(function (c) {
+                    var n = c.core.createNode({parent: c.root, base: c.fco}),
+                        result;
+
+                    c.core.setAttribute(n, 'name', 'Node');
+                    //c.core.addMember(c.root, 'MetaAspectSet', n);
+                    //c.core.setChildMeta(c.fco, c.fco, -1, -1);
+                    c.core.setAspectMetaTarget(c.fco, 'nonMeta', n);
+
+                    result = checkMetaConsistency(c.core, c.root);
+                    expect(result.length).to.equal(1);
+                    expect(result[0].message).to.include('defines an aspect [nonMeta] where ' +
+                        'a member is not part of the meta');
+                    expect(result[0].severity).to.include('error');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when an aspect has a member that does not have a containment def', function (done) {
+            getContext()
+                .then(function (c) {
+                    var n = c.core.createNode({parent: c.root, base: c.fco}),
+                        result;
+
+                    c.core.setAttribute(n, 'name', 'Node');
+                    c.core.addMember(c.root, 'MetaAspectSet', n);
+                    c.core.setAspectMetaTarget(c.fco, 'notChild', n);
+
+                    result = checkMetaConsistency(c.core, c.root);
+                    expect(result.length).to.equal(1);
+                    expect(result[0].message).to.include('defines an aspect [notChild] where ' +
+                        'a member does not have a containment definition');
+                    expect(result[0].severity).to.include('error');
+                })
+                .nodeify(done);
+        });
+
+        // Attributes
         it('should return error when regexp is invalid', function (done) {
             getContext()
                 .then(function (c) {

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -392,7 +392,7 @@ describe('Meta Rules', function () {
             .nodeify(done);
     });
 
-    describe.only('metaConsistencyCheck', function () {
+    describe('metaConsistencyCheck', function () {
         function getContext() {
             var result = {
                 root: null,
@@ -652,6 +652,177 @@ describe('Meta Rules', function () {
                         expect(res.message).to.include('defines an invalid');
                         expect(res.message).to.include('The type is not a number');
                     });
+                })
+                .nodeify(done);
+        });
+
+        // Invalid/reserved names
+        it.skip('should return error when attribute name starts with _', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setAttributeMeta(c.fco, '_underscore', {
+                        type: 'string'
+                    });
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines an invalid regular expression');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when set starts with _', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setPointerMetaTarget(c.fco, '_underscore', c.fco, -1, -1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines a set [_underscore] starting with an underscore');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when set is named ovr', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setPointerMetaTarget(c.fco, 'ovr', c.fco, -1, -1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines a set [ovr] which is a reserved name');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when aspect starts with _', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    c.core.setChildMeta(c.fco, c.fco, -1, -1);
+                    // TODO: This should throw!
+                    c.core.setAspectMetaTarget(c.fco, '_underscore', c.fco);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines an aspect [_underscore] starting with an underscore');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when aspect is named ovr', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    c.core.setChildMeta(c.fco, c.fco, -1, -1);
+                    // TODO: This should throw!
+                    c.core.setAspectMetaTarget(c.fco, 'ovr', c.fco);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines an aspect [ovr] which is a reserved name');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when pointer starts with _', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setPointerMetaTarget(c.fco, '_underscore', c.fco, 1, 1);
+                    c.core.setPointerMetaLimits(c.fco, '_underscore', 1, 1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines a pointer [_underscore] starting with an underscore');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when pointer is named base', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setPointerMetaTarget(c.fco, 'base', c.fco, 1, 1);
+                    c.core.setPointerMetaLimits(c.fco, 'base', 1, 1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines a pointer [base] which is a reserved name');
+                })
+                .nodeify(done);
+        });
+
+        it('should return error when pointer is named base', function (done) {
+            getContext()
+                .then(function (c) {
+                    var result;
+                    // TODO: This should throw!
+                    c.core.setPointerMetaTarget(c.fco, 'base', c.fco, 1, 1);
+                    c.core.setPointerMetaLimits(c.fco, 'base', 1, 1);
+
+                    result = checkMetaConsistency(c.core, c.root);
+
+                    expect(result.length).to.equal(1);
+                    expect(result[0].severity).to.equal('error');
+                    expect(result[0].message).to.include('defines a pointer [base] which is a reserved name');
+                })
+                .nodeify(done);
+        });
+
+        // Mixin - this only checks the single call to core.getMixinErrors which has its own tests.
+        it('should return warning when there is a mixin warning', function (done) {
+            getContext()
+                .then(function (c) {
+                    var n = c.core.createNode({parent: c.root, base: c.fco}),
+                        mixin = c.core.createNode({parent: c.root, base: c.fco}),
+                        mixin2 = c.core.createNode({parent: c.root, base: c.fco}),
+                        result;
+
+                    c.core.setAttribute(n, 'name', 'Node');
+                    c.core.setAttribute(mixin, 'name', 'mixin');
+                    c.core.setAttribute(mixin2, 'name', 'mixin2');
+                    c.core.addMember(c.root, 'MetaAspectSet', n);
+                    c.core.addMember(c.root, 'MetaAspectSet', mixin);
+                    c.core.addMember(c.root, 'MetaAspectSet', mixin2);
+
+                    c.core.setAttributeMeta(mixin, 'same', {
+                        type: 'string'
+                    });
+
+                    c.core.setAttributeMeta(mixin2, 'same', {
+                        type: 'string'
+                    });
+
+                    c.core.addMixin(n, c.core.getPath(mixin));
+                    c.core.addMixin(n, c.core.getPath(mixin2));
+
+                    result = checkMetaConsistency(c.core, c.root);
+                    expect(result.length).to.equal(1);
+                    expect(result[0].message).to.include('inherits attribute definition \'same\' from');
+                    expect(result[0].severity).to.include('warning');
                 })
                 .nodeify(done);
         });

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -14,7 +14,7 @@ describe('Meta Rules', function () {
         storage,
         expect = testFixture.expect,
         Q = testFixture.Q,
-        checkMetaRules = requireJS('common/core/users/metarules'),
+        checkNode = requireJS('common/core/users/metarules').checkNode,
         projectName = 'MetaRules',
         branchName = 'master',
         languagePath = '/822429792/',
@@ -59,7 +59,7 @@ describe('Meta Rules', function () {
 
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(false, result.message);
@@ -73,7 +73,7 @@ describe('Meta Rules', function () {
 
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -85,7 +85,7 @@ describe('Meta Rules', function () {
             var nodePath = languagePath + '1578427941';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -97,7 +97,7 @@ describe('Meta Rules', function () {
             var nodePath = languagePath + '942380411';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -109,7 +109,7 @@ describe('Meta Rules', function () {
             var nodePath = languagePath + '1686535233';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -121,7 +121,7 @@ describe('Meta Rules', function () {
             var nodePath = languagePath + '474747191';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -133,7 +133,7 @@ describe('Meta Rules', function () {
             var nodePath = languagePath + '474747191';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -148,7 +148,7 @@ describe('Meta Rules', function () {
             var nodePath = '/1936712753';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -160,7 +160,7 @@ describe('Meta Rules', function () {
             var nodePath = '/767879236';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -172,7 +172,7 @@ describe('Meta Rules', function () {
             var nodePath = '/31060956';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -184,7 +184,7 @@ describe('Meta Rules', function () {
             var nodePath = '/551635397';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -196,7 +196,7 @@ describe('Meta Rules', function () {
             var nodePath = '/361739760';
             testFixture.loadNode(ir.core, ir.rootNode, nodePath)
                 .then(function (node) {
-                    return checkMetaRules(ir.core, node);
+                    return checkNode(ir.core, node);
                 })
                 .then(function (result) {
                     expect(result.hasViolation).to.equal(false, result.message);
@@ -210,7 +210,7 @@ describe('Meta Rules', function () {
         var nodePath = '/994621516';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -223,7 +223,7 @@ describe('Meta Rules', function () {
         var nodePath = '/1694245053';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -236,7 +236,7 @@ describe('Meta Rules', function () {
         var nodePath = '/1868058421';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -249,7 +249,7 @@ describe('Meta Rules', function () {
         var nodePath = '/2048951527';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -262,7 +262,7 @@ describe('Meta Rules', function () {
         var nodePath = '/1672466581';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -275,7 +275,7 @@ describe('Meta Rules', function () {
         var nodePath = '/1232831412';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -288,7 +288,7 @@ describe('Meta Rules', function () {
         var nodePath = '/1702033017';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -301,7 +301,7 @@ describe('Meta Rules', function () {
         var nodePath = '/990231279';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -314,7 +314,7 @@ describe('Meta Rules', function () {
         var nodePath = '/3351391';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
@@ -327,7 +327,7 @@ describe('Meta Rules', function () {
         var nodePath = '/R';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(false, result.message);
@@ -339,7 +339,7 @@ describe('Meta Rules', function () {
         var nodePath = '/j';
         testFixture.loadNode(ir.core, ir.rootNode, nodePath)
             .then(function (node) {
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(false, result.message);
@@ -360,7 +360,7 @@ describe('Meta Rules', function () {
 
                 ir.core.setAttribute(node, 'withInvalidRegEx', 'hej');
 
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true, result.message);
@@ -369,7 +369,7 @@ describe('Meta Rules', function () {
                 ir.core.delAttribute(node, 'withInvalidRegEx', 'hej');
 
                 // Make sure that other tests could broke.
-                return checkMetaRules(ir.core, node);
+                return checkNode(ir.core, node);
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(false, result.message);


### PR DESCRIPTION
By default this is checked from the Meta-Editor on each update.

The mixin errors and name collisions are no longer checked separately on each state change by the client. Instead they are part of this check. To get details about the inconsistencies the Meta-Editor provides an invocation button on the toolbar that displays the errors next to the canvas. 

To check these errors `common/core/metarules.js` provides a method `checkMetaConsistency`, the client exposes this at `client.checkMetaConsistency` (no arguments needed).

In short the meta is checked for:

```
* - Meta name collisions.
* - Referencing nodes outside of the meta.
* - Duplicate definitions from mixins.
* - Collisions between set names and pointers/aspects
* - Invalid regular expression for attributes
* - Invalid min/max for attributes
* - Invalid set/pointer/attribute/aspect/constraint names
```