### PR TITLE
Better error handling in core

### DIFF
--- a/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
+++ b/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
@@ -23,11 +23,10 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
         INVALID_BUTTON_BASE = $('<i class="glyphicon glyphicon-exclamation-sign reset-badge btn-reset" ' +
             'title="Remove META-invalid property"/>');
 
-        PropertyGridPart = function (params) {
+    PropertyGridPart = function (params) {
         if (params.el) {
             this._containerElement = params.el;
         }
-
 
         this._el = $('<div/>', {
             class: CSS_NAMESPACE
@@ -79,7 +78,6 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
         titleRow.addClass('title');
         titleRow.on('click', onClickTitle);
     };
-
 
     /*************** PRIVATE API *************************/
 
@@ -136,7 +134,6 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
     };
 
     /*************** END OF - PRIVATE API *************************/
-
 
     /*************** PUBLIC API **************************/
 
@@ -221,10 +218,13 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
                 spnName.addClass('p-reset');
 
                 actionBtn.on('click', function (event) {
-                    self._reset(propertyDesc.id);
+                    if (self.__widgets[propertyDesc.name]._isReadOnly === false) {
+                        self._reset(propertyDesc.id);
+                    }
                     event.stopPropagation();
                     event.preventDefault();
                 });
+
             }
         }
 
@@ -334,7 +334,6 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
         this._widgetManager.registerWidgetForType(type, widget);
     };
     /*************** END OF - PUBLIC API **************************/
-
 
     return PropertyGridPart;
 });

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -791,9 +791,9 @@ define(['js/logger',
         var gmeIDs = [],
             len = selectedIds.length,
             id,
-            onlyConnectionSelected = selectedIds.length > 0;
+            onlyConnectionSelected = selectedIds.length > 0 && this.designerCanvas.getIsReadOnlyMode() === false;
 
-        while (len--) {
+        while (len-- && onlyConnectionSelected) {
             id = this._ComponentID2GMEID[selectedIds[len]];
             if (id) {
                 gmeIDs.push(id);

--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -201,7 +201,6 @@ define(['jquery',
 
             }
 
-
             //FILTER OUT ABSTRACTS
             if (result === true) {
                 //TODO: why just filter out, why not return false in the first place
@@ -450,7 +449,6 @@ define(['jquery',
         return validPointerTypes;
     }
 
-
     function canCreateChildrenInAspect(parentId, baseIdList, aspectName) {
         var canCreateInAspect = true,
             parentNode = client.getNode(parentId),
@@ -659,7 +657,6 @@ define(['jquery',
         return result;
     }
 
-
     function getValidPointerTypesFromSourceToTarget(sourceId, targetId) {
         var result = [],
             EXCLUDED_POINTERS = [CONSTANTS.POINTER_BASE],
@@ -678,7 +675,6 @@ define(['jquery',
 
         return result;
     }
-
 
     function getValidSetTypesFromContainerToMember(containerId, objId) {
         var result = [],
@@ -711,7 +707,7 @@ define(['jquery',
 
     function getSets(objID) {
         var obj = client.getNode(objID),
-            setNames = obj.getSetNames() || [],
+            setNames = _.union(obj.getSetNames() || [], obj.getValidSetNames() || []),
             aspects = obj.getValidAspectNames() || [],
             crossCuts = getCrosscuts(objID),
             crossCutNames = [];
@@ -777,13 +773,13 @@ define(['jquery',
 
         return result;
     }
-    
+
     function isReplaceable(nodeOrId) {
         var node = typeof nodeOrId === 'string' ? client.getNode(nodeOrId) : nodeOrId;
 
         return canBeReplaceable(node) && !!node.getRegistry(REGISTRY_KEYS.REPLACEABLE);
     }
-    
+
     function getConstrainedById(nodeOrId) {
         var node = typeof nodeOrId === 'string' ? client.getNode(nodeOrId) : nodeOrId,
             constrainedById = node.getPointerId(CONSTANTS.POINTER_CONSTRAINED_BY);
@@ -798,7 +794,7 @@ define(['jquery',
     function isInstanceOf(nodeOrId, baseNodeOrId) {
         var node = typeof nodeOrId === 'string' ? client.getNode(nodeOrId) : nodeOrId,
             nodeId = node.getId(),
-            prospectBaseNodeId = typeof baseNodeOrId === 'string' ? baseNodeOrId: baseNodeOrId.getId();
+            prospectBaseNodeId = typeof baseNodeOrId === 'string' ? baseNodeOrId : baseNodeOrId.getId();
 
         while (node) {
             if (nodeId === prospectBaseNodeId) {

--- a/src/client/js/Utils/PreferencesHelper.js
+++ b/src/client/js/Utils/PreferencesHelper.js
@@ -25,15 +25,23 @@ define([
             len = this._registryList.length,
             result,
             registryDesc,
-            container;
+            container,
+            setNames,
+            memberIds;
 
         for (i = 0; i < len; i += 1) {
             registryDesc = this._registryList[i];
             container = _client.getNode(registryDesc.containerID);
             if (container) {
-                result = container.getMemberRegistry(registryDesc.setID, objID, regKey);
-                if (result !== undefined && result !== null) {
-                    break;
+                setNames = container.getSetNames();
+                if (registryDesc.setID && setNames.indexOf(registryDesc.setID) !== -1) {
+                    memberIds = container.getMemberIds(registryDesc.setID);
+                    if (memberIds.indexOf(objID) !== -1) {
+                        result = container.getMemberRegistry(registryDesc.setID, objID, regKey);
+                        if (result !== undefined && result !== null) {
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -374,7 +374,7 @@ define([
 
     /****************** PUBLIC FUNCTIONS ***********************************/
 
-        //Called when the widget's container size changed
+    //Called when the widget's container size changed
     DiagramDesignerWidget.prototype.onWidgetContainerResize = function (width, height) {
         this._containerSize.w = width;
         this._containerSize.h = height;
@@ -1003,7 +1003,7 @@ define([
             }
         }
 
-        if (this.toolbarItems) {
+        if (this.toolbarItems && this.getIsReadOnlyMode() === false) {
             if (selectedIds.length > 0) {
                 if (this.toolbarItems.cpFillColor) {
                     this.toolbarItems.cpFillColor.enabled(true);

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -11,7 +11,7 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     function _logDeprecated(oldFn, newFn, comment) {
         var commentStr = comment ? comment : '';
         console.warn('"gmeNode.' + oldFn + '" is deprecated and will eventually be removed, use "gmeNode.' + newFn +
-        '" instead.' + commentStr);
+            '" instead.' + commentStr);
     }
 
     function _getNode(nodes, path) {
@@ -149,14 +149,6 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     };
 
     GMENode.prototype.getPointer = function (name) {
-        //return _core.getPointerPath(_nodes[this._id].node,name);
-        if (name === 'base') {
-            //base is a special case as it complicates with inherited children
-            return {
-                to: this._state.core.getPath(this._state.core.getBase(this._state.nodes[this._id].node)),
-                from: []
-            };
-        }
         return {to: this._state.core.getPointerPath(this._state.nodes[this._id].node, name), from: []};
     };
 

--- a/src/common/core/CoreAssert.js
+++ b/src/common/core/CoreAssert.js
@@ -1,0 +1,26 @@
+/*globals define*/
+/*jshint node: true, browser: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+
+define([], function () {
+    'use strict';
+
+    var assert = function (cond, msg) {
+        if (!cond) {
+            var error = new Error(msg || 'ASSERT failed');
+
+            if (typeof TESTING === 'undefined') {
+                console.log('Throwing', error.stack);
+                console.log();
+            }
+
+            throw error;
+        }
+    };
+
+    return assert;
+});

--- a/src/common/core/CoreAssert.js
+++ b/src/common/core/CoreAssert.js
@@ -6,12 +6,12 @@
  */
 
 
-define([], function () {
+define(['common/core/CoreInternalError'], function (CoreInternalError) {
     'use strict';
 
     var assert = function (cond, msg) {
         if (!cond) {
-            var error = new Error(msg || 'ASSERT failed');
+            var error = new CoreInternalError(msg || 'ASSERT failed');
 
             if (typeof TESTING === 'undefined') {
                 console.log('Throwing', error.stack);

--- a/src/common/core/CoreAssertError.js
+++ b/src/common/core/CoreAssertError.js
@@ -12,6 +12,8 @@ define([], function () {
         error.name = this.name = 'CoreAssertError';
         this.message = error.message;
         this.stack = error.stack;
+
+        return error;
     }
 
     CoreAssertError.prototype = Object.create(Error.prototype);

--- a/src/common/core/CoreAssertError.js
+++ b/src/common/core/CoreAssertError.js
@@ -1,0 +1,21 @@
+/*globals define*/
+/*jshint node: true, browser: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+define([], function () {
+    'use strict';
+    function CoreAssertError() {
+        var error = Error.apply(this, arguments);
+        error.name = this.name = 'CoreAssertError';
+        this.message = error.message;
+        this.stack = error.stack;
+    }
+
+    CoreAssertError.prototype = Object.create(Error.prototype);
+    CoreAssertError.prototype.constructor = CoreAssertError;
+
+    return CoreAssertError;
+});

--- a/src/common/core/CoreIllegalArgumentError.js
+++ b/src/common/core/CoreIllegalArgumentError.js
@@ -7,17 +7,17 @@
 
 define([], function () {
     'use strict';
-    function CoreAssertError() {
+    function CoreIllegalArgumentError() {
         var error = Error.apply(this, arguments);
-        error.name = this.name = 'CoreAssertError';
+        error.name = this.name = 'CoreIllegalArgumentError';
         this.message = error.message;
         this.stack = error.stack;
 
         return error;
     }
 
-    CoreAssertError.prototype = Object.create(Error.prototype);
-    CoreAssertError.prototype.constructor = CoreAssertError;
+    CoreIllegalArgumentError.prototype = Object.create(Error.prototype);
+    CoreIllegalArgumentError.prototype.constructor = CoreIllegalArgumentError;
 
-    return CoreAssertError;
+    return CoreIllegalArgumentError;
 });

--- a/src/common/core/CoreIllegalOperationError.js
+++ b/src/common/core/CoreIllegalOperationError.js
@@ -1,0 +1,21 @@
+/*globals define*/
+/*jshint node: true, browser: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+define([], function () {
+    'use strict';
+    function CoreIllegalOperationError() {
+        var error = Error.apply(this, arguments);
+        error.name = this.name = 'CoreIllegalOperationError';
+        this.message = error.message;
+        this.stack = error.stack;
+    }
+
+    CoreIllegalOperationError.prototype = Object.create(Error.prototype);
+    CoreIllegalOperationError.prototype.constructor = CoreIllegalOperationError;
+
+    return CoreIllegalOperationError;
+});

--- a/src/common/core/CoreIllegalOperationError.js
+++ b/src/common/core/CoreIllegalOperationError.js
@@ -12,6 +12,8 @@ define([], function () {
         error.name = this.name = 'CoreIllegalOperationError';
         this.message = error.message;
         this.stack = error.stack;
+
+        return error;
     }
 
     CoreIllegalOperationError.prototype = Object.create(Error.prototype);

--- a/src/common/core/CoreInputError.js
+++ b/src/common/core/CoreInputError.js
@@ -1,0 +1,21 @@
+/*globals define*/
+/*jshint node: true, browser: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+define([], function () {
+    'use strict';
+    function CoreInputError() {
+        var error = Error.apply(this, arguments);
+        error.name = this.name = 'CoreInputError';
+        this.message = error.message;
+        this.stack = error.stack;
+    }
+
+    CoreInputError.prototype = Object.create(Error.prototype);
+    CoreInputError.prototype.constructor = CoreInputError;
+
+    return CoreInputError;
+});

--- a/src/common/core/CoreInputError.js
+++ b/src/common/core/CoreInputError.js
@@ -12,6 +12,8 @@ define([], function () {
         error.name = this.name = 'CoreInputError';
         this.message = error.message;
         this.stack = error.stack;
+
+        return error;
     }
 
     CoreInputError.prototype = Object.create(Error.prototype);

--- a/src/common/core/CoreInternalError.js
+++ b/src/common/core/CoreInternalError.js
@@ -7,17 +7,17 @@
 
 define([], function () {
     'use strict';
-    function CoreInputError() {
+    function CoreInternalError() {
         var error = Error.apply(this, arguments);
-        error.name = this.name = 'CoreInputError';
+        error.name = this.name = 'CoreInternalError';
         this.message = error.message;
         this.stack = error.stack;
 
         return error;
     }
 
-    CoreInputError.prototype = Object.create(Error.prototype);
-    CoreInputError.prototype.constructor = CoreInputError;
+    CoreInternalError.prototype = Object.create(Error.prototype);
+    CoreInternalError.prototype.constructor = CoreInternalError;
 
-    return CoreInputError;
+    return CoreInternalError;
 });

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -118,7 +118,7 @@ define([
     'common/core/metaquerycore',
     'common/regexp',
     'common/core/librarycore',
-    'common/core/CoreInputError',
+    'common/core/CoreIllegalArgumentError',
     'common/core/CoreIllegalOperationError'
 ], function (CoreRel,
              Set,
@@ -136,7 +136,7 @@ define([
              MetaQueryCore,
              REGEXP,
              LibraryCore,
-             CoreInputError,
+             CoreIllegalArgumentError,
              CoreIllegalOperationError) {
     'use strict';
 
@@ -146,7 +146,7 @@ define([
     function ensureType(input, nameOfInput, type, isAsync) {
         var error;
         if (typeof input !== type) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not of type ' + type + '.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not of type ' + type + '.');
             if (isAsync) {
                 return error;
             } else {
@@ -158,7 +158,7 @@ define([
     function ensureValue(input, nameOfInput, isAsync) {
         var error;
         if (input === undefined) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' cannot be undefined.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' cannot be undefined.');
             if (isAsync) {
                 return error;
             } else {
@@ -170,7 +170,7 @@ define([
     function ensureInstanceOf(input, nameOfInput, type, isAsync) {
         var error;
         if (input instanceof type === false) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not of type ' + type + '.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not of type ' + type + '.');
             if (isAsync) {
                 return error;
             } else {
@@ -182,7 +182,7 @@ define([
     function ensurePath(input, nameOfInput, isAsync) {
         var error;
         if (isValidPath(input) === false) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not a valid path.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not a valid path.');
             if (isAsync) {
                 return error;
             } else {
@@ -194,7 +194,7 @@ define([
     function ensureNode(input, nameOfInput, isAsync) {
         var error;
         if (isValidNode(input) === false) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not a valid node.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not a valid node.');
             if (isAsync) {
                 return error;
             } else {
@@ -206,7 +206,7 @@ define([
     function ensureHash(input, nameOfInput, isAsync) {
         var error;
         if (REGEXP.DB_HASH.test(input) === false) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not a valid hash.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not a valid hash.');
             if (isAsync) {
                 return error;
             } else {
@@ -218,7 +218,7 @@ define([
     function ensureGuid(input, nameOfInput, isAsync) {
         var error;
         if (REGEXP.GUID.test(input) === false) {
-            error = new CoreInputError('Parameter \'' + nameOfInput + '\' is not a valid GUID.');
+            error = new CoreIllegalArgumentError('Parameter \'' + nameOfInput + '\' is not a valid GUID.');
             if (isAsync) {
                 return error;
             } else {
@@ -238,12 +238,38 @@ define([
             return;
         }
 
-        error = new CoreInputError('Parameter ' + nameOfInput + ' is not a safe integer from [-1,∞).');
+        error = new CoreIllegalArgumentError('Parameter ' + nameOfInput + ' is not a safe integer from [-1,∞).');
 
-        if (isAsync) {
-            return error;
+        if (error) {
+            if (isAsync) {
+                return error;
+            } else {
+                throw error;
+            }
+        }
+    }
+
+    function ensureRelationName(input, nameOfInput, isAsync) {
+        var error;
+
+        if (typeof input !== 'string') {
+            error = new CoreIllegalArgumentError('Parameter ' + nameOfInput + ' is not of type string.');
         } else {
-            throw error;
+            if (input.indexOf('_') === 0 ||
+                input === 'base' ||
+                input === 'ovr' ||
+                input === 'member') {
+                error = new CoreIllegalArgumentError('Parameter ' + nameOfInput + ' cannot start with \'_\'' +
+                    ', or be equal to \'base\', or be equal to \'ovr\', or be equal to \'member\'');
+            }
+        }
+
+        if (error) {
+            if (isAsync) {
+                return error;
+            } else {
+                throw error;
+            }
         }
     }
 
@@ -292,7 +318,7 @@ define([
          *
          * @return {module:Core~Node|null} Returns the parent of the node or NULL if it has no parent.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getParent = function (node) {
@@ -305,9 +331,9 @@ define([
          * Returns the parent-relative identifier of the node.
          * @param {module:Core~Node} node - the node in question.
          *
-         * @return {string|null|undefined} Returns the last segment of the node path.
+         * @return {string|null} Returns the last segment of the node path.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getRelid = function (node) {
@@ -322,7 +348,7 @@ define([
          *
          * @return {module:Core~Node} Returns the root of the containment hierarchy (it can be the node itself).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getRoot = function (node) {
@@ -339,7 +365,7 @@ define([
          * The path can be empty as well if the node in question is the  root itself, otherwise it should be a chain
          * of relative ids from the root of the containment hierarchy.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getPath = function (node) {
@@ -357,7 +383,7 @@ define([
          * @return {module:Core~Node} Return an empty node if it was created as a result of the function or
          * return the already existing and loaded node if it found.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getChild = function (node, relativeId) {
@@ -374,7 +400,7 @@ define([
          * @return {bool} Returns true if the node is 'empty' meaning that it is not reserved by real data.
          * Returns false if the node is exists and have some meaningful value.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isEmpty = function (node) {
@@ -391,7 +417,7 @@ define([
          * then it means that the node was mutated but not yet saved to the database, so it do not have a hash
          * temporarily.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getHash = function (node) {
@@ -408,7 +434,7 @@ define([
          * @return {module:Core~GmePersisted} The function returns an object which collects all the changes
          * on data level and necessary to update the database on server side
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.persist = function (node) {
@@ -421,13 +447,13 @@ define([
          * Loads the data object with the given hash and makes it a root of a containment hierarchy.
          * @param {module:Core~ObjectHash} hash - the hash of the data object we like to load as root.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting root node
          *
          * @return {External~Promise} If no callback is given, the result will be provided in
          * a promiselike manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadRoot = function (hash, callback) {
             var error = null;
@@ -450,12 +476,12 @@ define([
          * @param {module:Core~Node} parent - the container node in question.
          * @param {string} relativeId - the relative id of the child in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting child
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadChild = function (node, relativeId, callback) {
             var error = null;
@@ -477,12 +503,12 @@ define([
          * @param {module:Core~Node} node - the starting node of our search.
          * @param {string} relativePath - the relative path - built by relative ids - of the node in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting node
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadByPath = function (node, relativePath, callback) {
             var error = null;
@@ -503,12 +529,12 @@ define([
          * the parent, it only loads the already existing children (so no on-demand empty node creation).
          * @param {module:Core~Node} node - the container node in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.children - the resulting children
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadChildren = function (node, callback) {
             var error = null;
@@ -529,12 +555,12 @@ define([
          * (so no on-demand empty node creation).
          * @param {module:Core~Node} node - the container node in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting children
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadOwnChildren = function (node, callback) {
             var error = null;
@@ -557,16 +583,15 @@ define([
          * @param {module:Core~Node} node - the source node in question.
          * @param {string} pointerName - the name of the pointer.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting target
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadPointer = function (node, pointerName, callback) {
-            var error = null,
-                targetPath;
+            var error = null;
 
             ensureType(callback, 'callback', 'function');
             error = ensureNode(node, 'node', true);
@@ -575,13 +600,7 @@ define([
             if (error) {
                 callback(error);
             } else {
-                targetPath = core.getPointerPath(node, pointerName);
-
-                if (targetPath === undefined) {
-                    callback(new CoreIllegalOperationError('Cannot load target of undefined pointer.'));
-                } else {
-                    core.loadPointer(node, pointerName, callback);
-                }
+                core.loadPointer(node, pointerName, callback);
             }
 
         };
@@ -591,16 +610,15 @@ define([
          * @param {module:Core~Node} node - the target node in question.
          * @param {string} pointerName - the name of the pointer of the sources.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadCollection = function (node, pointerName, callback) {
-            var error = null,
-                collectionNames;
+            var error = null;
 
             ensureType(callback, 'callback', 'function');
             error = ensureNode(node, 'node', true);
@@ -609,13 +627,7 @@ define([
             if (error) {
                 callback(error);
             } else {
-                collectionNames = core.getCollectionNames(node);
-
-                if (collectionNames.indexOf(pointerName) === -1) {
-                    callback(new CoreIllegalOperationError('Cannot load sources of undefined pointer.'));
-                } else {
-                    core.loadCollection(node, pointerName, callback);
-                }
+                core.loadCollection(node, pointerName, callback);
             }
         };
 
@@ -623,12 +635,12 @@ define([
          * Loads a complete sub-tree of the containment hierarchy starting from the given node.
          * @param {module:Core~Node} node - the node that is the root of the sub-tree in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadSubTree = function (node, callback) {
             var error = null;
@@ -648,12 +660,12 @@ define([
          * children that has some additional data and not purely inherited.
          * @param {module:Core~Node} node - the container node in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadOwnSubTree = function (node, callback) {
             var error = null;
@@ -673,12 +685,12 @@ define([
          * as the root.
          * @param {module:Core~ObjectHash} hash - hash of the root node.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution.
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution.
          * @param {module:Core~Node[]} callback.nodes - the resulting nodes.
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadTree = function (hash, callback) {
             var error = null;
@@ -712,7 +724,7 @@ define([
          *
          * @return {string[]} The function returns an array of the relative ids.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnChildrenRelids = function (node) {
@@ -727,7 +739,7 @@ define([
          *
          *@return {string[]} The function returns an array of the absolute paths of the children.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getChildrenPaths = function (node) {
@@ -742,7 +754,7 @@ define([
          *
          *@return {string[]} The function returns an array of the absolute paths of the children.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnChildrenPaths = function (node) {
@@ -764,7 +776,7 @@ define([
          * @return {module:Core~Node} The function returns the created node or null if no node was created
          * or an error if the creation with the given parameters are not allowed.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -790,17 +802,14 @@ define([
          * Removes a node from the containment hierarchy.
          * @param {module:Core~Node} node - the node to be removed.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.deleteNode = function (node, technical) {
+        this.deleteNode = function (node) {
             ensureNode(node, 'node');
-            if (technical !== null && technical !== undefined) {
-                ensureType(technical, 'technical', 'boolean');
-            }
 
-            return core.deleteNode(node, technical);
+            return core.deleteNode(node, false);
         };
 
         /**
@@ -810,7 +819,7 @@ define([
          *
          * @return {module:Core~Node} The function returns the copied node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -828,7 +837,7 @@ define([
          *
          * @return {module:Core~Node[]} The function returns an array of the copied nodes.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -850,7 +859,7 @@ define([
          *
          * @return {boolean} True if the supplied parent is a valid parent for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidNewParent = function (node, parent) {
@@ -867,7 +876,7 @@ define([
          *
          * @return {module:Core~Node} The function returns the node after the move.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -884,7 +893,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the attributes of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAttributeNames = function (node) {
@@ -902,7 +911,7 @@ define([
          * The value can be an object or any primitive type. If the value is undefined that means the node do not have
          * such attribute defined. [The retrieved attribute should not be modified as is - it should be copied first!!]
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAttribute = function (node, name) {
@@ -920,7 +929,7 @@ define([
          * @param {object | primitive | null} value - the new of the attribute. Can be any primitive type or object.
          * Undefined is not allowed.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -937,17 +946,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAttribute = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getAttributeNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove non-existing attribute');
-            }
 
             return core.delAttribute(node, name);
         };
@@ -958,7 +963,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the registry entries of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getRegistryNames = function (node) {
@@ -977,7 +982,7 @@ define([
          * the node do not have such attribute defined. [The retrieved registry value should
          * not be modified as is - it should be copied first!!]
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getRegistry = function (node, name) {
@@ -995,7 +1000,7 @@ define([
          * @param {object | primitive | null} value - the new of the registry entry. Can be any primitive
          * type or object. Undefined is not allowed.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1013,17 +1018,13 @@ define([
          * @param {string} name - the name of the registry entry.
          *
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delRegistry = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getRegistryNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown registry entry.');
-            }
 
             return core.delRegistry(node, name);
         };
@@ -1034,7 +1035,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the pointers of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getPointerNames = function (node) {
@@ -1052,7 +1053,7 @@ define([
          * if there is a valid target. It returns null if though the pointer is defined it does not have any
          * valid target. Finally, it return undefined if there is no pointer defined for the node under the given name.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getPointerPath = function (node, name) {
@@ -1067,17 +1068,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the pointer in question.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.deletePointer = this.delPointer = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getPointerNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot delete unknown pointer.');
-            }
 
             return core.deletePointer(node, name);
         };
@@ -1088,7 +1085,7 @@ define([
          * @param {string} name - the name of the pointer in question.
          * @param {module:Core~Node|null} target - the new target of the pointer.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1108,7 +1105,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the pointers pointing to the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getCollectionNames = function (node) {
@@ -1125,7 +1122,7 @@ define([
          * @return {string[]} The function returns an array of absolute paths of nodes that
          * has the pointer pointing to the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getCollectionPaths = function (node, name) {
@@ -1142,7 +1139,7 @@ define([
          * @return {Object<string, module:Core~ObjectHash>} The function returns a dictionary of {@link module:Core~ObjectHash} that stored in pair
          * with the relative id of the corresponding child of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getChildrenHashes = function (node) {
@@ -1157,7 +1154,7 @@ define([
          *
          * @return {module:Core~Node | null} Returns the base of the given node or null if there is no such node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBase = function (node) {
@@ -1172,7 +1169,7 @@ define([
          *
          * @return {module:Core~Node} Returns the root of the inheritance chain (usually the FCO).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBaseRoot = function (node) {
@@ -1188,7 +1185,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the own attributes of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnAttributeNames = function (node) {
@@ -1204,7 +1201,7 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the own registry entries of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnRegistryNames = function (node) {
@@ -1222,7 +1219,7 @@ define([
          * the node. If undefined then it means that there is no such attribute defined directly for the node, meaning
          * that it either inherits some value or there is no such attribute at all.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnAttribute = function (node, name) {
@@ -1241,7 +1238,7 @@ define([
          * for the node. If undefined then it means that there is no such registry entry defined directly for the node,
          * meaning that it either inherits some value or there is no such registry entry at all.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnRegistry = function (node, name) {
@@ -1257,7 +1254,7 @@ define([
          *
          * @return {string[]} Returns an array of names of pointers defined specifically for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnPointerNames = function (node) {
@@ -1275,7 +1272,7 @@ define([
          * 'no-target' was defined specifically for this node for the pointer. If undefined it means that the node
          * either inherits the target of the pointer or there is no pointer defined at all.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnPointerPath = function (node, name) {
@@ -1292,12 +1289,12 @@ define([
          *
          * @return {boolean} True if the supplied base is a valid base for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidNewBase = function (node, base) {
             ensureNode(node, 'node');
-            if (base) {
+            if (base !== null) {
                 ensureNode(base, 'base');
             }
 
@@ -1310,13 +1307,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~Node | null} base - the new base.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setBase = function (node, base) {
             ensureNode(node, 'node');
-            if (base) {
+            if (base !== null) {
                 ensureNode(base, 'base');
             }
 
@@ -1330,7 +1327,7 @@ define([
          * @return {module:Core~Node | null} Returns the root of the inheritance chain of the node. If returns null,
          * that means the node in question is the root of the chain.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getTypeRoot = function (node) {
@@ -1345,7 +1342,7 @@ define([
          *
          * @return {string[]} Returns an array of set names that the node has.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getSetNames = function (node) {
@@ -1361,7 +1358,7 @@ define([
          *
          * @return {string[]} Returns an array of set names that were specifically created at the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnSetNames = function (node) {
@@ -1375,7 +1372,7 @@ define([
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1391,17 +1388,13 @@ define([
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.deleteSet = this.delSet = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getSetNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown set.');
-            }
 
             return core.deleteSet(node, name);
         };
@@ -1413,7 +1406,7 @@ define([
          *
          * @return {string[]} Returns the array of names of attribute entries in the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1435,7 +1428,7 @@ define([
          *
          * @return {string[]} Returns the array of names of attribute entries defined in the set at the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1459,7 +1452,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attribute at the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1484,7 +1477,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attribute at the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1507,7 +1500,7 @@ define([
          * @param {string} attrName - the name of the attribute entry.
          * @param {object|primitive|null} value - the new value of the attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1530,7 +1523,7 @@ define([
          * @param {string} setName - the name of the set.
          * @param {string} attrName - the name of the attribute entry.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1540,10 +1533,6 @@ define([
             ensureType(attrName, 'attrName', 'string');
             var names = core.getSetNames(node);
             if (names.indexOf(setName) === -1) {
-                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
-            }
-            names = core.getSetAttributeNames(node, setName);
-            if (names.indexOf(attrName) === -1) {
                 throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
             }
 
@@ -1559,7 +1548,7 @@ define([
          *
          * @return {string[]} Returns the array of names of registry entries in the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1581,7 +1570,7 @@ define([
          *
          * @return {string[]} Returns the array of names of registry entries defined in the set at the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1605,7 +1594,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry at the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1630,7 +1619,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry at the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnSetRegistry = function (node, setName, regName) {
@@ -1652,7 +1641,7 @@ define([
          * @param {string} regName - the name of the registry entry.
          * @param {object|primitive|null} value - the new value of the registry.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1675,7 +1664,7 @@ define([
          * @param {string} setName - the name of the set.
          * @param {string} regName - the name of the registry entry.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1685,10 +1674,6 @@ define([
             ensureType(regName, 'regName', 'string');
             var names = core.getSetNames(node);
             if (names.indexOf(setName) === -1) {
-                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
-            }
-            names = core.getSetRegistryNames(node, setName);
-            if (names.indexOf(regName) === -1) {
                 throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
             }
 
@@ -1702,7 +1687,7 @@ define([
          *
          * @return {string[]} Returns an array of absolute path strings of the member nodes of the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1726,7 +1711,7 @@ define([
          * @return {string[]} Returns an array of absolute path strings of the member nodes of the set that has
          * information on the node's inheritance level.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1747,7 +1732,7 @@ define([
          * @param {string} name - the name of the set.
          * @param {string} path - the absolute path of the member to be removed.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1759,10 +1744,6 @@ define([
             if (names.indexOf(name) === -1) {
                 throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
             }
-            var paths = core.getMemberPaths(node, name);
-            if (paths.indexOf(path) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown member.');
-            }
 
             return core.delMember(node, name, path);
         };
@@ -1773,7 +1754,7 @@ define([
          * @param {string} name - the name of the set.
          * @param {module:Core~Node} member - the new member of the set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1792,7 +1773,7 @@ define([
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1820,7 +1801,7 @@ define([
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1850,7 +1831,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attributed connected to the given set membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1881,7 +1862,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attributed connected to the given set membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1910,7 +1891,7 @@ define([
          * @param {string} attrName - the name of the attribute.
          * @param {object|primitive|null} value - the new value of the attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1939,7 +1920,7 @@ define([
          * @param {string} memberPath - the absolute path of the member node.
          * @param {string} attrName - the name of the attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -1956,10 +1937,6 @@ define([
             if (paths.indexOf(path) === -1) {
                 throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
             }
-            names = core.getMemberAttributeNames(node, setName, path);
-            if (names.indexOf(attrName) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown attribute.');
-            }
 
             return core.delMemberAttribute(node, setName, path, attrName);
         };
@@ -1973,7 +1950,7 @@ define([
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2003,7 +1980,7 @@ define([
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2033,7 +2010,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry connected to the given set membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2064,7 +2041,7 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry connected to the given set membership.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2093,7 +2070,7 @@ define([
          * @param {string} regName - the name of the registry entry.
          * @param {object|primitive|null} value - the new value of the registry.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2122,7 +2099,7 @@ define([
          * @param {string} path - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2139,10 +2116,6 @@ define([
             if (paths.indexOf(path) === -1) {
                 throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
             }
-            names = core.getMemberRegistryNames(node, setName, path);
-            if (names.indexOf(regName) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown registry entry.');
-            }
 
             return core.delMemberRegistry(node, setName, path, regName);
         };
@@ -2154,7 +2127,7 @@ define([
          * @return {object} Returns a dictionary where every the key of every entry is an absolute path of a set owner
          * node. The value of each entry is an array with the set names in which the node can be found as a member.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isMemberOf = function (node) {
@@ -2169,7 +2142,7 @@ define([
          *
          * @return {module:Core~GUID} Returns the globally unique identifier.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getGuid = function (node) {
@@ -2185,10 +2158,10 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~GUID} guid - the new globally unique identifier.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * @param {Error|CoreIllegalArgumentError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * result of the execution.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.setGuid = function (node, guid, callback) {
             var error = null;
@@ -2212,7 +2185,7 @@ define([
          * @return {module:Core~Constraint | null} Returns the defined constraint or null if it was not
          * defined for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
@@ -2236,7 +2209,7 @@ define([
          * @param {string} name - the name of the constraint.
          * @param {module:Core~Constraint} constraint  - the constraint to be set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2253,17 +2226,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the constraint.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delConstraint = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getConstraintNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown constraint.');
-            }
 
             return core.delConstraint(node, name);
         };
@@ -2274,7 +2243,7 @@ define([
          *
          * @return {string[]} Returns the array of names of constraints available for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getConstraintNames = function (node) {
@@ -2289,7 +2258,7 @@ define([
          *
          * @return {string[]} Returns the array of names of constraints for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnConstraintNames = function (node) {
@@ -2306,7 +2275,7 @@ define([
          * @return {bool} The function returns true if the type is in the inheritance chain of the node or false
          * otherwise. Every node is type of itself.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isTypeOf = function (node, type) {
@@ -2325,7 +2294,7 @@ define([
          * parent. The check does not cover multiplicity (so if the parent can only have twi children and it already
          * has them, this function will still returns true).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidChildOf = function (node, parent) {
@@ -2341,7 +2310,7 @@ define([
          *
          * @return {string[]} The function returns all the pointer names that are defined among the META rules of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidPointerNames = function (node) {
@@ -2356,7 +2325,7 @@ define([
          *
          * @return {string[]} The function returns all the set names that are defined among the META rules of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidSetNames = function (node) {
@@ -2374,7 +2343,7 @@ define([
          * @return {bool} The function returns true if according to the META rules, the given node is a valid
          * target of the given pointer of the source.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2382,10 +2351,6 @@ define([
             ensureNode(node, 'node');
             ensureNode(source, 'source');
             ensureType(name, 'name', 'string');
-            var names = core.getValidPointerNames(source).concat(core.getValidSetNames(source));
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot get information about unknown pointer definition.');
-            }
 
             return core.isValidTargetOf(node, source, name);
         };
@@ -2397,7 +2362,7 @@ define([
          * @return {string[]} The function returns all the attribute names that are defined among the META rules of the
          * node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidAttributeNames = function (node) {
@@ -2412,7 +2377,7 @@ define([
          *
          * @return {string[]} The function returns the attribute names that are defined specifically for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnValidAttributeNames = function (node) {
@@ -2429,7 +2394,7 @@ define([
          *
          * @return {bool} Returns true if the value matches the META definitions.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2437,10 +2402,6 @@ define([
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
             ensureValue(value, 'value');
-            var names = core.getValidAttributeNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot get information about unknown attribute definition.');
-            }
 
             return core.isValidAttributeValueOf(node, name, value);
         };
@@ -2452,7 +2413,7 @@ define([
          * @return {string[]} The function returns all the aspect names that are defined among the META rules of the
          * node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidAspectNames = function (node) {
@@ -2467,7 +2428,7 @@ define([
          *
          * @return {string[]} The function returns the aspect names that are specifically defined for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnValidAspectNames = function (node) {
@@ -2485,7 +2446,7 @@ define([
          * and fits to the META rules defined for the aspect. Any children, visible under the given aspect of the node
          * must be an instance of at least one node represented by the absolute paths.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAspectMeta = function (node, name) {
@@ -2501,7 +2462,7 @@ define([
          *
          * @return {object} Returns an object that represents all the META rules of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
          * @example
@@ -2565,7 +2526,7 @@ define([
          * @return {object} The function returns an object that represent the META rules that were defined
          * specifically for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnJsonMeta = function (node) {
@@ -2579,7 +2540,7 @@ define([
          * inherited rules).
          * @param {module:Core~Node} node - the node in question.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2600,7 +2561,7 @@ define([
          * @param {string|number|boolean} [rule.default] - The value the attribute should have at the node. If not given
          * it should be set at some point.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2618,17 +2579,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAttributeMeta = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getValidAttributeNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown attribute definition');
-            }
 
             return core.delAttributeMeta(node, name);
         };
@@ -2640,7 +2597,7 @@ define([
          *
          * @return {object} The function returns the definition object, where type is always defined.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
@@ -2702,7 +2659,7 @@ define([
          * @return {string[]} The function returns an array of absolute paths of the nodes that was defined as valid
          * children for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidChildrenPaths = function (node) {
@@ -2718,7 +2675,7 @@ define([
          * @return {module:Core~RelationRule} The function returns a detailed JSON structure that represents the META
          * rules regarding the possible children of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
          * @example
@@ -2745,7 +2702,7 @@ define([
          * @param {integer} [max] - the allowed maximum number of children from this given node type (if not given or
          * -1 is set, then there will be no minimum rule according this child type)
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2763,17 +2720,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} path - the absolute path of the child which rule is to be removed from the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delChildMeta = function (node, path) {
             ensureNode(node, 'node');
             ensurePath(path, 'path');
-            var paths = core.getValidChildrenPaths(node);
-            if (paths.indexOf(path) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove child definition of an unknown child.');
-            }
 
             return core.delChildMeta(node, path);
         };
@@ -2786,7 +2739,7 @@ define([
          * @param {integer} [max] - the allowed maximum number of children (if not given or
          * -1 is set, then there will be no maximum rule according children)
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2808,13 +2761,13 @@ define([
          * @param {integer} [max] - the allowed maximum number of target/member from this given node type (if not
          * given or -1 is set, then there will be no minimum rule according this target type)
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setPointerMetaTarget = function (node, name, target, min, max) {
             ensureNode(node, 'node');
-            ensureType(name, 'name', 'string');
+            ensureRelationName(name, 'name');
             ensureNode(target, 'target');
             ensureMinMax(min, 'min');
             ensureMinMax(max, 'max');
@@ -2828,7 +2781,7 @@ define([
          * @param {string} name - the name of the pointer/set
          * @param {string} path - the absolute path of the possible target type.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2839,10 +2792,6 @@ define([
             var names = core.getValidPointerNames(node).concat(core.getValidSetNames(node));
             if (names.indexOf(name) === -1) {
                 throw new CoreIllegalOperationError('Cannot access definition of unknown pointer.');
-            }
-            var paths = core.getValidTargetPaths(node, name);
-            if (paths.indexOf(path) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove definition regarding unknown target.');
             }
 
             return core.delPointerMetaTarget(node, name, path);
@@ -2858,13 +2807,13 @@ define([
          * @param {integer} [max] - the allowed maximum number of children (if not given or
          * -1 is set, then there will be no maximum rule according targets)
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setPointerMetaLimits = function (node, name, min, max) {
             ensureNode(node, 'node');
-            ensureType(name, 'name', 'string');
+            ensureRelationName(name, 'name');
             ensureMinMax(min, 'min');
             ensureMinMax(max, 'max');
 
@@ -2876,17 +2825,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the pointer/set.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delPointerMeta = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getValidPointerNames(node).concat(core.getValidSetNames(node));
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown pointer definition.');
-            }
 
             return core.delPointerMeta(node, name);
         };
@@ -2899,7 +2844,7 @@ define([
          * @return {module:Core~RelationRule|undefined} The function returns a detailed JSON structure that
          * represents the META rules regarding the given pointer/set of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
@@ -2932,13 +2877,13 @@ define([
          * @param {string} name - the name of the aspect.
          * @param {module:Core~Node} target - the valid type for the aspect.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setAspectMetaTarget = function (node, name, target) {
             ensureNode(node, 'node');
-            ensureType(name, 'name', 'string');
+            ensureRelationName(name, 'name');
             ensureNode(target, 'target');
 
             return core.setAspectMetaTarget(node, name, target);
@@ -2950,7 +2895,7 @@ define([
          * @param {string} name - the name of the aspect.
          * @param {string} path - the absolute path of the valid type of the aspect.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -2962,10 +2907,6 @@ define([
             if (names.indexOf(name) === -1) {
                 throw new CoreIllegalOperationError('Cannot change definition of unknown aspect.');
             }
-            var paths = core.getAspectMeta(node, name);
-            if (paths.indexOf(path) === -1) {
-                throw new CoreIllegalOperationError('Cannot delete unknown target of aspect.');
-            }
 
             return core.delAspectMetaTarget(node, name, path);
         };
@@ -2975,17 +2916,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the aspect.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAspectMeta = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getValidAspectNames(node);
-            if (names.indexOf(name) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove definition of unknown aspect.');
-            }
 
             return core.delAspectMeta(node, name);
         };
@@ -2998,7 +2935,7 @@ define([
          * that is a META node. It returns null if it does not find such node (ideally the only node with this result
          * is the ROOT).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBaseType = this.getMetaType = function (node) {
@@ -3014,7 +2951,7 @@ define([
          *
          * @return {bool} The function returns true if it finds an ancestor with the given name attribute.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isInstanceOf = function (node, name) {
@@ -3030,14 +2967,14 @@ define([
          * @param {module:Core~Node} sourceRoot - the root node of the source state.
          * @param {module:Core~Node} targetRoot - the root node of the target state.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the exectuion.
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the status of the exectuion.
          * @param {object} callback.treeDiff - the difference between the two containment hierarchies in
          * a special JSON object
          *
          * @return {External~Promise} - if the callback is not defined, the result is provided in a promise
          * like manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.generateTreeDiff = function (sourceRoot, targetRoot, callback) {
             var error;
@@ -3057,9 +2994,9 @@ define([
          * @param {module:Core~Node} node - the root of the containment hierarchy where we wish to apply the changes
          * @param {object} patch - the tree structured collection of changes represented with a special JSON object
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution.
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the result of the execution.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.applyTreeDiff = function (node, patch, callback) {
             var error;
@@ -3084,7 +3021,7 @@ define([
          * @return {object} The function returns with an object that contains the conflicts (if any) and the merged
          * patch.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.tryToConcatChanges = function (mine, theirs) {
@@ -3105,7 +3042,7 @@ define([
          * @return {object} The function results in a tree structured patch object that contains the changesthat cover
          * both parties modifications (and the conflicts are resolved according the input settings).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.applyResolution = function (conflict) {
@@ -3121,7 +3058,7 @@ define([
          * @return {bool} The function returns true if the registry entry 'isAbstract' of the node if true hence
          * the node is abstract.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isAbstract = function (node) {
@@ -3136,7 +3073,7 @@ define([
          *
          * @return {bool} Returns true if both the 'src' and 'dst' pointer are defined as valid for the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isConnection = function (node) {
@@ -3160,7 +3097,7 @@ define([
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * child of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidChildrenMetaNodes = function (parameters) {
@@ -3200,7 +3137,7 @@ define([
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * member of the set of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidSetElementsMetaNodes = function (parameters) {
@@ -3229,7 +3166,7 @@ define([
          * @return {Object<string, module:Core~Node>} The function returns a dictionary. The keys of the dictionary are the absolute paths of
          * the META nodes of the project. Every value of the dictionary is a {@link module:Core~Node}.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAllMetaNodes = function (node) {
@@ -3245,7 +3182,7 @@ define([
          * @return {bool} Returns true if the node is a member of the METAAspectSet of the ROOT node hence can be
          * seen as a META node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isMetaNode = function (node) {
@@ -3265,7 +3202,7 @@ define([
          * or the member do not have a 'base' member or just some property was overridden, the function returns
          * false.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3291,7 +3228,7 @@ define([
          * @return {module:Core~MixinViolation[]} Returns the array of violations. If the array is empty,
          * there is no violation.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinErrors = function (node) {
@@ -3307,7 +3244,7 @@ define([
          *
          * @return {string[]} The paths of the mixins in an array.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinPaths = function (node) {
@@ -3323,7 +3260,7 @@ define([
          *
          * @return {Object<string, module:Core~Node>} The dictionary of the mixin nodes keyed by their paths.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinNodes = function (node) {
@@ -3338,17 +3275,13 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} path - the path of the mixin node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delMixin = function (node, path) {
             ensureNode(node, 'node');
             ensurePath(path, 'path');
-            var paths = core.getMixinPaths(node);
-            if (paths.indexOf(path) === -1) {
-                throw new CoreIllegalOperationError('Cannot remove unknown mixin.');
-            }
 
             return core.delMixin(node, path);
         };
@@ -3359,7 +3292,7 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} path - the path of the mixin node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3375,7 +3308,7 @@ define([
          *
          * @param {module:Core~Node} node - the node in question.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.clearMixins = function (node) {
@@ -3391,7 +3324,7 @@ define([
          * @return {Object<string, module:Core~Node>} Returns the closest Meta node that is a base of the given node
          * plus it returns all the mixin nodes associated with the base in a path-node dictionary.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBaseTypes = function (node) {
@@ -3406,7 +3339,7 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} path - the path of the mixin node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.canSetAsMixin = function (node, path) {
@@ -3433,12 +3366,12 @@ define([
          * @param {string} [libraryInfo.branchName] - the branch that your library follows in the origin project.
          * @param {string} [libraryInfo.commitHash] - the version of your library.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * @param {Error|CoreIllegalArgumentError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * result of the execution.
          *
          * @return {External~Promise} If no callback is given, the result is provided in a promise like manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.addLibrary = function (node, name, libraryRootHash, libraryInfo, callback) {
             ensureType(callback, 'callback', 'function');
@@ -3477,12 +3410,12 @@ define([
          * @param {string} [libraryInfo.commitHash] - the version of your library.
          * @param updateInstructions - not yet used parameter.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * @param {Error|CoreIllegalArgumentError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * status of the execution.
          *
          * @return {External~Promise} If no callback is given, the result is presented in a promise like manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.updateLibrary = function (node, name, libraryRootHash, libraryInfo, updateInstructions, callback) {
             ensureType(callback, 'callback', 'function');
@@ -3517,7 +3450,7 @@ define([
          * @return {string[]} - Returns the fully qualified names of all the libraries in your project
          * (even embedded ones).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryNames = function (node) {
@@ -3533,7 +3466,7 @@ define([
          *
          * @return {module:Core~Node} - Returns the acting FCO of your project.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getFCO = function (node) {
@@ -3550,7 +3483,7 @@ define([
          * @return {bool} - Returns true if your node is a library root (even if it is embedded in other library),
          * false otherwise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isLibraryRoot = function (node) {
@@ -3566,7 +3499,7 @@ define([
          *
          * @return {bool} - Returns true if your node is a library element, false otherwise.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isLibraryElement = function (node) {
@@ -3584,7 +3517,7 @@ define([
          *
          * @return {string} - Returns the name space of the node.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
          * @example NS1.NS2
@@ -3604,7 +3537,7 @@ define([
          * @return {string} - Returns the fully qualified name of the node,
          * i.e. its namespaces and name join together by dots.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
@@ -3622,7 +3555,7 @@ define([
          * @param {module:Core~Node} node - any node in your project.
          * @param {string} name - the name of your library.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3647,7 +3580,7 @@ define([
          * @return {module:Core~GUID | Error} - Returns the origin GUID of the node or
          * error if the query cannot be fulfilled.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3667,7 +3600,7 @@ define([
          * @param {string} oldName - the current name of the library.
          * @param {string} newName - the new name of the project.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3688,7 +3621,7 @@ define([
          * @return {object} - Returns the information object, stored alongside the library (that basically
          * carries metaData about the library).
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3707,7 +3640,7 @@ define([
          *
          * @return {module:Core~Node | null} - Returns the library root node or null, if the library is unknown.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3729,7 +3662,7 @@ define([
          * @return {module:Core~Node[]} - Returns an array of core nodes that are part of your meta from
          * the given library.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3761,12 +3694,12 @@ define([
          * @param {function} visitFn.next - the callback function of the visit function that marks the end
          * of visitation.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the status of the execution.
          *
          * @return {External~Promise} If no callback is given, the end of traverse is marked in a promise like
          * manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.traverse = function (root, options, visitFn, callback) {
             ensureType(callback, 'callback', 'function');
@@ -3780,7 +3713,7 @@ define([
                     error = error || ensureType(options.order, 'options.order', 'string', true);
                     if (options.order !== 'BFS' && options.order !== 'DFS') {
                         error = error ||
-                            new CoreInputError('Parameter options.order must be either \'BFS\' or \'DFS\'.');
+                            new CoreIllegalArgumentError('Parameter options.order must be either \'BFS\' or \'DFS\'.');
                     }
                 }
                 if (options.hasOwnProperty('stopOnError')) {
@@ -3807,7 +3740,7 @@ define([
          * will contain information about the necessary data that needs to be exported as well as relations
          * that will need to be recreated in the destination project to preserve the structure of nodes.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3832,7 +3765,7 @@ define([
          * @return {object} If the closure cannot be imported the resulting error highlights the causes,
          * otherwise a specific object will be returned that holds information about the closure.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
@@ -3849,7 +3782,7 @@ define([
          *
          *@return {string[]} The function returns an array of the absolute paths of the instances.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getInstancePaths = function (node) {
@@ -3862,13 +3795,13 @@ define([
          * Loads all the instances of the given node.
          * @param {module:Core~Node} node - the node in question.
          * @param {function} [callback]
-         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the status of the execution.
          * @param {module:Core~Node[]} callback.nodes - the found instances of the node.
          *
          * @return {External~Promise} If no callback is given, the result will be provided in a promise
          * like manner.
          *
-         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          */
         this.loadInstances = function (node, callback) {
             ensureType(callback, 'callback', 'function');

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -2148,7 +2148,11 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getGuid = core.getGuid;
+        this.getGuid = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getGuid(node);
+        };
 
         //TODO this is only used in import - export use-cases, probably could be removed...
         /**
@@ -2157,13 +2161,24 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~GUID} guid - the new globally unique identifier.
          * @param {function} callback[]
-         * @param {Error|null} callback.error - the result of the executiob.
+         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * result of the execution.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
-         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
-         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setGuid = core.setGuid;
+        this.setGuid = function (node, guid, callback) {
+            var error = null;
+            ensureType(callback, 'callback', 'function');
+            error = ensureNode(node, 'node', true);
+            error = error || ensureGuid(guid, 'guid', true);
+
+            if (error) {
+                callback(error);
+            } else {
+                core.setGuid(node, guid, callback);
+            }
+
+        };
 
         /**
          * Gets a constraint object of the node.
@@ -2184,7 +2199,12 @@ define([
          *   info: "Should check unique name"
          * }
          */
-        this.getConstraint = core.getConstraint;
+        this.getConstraint = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getConstraint(node, name);
+        };
 
         /**
          * Sets a constraint object of the node.
@@ -2196,7 +2216,13 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setConstraint = core.setConstraint;
+        this.setConstraint = function (node, name, constraint) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensureType(constraint, 'constraint', 'object');
+
+            return core.setConstraint(node, name, constraint);
+        };
 
         /**
          * Removes a constraint from the node.
@@ -2207,7 +2233,16 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delConstraint = core.delConstraint;
+        this.delConstraint = function (node, name) {
+            ensureNode(node,'node');
+            ensureType(name,'name','string');
+            var names = core.getConstraintNames(node);
+            if(names.indexOf(name) === -1){
+                throw new CoreIllegalOperationError('Cannot remove unknown constraint.');
+            }
+
+            return core.delConstraint(node,name);
+        };
 
         /**
          * Retrieves the list of constraint names defined for the node.
@@ -2218,7 +2253,11 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getConstraintNames = core.getConstraintNames;
+        this.getConstraintNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getConstraintNames(node);
+        };
 
         /**
          * Retrieves the list of constraint names defined specifically for the node.
@@ -2229,7 +2268,11 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnConstraintNames = core.getOwnConstraintNames;
+        this.getOwnConstraintNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getOwnConstraintNames(node);
+        };
 
         /**
          * Checks if the given typeNode is really a base of the node.
@@ -2242,7 +2285,12 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isTypeOf = core.isTypeOf;
+        this.isTypeOf = function (node,type) {
+            ensureNode(node, 'node');
+            ensureNode(type, 'type');
+
+            return core.isTypeOf(node);
+        };
 
         /**
          * Checks if according to the META rules the given node can be a child of the parent.
@@ -2256,7 +2304,12 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isValidChildOf = core.isValidChildOf;
+        this.isValidChildOf = function (node,parent) {
+            ensureNode(node, 'node');
+            ensureNode(parent, 'parent');
+
+            return core.isTypeOf(node);
+        };
 
         /**
          * Returns the list of the META defined pointer names of the node.

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -3155,7 +3155,7 @@ define([
          * @param {bool} - [parameters.multiplicity] - if true, the query tries to filter out even more nodes according
          * to the multiplicity rules (the default value is false, the check is only meaningful if all the children were
          * passed)
-         * @param {string} - [parameters.aspect] - if given, the query filters to contain only types that are visible
+         * @param {string|null} - [parameters.aspect] - if given, the query filters to contain only types that are visible
          * in the given aspect.
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * child of the node.
@@ -3178,7 +3178,7 @@ define([
             if (parameters.hasOwnProperty('multiplicity')) {
                 ensureType(parameters.multiplicity, 'parameters.multiplicity', 'boolean');
             }
-            if (parameters.hasOwnProperty('aspect') && parameters.aspect !== undefined) {
+            if (parameters.hasOwnProperty('aspect') && parameters.aspect !== undefined && parameters.aspect !== null) {
                 ensureType(parameters.aspect, 'parameters.aspect', 'string');
             }
 

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1531,9 +1531,19 @@ define([
          * @return {string[]} Returns the array of names of registry entries in the set.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getSetRegistryNames = core.getSetRegistryNames;
+        this.getSetRegistryNames = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getSetRegistryNames(node, name);
+        };
 
         /**
          * Return the names of the registry entries specifically set for the set at the node.
@@ -1543,9 +1553,19 @@ define([
          * @return {string[]} Returns the array of names of registry entries defined in the set at the node.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnSetRegistryNames = core.getOwnSetRegistryNames;
+        this.getOwnSetRegistryNames = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getOwnSetRegistryNames(node, name);
+        };
 
         /**
          * Get the value of the registry entry in the set.
@@ -1557,9 +1577,20 @@ define([
          * is no such registry at the set.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getSetRegistry = core.getSetRegistry;
+        this.getSetRegistry = function (node, setName, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getSetRegistry(node, setName, regName);
+        };
 
         /**
          * Get the value of the registry entry specifically set for the set at the node.
@@ -1573,7 +1604,17 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnSetRegistry = core.getOwnSetRegistry;
+        this.getOwnSetRegistry = function (node, setName, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getOwnSetRegistry(node, setName, regName);
+        };
 
         /**
          * Sets the registry entry value for the set at the node.
@@ -1586,7 +1627,18 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setSetRegistry = core.setSetRegistry;
+        this.setSetRegistry = function (node, setName, regName, value) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(regName, 'regName', 'string');
+            ensureValue(value, 'value');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.setSetRegistry(node, setName, regName, value);
+        };
 
         /**
          * Removes the registry entry for the set at the node.
@@ -1598,7 +1650,21 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delSetRegistry = core.delSetRegistry;
+        this.delSetRegistry = function (node, setName, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+            names = core.getSetRegistryNames(node, setName);
+            if (names.indexOf(regName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.delSetRegistry(node, setName, regName);
+        };
 
         /**
          * Returns the list of absolute paths of the members of the given set of the given node.
@@ -1608,9 +1674,19 @@ define([
          * @return {string[]} Returns an array of absolute path strings of the member nodes of the set.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberPaths = core.getMemberPaths;
+        this.getMemberPaths = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+
+            return core.getMemberPaths(node, name);
+        };
 
         /**
          * Returns the list of absolute paths of the members of the given set of the given node that not simply
@@ -1622,9 +1698,19 @@ define([
          * information on the node's inheritance level.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnMemberPaths = core.getOwnMemberPaths;
+        this.getOwnMemberPaths = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+
+            return core.getOwnMemberPaths(node, name);
+        };
 
         /**
          * Removes a member from the set. The functions doesn't remove the node itself.
@@ -1636,7 +1722,21 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delMember = core.delMember;
+        this.delMember = function (node, name, path) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensurePath(path, 'path');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, name);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove unknown member.');
+            }
+
+            return core.delMember(node, name, path);
+        };
 
         /**
          * Adds a member to the given set.
@@ -1648,13 +1748,23 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.addMember = core.addMember;
+        this.addMember = function (node, name, member) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensureNode(member, 'member');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+
+            return core.addMember(node, name, member);
+        };
 
         /**
          * Return the names of the attributes defined for the set membership to the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
-         * @param {string} memberPath - the absolute path of the member.
+         * @param {string} path - the absolute path of the member.
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
@@ -1662,13 +1772,27 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberAttributeNames = core.getMemberAttributeNames;
+        this.getMemberAttributeNames = function (node, name, path) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensurePath(path, 'path');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, name);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+
+            return core.getMemberAttributeNames(node, name, path);
+        };
 
         /**
          * Return the names of the attributes defined for the set membership specifically defined to the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
-         * @param {string} memberPath - the absolute path of the member.
+         * @param {string} path - the absolute path of the member.
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
@@ -1676,13 +1800,27 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberOwnAttributeNames = core.getMemberOwnAttributeNames;
+        this.getMemberOwnAttributeNames = function (node, name, path) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensurePath(path, 'path');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, name);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+
+            return core.getMemberOwnAttributeNames(node, name, path);
+        };
 
         /**
          * Get the value of the attribute in relation with the set membership.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} attrName - the name of the attribute.
          *
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
@@ -1692,13 +1830,28 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberAttribute = core.getMemberAttribute;
+        this.getMemberAttribute = function (node, setName, path, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+
+            return core.getMemberAttribute(node, setName, path, attrName);
+        };
 
         /**
          * Get the value of the attribute for the set membership specifically defined to the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} attrName - the name of the attribute.
          *
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
@@ -1708,13 +1861,28 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberOwnAttribute = core.getMemberOwnAttribute;
+        this.getMemberOwnAttribute = function (node, setName, path, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+
+            return core.getMemberOwnAttribute(node, setName, path, attrName);
+        };
 
         /**
          * Sets the attribute value which represents a property of the membership.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} attrName - the name of the attribute.
          * @param {object|primitive|null} value - the new value of the attribute.
          *
@@ -1722,7 +1890,23 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setMemberAttribute = core.setMemberAttribute;
+        this.setMemberAttribute = function (node, setName, path, attrName, value) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(attrName, 'attrName', 'string');
+            ensureValue(value, 'value');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+
+            return core.setMemberAttribute(node, setName, path, attrName);
+        };
 
         /**
          * Removes an attribute which represented a property of the given set membership.
@@ -1735,13 +1919,32 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delMemberAttribute = core.delMemberAttribute;
+        this.delMemberAttribute = function (node, setName, path, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
+            }
+            names = core.getMemberAttributeNames(node, setName, path);
+            if (names.indexOf(attrName) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove unknown attribute.');
+            }
+
+            return core.delMemberAttribute(node, setName, path, attrName);
+        };
 
         /**
          * Return the names of the registry entries defined for the set membership to the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
-         * @param {string} memberPath - the absolute path of the member.
+         * @param {string} path - the absolute path of the member.
          *
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
@@ -1750,14 +1953,28 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberRegistryNames = core.getMemberRegistryNames;
+        this.getMemberRegistryNames = function (node, name, path) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensurePath(path, 'path');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, name);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+
+            return core.getMemberRegistryNames(node, name, path);
+        };
 
         /**
          * Return the names of the registry entries defined for the set membership specifically defined to
          * the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
-         * @param {string} memberPath - the absolute path of the member.
+         * @param {string} path - the absolute path of the member.
          *
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
@@ -1766,13 +1983,27 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberOwnRegistryNames = core.getMemberOwnRegistryNames;
+        this.getMemberOwnRegistryNames = function (node, name, path) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensurePath(path, 'path');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, name);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+
+            return core.getMemberOwnRegistryNames(node, name, path);
+        };
 
         /**
          * Get the value of the registry entry in relation with the set membership.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          *
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
@@ -1782,13 +2013,28 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberRegistry = core.getMemberRegistry;
+        this.getMemberRegistry = function (node, setName, path, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+
+            return core.getMemberRegistry(node, setName, path, regName);
+        };
 
         /**
          * Get the value of the registry entry for the set membership specifically defined to the member node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          *
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
@@ -1798,13 +2044,28 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getMemberOwnRegistry = core.getMemberOwnRegistry;
+        this.getMemberOwnRegistry = function (node, setName, path, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+
+            return core.getMemberOwnRegistry(node, setName, path, regName);
+        };
 
         /**
          * Sets the registry entry value which represents a property of the membership.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          * @param {object|primitive|null} value - the new value of the registry.
          *
@@ -1812,20 +2073,55 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setMemberRegistry = core.setMemberRegistry;
+        this.setMemberRegistry = function (node, setName, path, regName, value) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(regName, 'regName', 'string');
+            ensureValue(value, 'value');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+
+            return core.setMemberRegistry(node, setName, path, regName);
+        };
 
         /**
          * Removes a registry entry which represented a property of the given set membership.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} setName - the name of the set.
-         * @param {string} memberPath - the absolute path of the member node.
+         * @param {string} path - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delMemberRegistry = core.delMemberRegistry;
+        this.delMemberRegistry = function (node, setName, path, regName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensurePath(path, 'path');
+            ensureType(regName, 'regName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
+            }
+            var paths = core.getMemberPaths(node, setName);
+            if (paths.indexOf(path) === -1) {
+                throw new CoreIllegalOperationError('Cannot access registry of an unknown member.');
+            }
+            names = core.getMemberRegistryNames(node, setName, path);
+            if (names.indexOf(regName) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove unknown registry entry.');
+            }
+
+            return core.delMemberRegistry(node, setName, path, regName);
+        };
 
         /**
          * Returns all membership information of the given node.
@@ -1837,7 +2133,11 @@ define([
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isMemberOf = core.isMemberOf;
+        this.isMemberOf = function (node) {
+            ensureNode(node, 'node');
+
+            return core.isMemberOf(node);
+        };
 
         /**
          * Get the GUID of a node.

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -119,7 +119,8 @@ define([
     'common/regexp',
     'common/core/librarycore',
     'common/core/CoreIllegalArgumentError',
-    'common/core/CoreIllegalOperationError'
+    'common/core/CoreIllegalOperationError',
+    'common/core/constants'
 ], function (CoreRel,
              Set,
              Guid,
@@ -137,7 +138,8 @@ define([
              REGEXP,
              LibraryCore,
              CoreIllegalArgumentError,
-             CoreIllegalOperationError) {
+             CoreIllegalOperationError,
+             CONSTANTS) {
     'use strict';
 
     var isValidNode,
@@ -250,17 +252,20 @@ define([
     }
 
     function ensureRelationName(input, nameOfInput, isAsync) {
-        var error;
+        var error,
+            reserved = [
+                CONSTANTS.BASE_POINTER,
+                CONSTANTS.OVERLAYS_PROPERTY,
+                CONSTANTS.MEMBER_RELATION
+            ];
 
         if (typeof input !== 'string') {
             error = new CoreIllegalArgumentError('Parameter ' + nameOfInput + ' is not of type string.');
         } else {
             if (input.indexOf('_') === 0 ||
-                input === 'base' ||
-                input === 'ovr' ||
-                input === 'member') {
+                reserved.indexOf(input) !== -1) {
                 error = new CoreIllegalArgumentError('Parameter ' + nameOfInput + ' cannot start with \'_\'' +
-                    ', or be equal to \'base\', or be equal to \'ovr\', or be equal to \'member\'');
+                    ', or be equal with any of the reserved ' + reserved + ' words.');
             }
         }
 
@@ -1394,7 +1399,7 @@ define([
          */
         this.deleteSet = this.delSet = function (node, name) {
             ensureNode(node, 'node');
-            ensureType(name, 'name', 'string');
+            ensureRelationName(name, 'name');
 
             return core.deleteSet(node, name);
         };

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -914,7 +914,16 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delAttribute = core.delAttribute;
+        this.delAttribute = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getAttributeNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove non-existing attribute');
+            }
+
+            return core.delAttribute(node, name);
+        };
 
         /**
          * Returns the names of the defined registry entries of the node.

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -931,9 +931,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the registry entries of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getRegistryNames = core.getRegistryNames;
+        this.getRegistryNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getRegistryNames(node);
+        };
 
         /**
          * Retrieves the value of the given registry entry of the given node.
@@ -945,9 +950,15 @@ define([
          * the node do not have such attribute defined. [The retrieved registry value should
          * not be modified as is - it should be copied first!!]
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getRegistry = core.getRegistry;
+        this.getRegistry = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getRegistry(node, name);
+        };
 
         /**
          * Sets the value of the given registry entry of the given node. It defines the registry entry on demand,
@@ -957,23 +968,38 @@ define([
          * @param {object | primitive | null} value - the new of the registry entry. Can be any primitive
          * type or object. Undefined is not allowed.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setRegistry = core.setRegistry;
+        this.setRegistry = function (node, name, value) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensureValue(value, 'value');
+
+            return core.setRegistry(node, name, value);
+        };
 
         /**
          * Removes the given registry entry from the given node.
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the registry entry.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delRegistry = core.delRegistry;
+        this.delRegistry = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getRegistryNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove unknown registry entry.');
+            }
+
+            return core.delRegistry(node, name);
+        };
 
         /**
          * Retrieves a list of the defined pointer names of the node.
@@ -981,9 +1007,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the pointers of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getPointerNames = core.getPointerNames;
+        this.getPointerNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getPointerNames(node);
+        };
 
         /**
          * Retrieves the path of the target of the given pointer of the given node.
@@ -994,21 +1025,35 @@ define([
          * if there is a valid target. It returns null if though the pointer is defined it does not have any
          * valid target. Finally, it return undefined if there is no pointer defined for the node under the given name.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getPointerPath = core.getPointerPath;
+        this.getPointerPath = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getPointerPath(node, name);
+        };
 
         /**
          * Removes the pointer from the node.
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the pointer in question.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.deletePointer = this.delPointer = core.deletePointer;
+        this.deletePointer = this.delPointer = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getPointerNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot delete unknown pointer.');
+            }
+
+            return core.deletePointer(node, name);
+        };
 
         /**
          * Sets the target of the pointer of the node.
@@ -1016,12 +1061,17 @@ define([
          * @param {string} name - the name of the pointer in question.
          * @param {module:Core~Node} target - the new target of the pointer.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setPointer = core.setPointer;
+        this.setPointer = function (node, name, target) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensureNode(target, 'target');
+
+            return core.setPointer(node, name, target);
+        };
 
         /**
          * Retrieves a list of the defined pointer names that has the node as target.
@@ -1029,9 +1079,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the pointers pointing to the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getCollectionNames = core.getCollectionNames;
+        this.getCollectionNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getCollectionNames(node);
+        };
 
         /**
          * Retrieves a list of absolute paths of nodes that has a given pointer which points to the given node.
@@ -1041,9 +1096,15 @@ define([
          * @return {string[]} The function returns an array of absolute paths of nodes that
          * has the pointer pointing to the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getCollectionPaths = core.getCollectionPaths;
+        this.getCollectionPaths = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getCollectionPaths(node, name);
+        };
 
         /**
          * Collects the data hash values of the children of the node.
@@ -1052,9 +1113,14 @@ define([
          * @return {Object<string, module:Core~ObjectHash>} The function returns a dictionary of {@link module:Core~ObjectHash} that stored in pair
          * with the relative id of the corresponding child of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getChildrenHashes = core.getChildrenHashes;
+        this.getChildrenHashes = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getChildrenHashes(node);
+        };
 
         /**
          * Returns the base node.
@@ -1062,9 +1128,14 @@ define([
          *
          * @return {module:Core~Node | null} Returns the base of the given node or null if there is no such node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getBase = core.getBase;
+        this.getBase = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getBase(node);
+        };
 
         /**
          * Returns the root of the inheritance chain of the given node.
@@ -1072,9 +1143,14 @@ define([
          *
          * @return {module:Core~Node} Returns the root of the inheritance chain (usually the FCO).
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getBaseRoot = core.getBaseRoot;
+        this.getBaseRoot = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getBaseRoot(node);
+        };
 
         /**
          * Returns the names of the attributes of the node that have been first defined for the node and not for its
@@ -1083,9 +1159,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the own attributes of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnAttributeNames = core.getOwnAttributeNames;
+        this.getOwnAttributeNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getOwnAttributeNames(node);
+        };
 
         /**
          * Returns the names of the registry enrties of the node that have been first defined for the node
@@ -1094,9 +1175,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the own registry entries of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnRegistryNames = core.getOwnRegistryNames;
+        this.getOwnRegistryNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getOwnRegistryNames(node);
+        };
 
         /**
          * Returns the value of the attribute defined for the given node.
@@ -1107,9 +1193,15 @@ define([
          * the node. If undefined then it means that there is no such attribute defined directly for the node, meaning
          * that it either inherits some value or there is no such attribute at all.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnAttribute = core.getOwnAttribute;
+        this.getOwnAttribute = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getOwnAttribute(node, name);
+        };
 
         /**
          * Returns the value of the registry entry defined for the given node.
@@ -1120,9 +1212,15 @@ define([
          * for the node. If undefined then it means that there is no such registry entry defined directly for the node,
          * meaning that it either inherits some value or there is no such registry entry at all.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnRegistry = core.getOwnRegistry;
+        this.getOwnRegistry = function (node, name) {
+            ensureNode(node, 'node')
+            ensureType(name, 'name', 'string');
+
+            return core.getOwnRegistry(node, name);
+        };
 
         /**
          * Returns the list of the names of the pointers that were defined specifically for the node.
@@ -1130,9 +1228,14 @@ define([
          *
          * @return {string[]} Returns an array of names of pointers defined specifically for the node.
          *
-         *@func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnPointerNames = core.getOwnPointerNames;
+        this.getOwnPointerNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getOwnPointerNames(node);
+        };
 
         /**
          * Returns the absolute path of the target of the pointer specifically defined for the node.
@@ -1143,9 +1246,15 @@ define([
          * 'no-target' was defined specifically for this node for the pointer. If undefined it means that the node
          * either inherits the target of the pointer or there is no pointer defined at all.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnPointerPath = core.getOwnPointerPath;
+        this.getOwnPointerPath = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getOwnPointerPath(node, name);
+        };
 
         /**
          * Checks if base can be the new base of node.
@@ -1154,9 +1263,17 @@ define([
          *
          * @return {boolean} True if the supplied base is a valid base for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isValidNewBase = core.isValidNewBase;
+        this.isValidNewBase = function (node, base) {
+            ensureNode(node, 'node');
+            if (base) {
+                ensureNode(base, 'base');
+            }
+
+            return core.isValidNewBase(node, base);
+        };
 
         /**
          * Sets the base node of the given node. The function doesn't touches the properties or the children of the node
@@ -1164,12 +1281,18 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~Node | null} base - the new base.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setBase = core.setBase;
+        this.setBase = function (node, base) {
+            ensureNode(node, 'node');
+            if (base) {
+                ensureNode(base, 'base');
+            }
+
+            return core.setBase(node, base);
+        };
 
         /**
          * Returns the root of the inheritance chain (cannot be the node itself).
@@ -1178,9 +1301,14 @@ define([
          * @return {module:Core~Node | null} Returns the root of the inheritance chain of the node. If returns null,
          * that means the node in question is the root of the chain.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getTypeRoot = core.getTypeRoot;
+        this.getTypeRoot = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getTypeRoot(node);
+        };
 
         /**
          * Returns the names of the sets of the node.
@@ -1188,9 +1316,14 @@ define([
          *
          * @return {string[]} Returns an array of set names that the node has.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getSetNames = core.getSetNames;
+        this.getSetNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getSetNames(node);
+        };
 
         /**
          * Returns the names of the sets created specifically at the node.
@@ -1199,33 +1332,50 @@ define([
          *
          * @return {string[]} Returns an array of set names that were specifically created at the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnSetNames = core.getOwnSetNames;
+        this.getOwnSetNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getOwnSetNames(node);
+        };
 
         /**
          * Creates a set for the node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.createSet = core.createSet;
+        this.createSet = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.createSet(node, name);
+        };
 
         /**
          * Removes a set from the node.
          * @param {module:Core~Node} node - the owner of the set.
          * @param {string} name - the name of the set.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.deleteSet = this.delSet = core.deleteSet;
+        this.deleteSet = this.delSet = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot remove unknown set.');
+            }
+
+            return core.deleteSet(node, name);
+        };
 
         /**
          * Return the names of the attribute entries for the set.
@@ -1234,9 +1384,20 @@ define([
          *
          * @return {string[]} Returns the array of names of attribute entries in the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getSetAttributeNames = core.getSetAttributeNames;
+        this.getSetAttributeNames = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getSetAttributeNames(node, name);
+        };
 
         /**
          * Return the names of the attribute entries specifically set for the set at the node.
@@ -1245,9 +1406,20 @@ define([
          *
          * @return {string[]} Returns the array of names of attribute entries defined in the set at the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnSetAttributeNames = core.getOwnSetAttributeNames;
+        this.getOwnSetAttributeNames = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(name) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getOwnSetAttributeNames(node, name);
+        };
 
         /**
          * Get the value of the attribute entry in the set.
@@ -1258,9 +1430,21 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attribute at the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getSetAttribute = core.getSetAttribute;
+        this.getSetAttribute = function (node, setName, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getSetAttribute(node, setName, attrName);
+        };
 
         /**
          * Get the value of the attribute entry specifically set for the set at the node.
@@ -1271,9 +1455,21 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attribute at the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getOwnSetAttribute = core.getOwnSetAttribute;
+        this.getOwnSetAttribute = function (node, setName, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.getOwnSetAttribute(node, setName, attrName);
+        };
 
         /**
          * Sets the attribute entry value for the set at the node.
@@ -1282,12 +1478,22 @@ define([
          * @param {string} attrName - the name of the attribute entry.
          * @param {object|primitive|null} value - the new value of the attribute.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setSetAttribute = core.setSetAttribute;
+        this.setSetAttribute = function (node, setName, attrName, value) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(attrName, 'attrName', 'string');
+            ensureValue(value, 'value');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.setSetAttribute(node, setName, attrName, value);
+        };
 
         /**
          * Removes the attribute entry for the set at the node.
@@ -1295,12 +1501,25 @@ define([
          * @param {string} setName - the name of the set.
          * @param {string} attrName - the name of the attribute entry.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delSetAttribute = core.delSetAttribute;
+        this.delSetAttribute = function (node, setName, attrName) {
+            ensureNode(node, 'node');
+            ensureType(setName, 'setName', 'string');
+            ensureType(attrName, 'attrName', 'string');
+            var names = core.getSetNames(node);
+            if (names.indexOf(setName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+            names = core.getSetAttributeNames(node, setName);
+            if (names.indexOf(attrName) === -1) {
+                throw new CoreIllegalOperationError('Cannot access attributes of unknown set.');
+            }
+
+            return core.delSetAttribute(node, setName, attrName);
+        };
 
         //Regs
 
@@ -1311,7 +1530,8 @@ define([
          *
          * @return {string[]} Returns the array of names of registry entries in the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getSetRegistryNames = core.getSetRegistryNames;
 
@@ -1322,7 +1542,8 @@ define([
          *
          * @return {string[]} Returns the array of names of registry entries defined in the set at the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnSetRegistryNames = core.getOwnSetRegistryNames;
 
@@ -1335,7 +1556,8 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry at the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getSetRegistry = core.getSetRegistry;
 
@@ -1348,7 +1570,8 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry at the set.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnSetRegistry = core.getOwnSetRegistry;
 
@@ -1359,10 +1582,9 @@ define([
          * @param {string} regName - the name of the registry entry.
          * @param {object|primitive|null} value - the new value of the registry.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setSetRegistry = core.setSetRegistry;
 
@@ -1372,10 +1594,9 @@ define([
          * @param {string} setName - the name of the set.
          * @param {string} regName - the name of the registry entry.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delSetRegistry = core.delSetRegistry;
 
@@ -1385,7 +1606,9 @@ define([
          * @param {string} name - the name of the set.
          *
          * @return {string[]} Returns an array of absolute path strings of the member nodes of the set.
-         * @func
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberPaths = core.getMemberPaths;
 
@@ -1397,7 +1620,9 @@ define([
          *
          * @return {string[]} Returns an array of absolute path strings of the member nodes of the set that has
          * information on the node's inheritance level.
-         * @func
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnMemberPaths = core.getOwnMemberPaths;
 
@@ -1407,10 +1632,9 @@ define([
          * @param {string} name - the name of the set.
          * @param {string} path - the absolute path of the member to be removed.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delMember = core.delMember;
 
@@ -1420,10 +1644,9 @@ define([
          * @param {string} name - the name of the set.
          * @param {module:Core~Node} member - the new member of the set.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.addMember = core.addMember;
 
@@ -1435,7 +1658,9 @@ define([
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberAttributeNames = core.getMemberAttributeNames;
 
@@ -1447,7 +1672,9 @@ define([
          *
          * @return {string[]} Returns the array of names of attributes that represents some property of the membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberOwnAttributeNames = core.getMemberOwnAttributeNames;
 
@@ -1461,7 +1688,9 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attributed connected to the given set membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberAttribute = core.getMemberAttribute;
 
@@ -1475,7 +1704,9 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the attribute. If it is undefined, than there
          * is no such attributed connected to the given set membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberOwnAttribute = core.getMemberOwnAttribute;
 
@@ -1487,10 +1718,9 @@ define([
          * @param {string} attrName - the name of the attribute.
          * @param {object|primitive|null} value - the new value of the attribute.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setMemberAttribute = core.setMemberAttribute;
 
@@ -1501,10 +1731,9 @@ define([
          * @param {string} memberPath - the absolute path of the member node.
          * @param {string} attrName - the name of the attribute.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delMemberAttribute = core.delMemberAttribute;
 
@@ -1517,7 +1746,9 @@ define([
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberRegistryNames = core.getMemberRegistryNames;
 
@@ -1531,7 +1762,9 @@ define([
          * @return {string[]} Returns the array of names of registry entries that represents some property of the
          * membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberOwnRegistryNames = core.getMemberOwnRegistryNames;
 
@@ -1545,7 +1778,9 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry connected to the given set membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberRegistry = core.getMemberRegistry;
 
@@ -1559,7 +1794,9 @@ define([
          * @return {object|primitive|null|undefined} Return the value of the registry. If it is undefined, than there
          * is no such registry connected to the given set membership.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMemberOwnRegistry = core.getMemberOwnRegistry;
 
@@ -1571,10 +1808,9 @@ define([
          * @param {string} regName - the name of the registry entry.
          * @param {object|primitive|null} value - the new value of the registry.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setMemberRegistry = core.setMemberRegistry;
 
@@ -1585,10 +1821,9 @@ define([
          * @param {string} memberPath - the absolute path of the member node.
          * @param {string} regName - the name of the registry entry.
          *
-         * @return {undefined | Error} If the set is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delMemberRegistry = core.delMemberRegistry;
 
@@ -1599,18 +1834,19 @@ define([
          * @return {object} Returns a dictionary where every the key of every entry is an absolute path of a set owner
          * node. The value of each entry is an array with the set names in which the node can be found as a member.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isMemberOf = core.isMemberOf;
-
-        //this.getMiddleGuid = core.getMiddleGuid;
 
         /**
          * Get the GUID of a node.
          * @param {module:Core~Node} node - the node in question.
          *
          * @return {module:Core~GUID} Returns the globally unique identifier.
-         * @func
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getGuid = core.getGuid;
 
@@ -1620,12 +1856,12 @@ define([
          * this function is only advised during the creation of the node.
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~GUID} guid - the new globally unique identifier.
-         * @param {function()} callback
+         * @param {function} callback[]
+         * @param {Error|null} callback.error - the result of the executiob.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setGuid = core.setGuid;
 
@@ -1636,13 +1872,17 @@ define([
          *
          * @return {module:Core~Constraint | null} Returns the defined constraint or null if it was not
          * defined for the node.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         *
          * @example
          * {
          *   script: "function (core, node, callback) {callback(null, {hasViolation: false, message: ''});}",
          *   priority: 1,
          *   info: "Should check unique name"
          * }
-         * @func
          */
         this.getConstraint = core.getConstraint;
 
@@ -1652,10 +1892,9 @@ define([
          * @param {string} name - the name of the constraint.
          * @param {module:Core~Constraint} constraint  - the constraint to be set.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setConstraint = core.setConstraint;
 
@@ -1664,10 +1903,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the constraint.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delConstraint = core.delConstraint;
 
@@ -1677,7 +1915,8 @@ define([
          *
          * @return {string[]} Returns the array of names of constraints available for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getConstraintNames = core.getConstraintNames;
 
@@ -1687,7 +1926,8 @@ define([
          *
          * @return {string[]} Returns the array of names of constraints for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnConstraintNames = core.getOwnConstraintNames;
 
@@ -1699,7 +1939,8 @@ define([
          * @return {bool} The function returns true if the type is in the inheritance chain of the node or false
          * otherwise. Every node is type of itself.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isTypeOf = core.isTypeOf;
 
@@ -1711,7 +1952,9 @@ define([
          * @return {bool} The function returns true if according to the META rules the node can be a child of the
          * parent. The check does not cover multiplicity (so if the parent can only have twi children and it already
          * has them, this function will still returns true).
-         * @func
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidChildOf = core.isValidChildOf;
 
@@ -1721,7 +1964,8 @@ define([
          *
          * @return {string[]} The function returns all the pointer names that are defined among the META rules of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidPointerNames = core.getValidPointerNames;
 
@@ -1731,7 +1975,8 @@ define([
          *
          * @return {string[]} The function returns all the set names that are defined among the META rules of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidSetNames = core.getValidSetNames;
 
@@ -1744,7 +1989,8 @@ define([
          * @return {bool} The function returns true if according to the META rules, the given node is a valid
          * target of the given pointer of the source.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidTargetOf = core.isValidTargetOf;
 
@@ -1755,7 +2001,8 @@ define([
          * @return {string[]} The function returns all the attribute names that are defined among the META rules of the
          * node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidAttributeNames = core.getValidAttributeNames;
 
@@ -1765,7 +2012,8 @@ define([
          *
          * @return {string[]} The function returns the attribute names that are defined specifically for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnValidAttributeNames = core.getOwnValidAttributeNames;
 
@@ -1777,7 +2025,8 @@ define([
          *
          * @return {bool} Returns true if the value matches the META definitions.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isValidAttributeValueOf = core.isValidAttributeValueOf;
 
@@ -1788,7 +2037,8 @@ define([
          * @return {string[]} The function returns all the aspect names that are defined among the META rules of the
          * node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidAspectNames = core.getValidAspectNames;
 
@@ -1798,7 +2048,8 @@ define([
          *
          * @return {string[]} The function returns the aspect names that are specifically defined for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnValidAspectNames = core.getOwnValidAspectNames;
 
@@ -1811,7 +2062,9 @@ define([
          * and fits to the META rules defined for the aspect. Any children, visible under the given aspect of the node
          * must be an instance of at least one node represented by the absolute paths.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAspectMeta = core.getAspectMeta;
 
@@ -1820,6 +2073,10 @@ define([
          * @param {module:Core~Node} node - the node in question.
          *
          * @return {object} Returns an object that represents all the META rules of the node.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         *
          * @example
          * {
          *   children: {
@@ -1867,7 +2124,6 @@ define([
          *   pointers: {},
          *   aspects: {},
          *   constraints: {}
-         * @func
          */
         this.getJsonMeta = core.getJsonMeta;
 
@@ -1877,9 +2133,9 @@ define([
          *
          * @return {object} The function returns an object that represent the META rules that were defined
          * specifically for the node.
-         * @example
-         * see getJsonMeta
-         * @func
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getOwnJsonMeta = core.getOwnJsonMeta;
 
@@ -1888,10 +2144,9 @@ define([
          * inherited rules).
          * @param {module:Core~Node} node - the node in question.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.clearMetaRules = core.clearMetaRules;
 
@@ -1906,10 +2161,9 @@ define([
          * @param {string|number|boolean} [rule.default] - The value the attribute should have at the node. If not given
          * it should be set at some point.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setAttributeMeta = core.setAttributeMeta;
 
@@ -1918,10 +2172,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the attribute.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAttributeMeta = core.delAttributeMeta;
 
@@ -1931,6 +2184,11 @@ define([
          * @param {string} name - the name of the attribute.
          *
          * @return {object} The function returns the definition object, where type is always defined.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         *
          * @example
          * {
          *    type: "string"
@@ -1974,7 +2232,6 @@ define([
          * {
          *    type: "asset"
          * }
-         * @func
          */
         this.getAttributeMeta = core.getAttributeMeta;
 
@@ -1985,7 +2242,8 @@ define([
          * @return {string[]} The function returns an array of absolute paths of the nodes that was defined as valid
          * children for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidChildrenPaths = core.getValidChildrenPaths;
 
@@ -1995,6 +2253,10 @@ define([
          *
          * @return {module:Core~RelationRule} The function returns a detailed JSON structure that represents the META
          * rules regarding the possible children of the node.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         *
          * @example
          * {
          *   '/5': { max: 1, min: -1 },
@@ -2015,10 +2277,9 @@ define([
          * @param {integer} [max] - the allowed maximum number of children from this given node type (if not given or
          * -1 is set, then there will be no minimum rule according this child type)
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setChildMeta = core.setChildMeta;
 
@@ -2027,10 +2288,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} childPath - the absolute path of the child which rule is to be removed from the node.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delChildMeta = core.delChildMeta;
 
@@ -2042,10 +2302,9 @@ define([
          * @param {integer} [max] - the allowed maximum number of children (if not given or
          * -1 is set, then there will be no maximum rule according children)
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setChildrenMetaLimits = core.setChildrenMetaLimits;
 
@@ -2059,10 +2318,9 @@ define([
          * @param {integer} [max] - the allowed maximum number of target/member from this given node type (if not
          * given or -1 is set, then there will be no minimum rule according this target type)
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setPointerMetaTarget = core.setPointerMetaTarget;
 
@@ -2072,10 +2330,9 @@ define([
          * @param {string} name - the name of the pointer/set
          * @param {string} targetPath - the absolute path of the possible target type.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delPointerMetaTarget = core.delPointerMetaTarget;
 
@@ -2089,10 +2346,9 @@ define([
          * @param {integer} [max] - the allowed maximum number of children (if not given or
          * -1 is set, then there will be no maximum rule according targets)
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setPointerMetaLimits = core.setPointerMetaLimits;
 
@@ -2101,10 +2357,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the pointer/set.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delPointerMeta = core.delPointerMeta;
 
@@ -2115,6 +2370,11 @@ define([
          *
          * @return {module:Core~RelationRule} The function returns a detailed JSON structure that represents the META
          * rules regarding the given pointer/set of the node.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         *
          * @example
          * pointer
          * {
@@ -2130,7 +2390,6 @@ define([
          *   max: -1
          *   min: -1
          * }
-         * @func
          */
         this.getPointerMeta = core.getPointerMeta;
 
@@ -2140,10 +2399,9 @@ define([
          * @param {string} name - the name of the aspect.
          * @param {module:Core~Node} target - the valid type for the aspect.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.setAspectMetaTarget = core.setAspectMetaTarget;
 
@@ -2153,10 +2411,9 @@ define([
          * @param {string} name - the name of the aspect.
          * @param {string} targetPath - the absolute path of the valid type of the aspect.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAspectMetaTarget = core.delAspectMetaTarget;
 
@@ -2165,10 +2422,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the aspect.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAspectMeta = core.delAspectMeta;
 
@@ -2180,7 +2436,8 @@ define([
          * that is a META node. It returns null if it does not find such node (ideally the only node with this result
          * is the ROOT).
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBaseType = this.getMetaType = core.getBaseType;
 
@@ -2191,33 +2448,36 @@ define([
          *
          * @return {bool} The function returns true if it finds an ancestor with the given name attribute.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isInstanceOf = core.isInstanceOf;
-
-        //this.nodeDiff = core.nodeDiff;
 
         /**
          * Generates a differential tree among the two states of the project that contains the necessary changes
          * that can modify the source to be identical to the target. The result is in form of a json object.
          * @param {module:Core~Node} sourceRoot - the root node of the source state.
          * @param {module:Core~Node} targetRoot - the root node of the target state.
+         * @param {function} callback[]
+         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the exectuion.
+         * @param {object} callback.treeDiff - the difference between the two containment hierarchies in
+         * a special JSON object
          *
-         * @param {function(string, object)} callback
+         * @return {External~Promise} - if the callback is not defined, the result is provided in a promise
+         * like manner.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.generateTreeDiff = core.generateTreeDiff;
-
-        //this.generateLightTreeDiff = core.generateLightTreeDiff;
 
         /**
          * Apply changes to the current project.
          * @param {module:Core~Node} root - the root of the containment hierarchy where we wish to apply the changes
          * @param {object} patch - the tree structured collection of changes represented with a special JSON object
-         * @param {function(string)} callback
+         * @param {function} callback[]
+         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.applyTreeDiff = core.applyTreeDiff;
 
@@ -2231,7 +2491,8 @@ define([
          * @return {object} The function returns with an object that contains the conflicts (if any) and the merged
          * patch.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.tryToConcatChanges = core.tryToConcatChanges;
 
@@ -2246,7 +2507,8 @@ define([
          * @return {object} The function results in a tree structured patch object that contains the changesthat cover
          * both parties modifications (and the conflicts are resolved according the input settings).
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.applyResolution = core.applyResolution;
 
@@ -2257,7 +2519,8 @@ define([
          * @return {bool} The function returns true if the registry entry 'isAbstract' of the node if true hence
          * the node is abstract.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isAbstract = core.isAbstract;
 
@@ -2267,7 +2530,8 @@ define([
          *
          * @return {bool} Returns true if both the 'src' and 'dst' pointer are defined as valid for the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isConnection = core.isConnection;
 
@@ -2286,7 +2550,8 @@ define([
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * child of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidChildrenMetaNodes = core.getValidChildrenMetaNodes;
 
@@ -2305,7 +2570,8 @@ define([
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * member of the set of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getValidSetElementsMetaNodes = core.getValidSetElementsMetaNodes;
 
@@ -2316,7 +2582,8 @@ define([
          * @return {Object<string, module:Core~Node>} The function returns a dictionary. The keys of the dictionary are the absolute paths of
          * the META nodes of the project. Every value of the dictionary is a {@link module:Core~Node}.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getAllMetaNodes = core.getAllMetaNodes;
 
@@ -2327,7 +2594,8 @@ define([
          * @return {bool} Returns true if the node is a member of the METAAspectSet of the ROOT node hence can be
          * seen as a META node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isMetaNode = core.isMetaNode;
 
@@ -2342,7 +2610,9 @@ define([
          * or the member do not have a 'base' member or just some property was overridden, the function returns
          * false.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isFullyOverriddenMember = core.isFullyOverriddenMember;
 
@@ -2356,7 +2626,8 @@ define([
          * @return {module:Core~MixinViolation[]} Returns the array of violations. If the array is empty,
          * there is no violation.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinErrors = core.getMixinErrors;
 
@@ -2367,7 +2638,8 @@ define([
          *
          * @return {string[]} The paths of the mixins in an array.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinPaths = core.getMixinPaths;
 
@@ -2378,7 +2650,8 @@ define([
          *
          * @return {Object<string, module:Core~Node>} The dictionary of the mixin nodes keyed by their paths.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getMixinNodes = core.getMixinNodes;
 
@@ -2388,10 +2661,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} mixinPath - the path of the mixin node.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delMixin = core.delMixin;
 
@@ -2401,10 +2673,9 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} mixinPath - the path of the mixin node.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.addMixin = core.addMixin;
 
@@ -2413,10 +2684,8 @@ define([
          *
          * @param {module:Core~Node} node - the node in question.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.clearMixins = core.clearMixins;
 
@@ -2427,7 +2696,8 @@ define([
          * @return {Object<string, module:Core~Node>} Returns the closest Meta node that is a base of the given node
          * plus it returns all the mixin nodes associated with the base in a path-node dictionary.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getBaseTypes = core.getBaseTypes;
 
@@ -2437,9 +2707,8 @@ define([
          * @param {module:Core~Node} node - the node in question.
          * @param {string} mixinPath - the path of the mixin node.
          *
-         * @return {Object} - Returns if the mixin could be added, or the reason why it is not.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.canSetAsMixin = core.canSetAsMixin;
 
@@ -2459,9 +2728,13 @@ define([
          * @param {string} libraryInfo.projectId - the projectId of your library.
          * @param {string} libraryInfo.branchName - the branch that your library follows in the origin project.
          * @param {string} libraryInfo.commitHash - the version of your library.
-         * @param {function()} callback
+         * @param {function} callback[]
+         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * result of the execution.
          *
-         * @func
+         * @return {External~Promise} If no callback is given, the result is provided in a promise like manner.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.addLibrary = core.addLibrary;
 
@@ -2476,9 +2749,13 @@ define([
          * @param {string} libraryInfo.projectId - the projectId of your library.
          * @param {string} libraryInfo.branchName - the branch that your library follows in the origin project.
          * @param {string} libraryInfo.commitHash - the version of your library.
-         * @param {function()} callback
+         * @param {function} callback[]
+         * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
+         * status of the execution.
          *
-         * @func
+         * @return {External~Promise} If no callback is given, the result is presented in a promise like manner.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.updateLibrary = core.updateLibrary;
 
@@ -2490,7 +2767,8 @@ define([
          * @return {string[]} - Returns the fully qualified names of all the libraries in your project
          * (even embedded ones).
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryNames = core.getLibraryNames;
 
@@ -2501,7 +2779,8 @@ define([
          *
          * @return {module:Core~Node} - Returns the acting FCO of your project.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getFCO = core.getFCO;
 
@@ -2513,7 +2792,8 @@ define([
          * @return {bool} - Returns true if your node is a library root (even if it is embedded in other library),
          * false otherwise.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isLibraryRoot = core.isLibraryRoot;
 
@@ -2524,7 +2804,8 @@ define([
          *
          * @return {bool} - Returns true if your node is a library element, false otherwise.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.isLibraryElement = core.isLibraryElement;
 
@@ -2537,9 +2818,10 @@ define([
          *
          * @return {string} - Returns the name space of the node.
          *
-         * @example NS1.NS2
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
-         * @func
+         * @example NS1.NS2
          */
         this.getNamespace = core.getNamespace;
 
@@ -2552,9 +2834,11 @@ define([
          * @return {string} - Returns the fully qualified name of the node,
          * i.e. its namespaces and name join together by dots.
          *
-         * @example NS1.NS2.name
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          *
-         * @func
+         * @example NS1.NS2.name
          */
         this.getFullyQualifiedName = core.getFullyQualifiedName;
 
@@ -2564,7 +2848,9 @@ define([
          * @param {module:Core~Node} node - any node in your project.
          * @param {string} name - the name of your library.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.removeLibrary = core.removeLibrary;
 
@@ -2578,7 +2864,9 @@ define([
          * @return {module:Core~GUID | Error} - Returns the origin GUID of the node or
          * error if the query cannot be fulfilled.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryGuid = core.getLibraryGuid;
 
@@ -2589,7 +2877,9 @@ define([
          * @param {string} oldName - the current name of the library.
          * @param {string} newName - the new name of the project.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.renameLibrary = core.renameLibrary;
 
@@ -2602,7 +2892,9 @@ define([
          * @return {object} - Returns the information object, stored alongside the library (that basically
          * carries metaData about the library).
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryInfo = core.getLibraryInfo;
 
@@ -2614,7 +2906,9 @@ define([
          *
          * @return {module:Core~Node | null} - Returns the library root node or null, if the library is unknown.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryRoot = core.getLibraryRoot;
 
@@ -2629,7 +2923,9 @@ define([
          * @return {module:Core~Node[]} - Returns an array of core nodes that are part of your meta from
          * the given library.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getLibraryMetaNodes = core.getLibraryMetaNodes;
 
@@ -2644,16 +2940,55 @@ define([
          * or depth first.
          * @param {integer} [options.maxParallelLoad = 100]- the maximum number of parallel loads allowed.
          * @param {bool} [options.stopOnError = true]- controls if the traverse should stop in case of error.
-         * @param {function(module:Core~Node,function)} visitFn - the visitation function that will be called for
+         * @param {function} visitFn - the visitation function that will be called for
          * every node in the sub-tree, the second parameter of the function is a callback that should be called to
          * note to the traversal function that the visitation for a given node finished.
-         * @param {function()} callback
+         * @param {module:Core~Node} visitFn.node - the node that is being visited.
+         * @param {function} visitFn.next - the callback function of the visit function that marks the end
+         * of visitation.
+         * @param {function} callback[]
+         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
          *
-         * @func
+         * @return {External~Promise} If no callback is given, the end of traverse is marked in a promise like
+         * manner.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.traverse = core.traverse;
 
+        /**
+         * Collects the necessary information to export the set of input nodes and use it in other
+         * - compatible - projects.
+         * @private
+         *
+         * @param {module:Core~Node[]} nodesToExport - the set of nodes that we want to export
+         *
+         * @return {object} If the closure is available for export, the returned special JSON object
+         * will contain information about the necessary data that needs to be exported as well as relations
+         * that will need to be recreated in the destination project to preserve the structure of nodes.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         */
         this.getClosureInformation = core.getClosureInformation;
+
+        /**
+         * Imports the set of nodes in the closureInformation - that has the format created by
+         * [getClosureInformation]{@link Core#getClosureInformation} - as direct children of the parent node.
+         * All data necessary for importing the closure has to be imported beforehand!
+         * @private
+         *
+         * @param {module:Core~Node} node - the parent node where the closure will be imported.
+         * @param {object} closureInformation - the information about the closure.
+         *
+         * @return {object} If the closure cannot be imported the resulting error highlights the causes,
+         * otherwise a specific object will be returned that holds information about the closure.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         */
         this.importClosure = core.importClosure;
 
         /**
@@ -2662,16 +2997,22 @@ define([
          *
          *@return {string[]} The function returns an array of the absolute paths of the instances.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.getInstancePaths = core.getInstancePaths;
 
         /**
          * Loads all the instances of the given node.
          * @param {module:Core~Node} node - the node in question.
-         * @param {function(string, module:Core~Node[])} callback
+         * @param {function(string, module:Core~Node[])} callback[]
+         * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
+         * @param {module:Core~Node[]} callback.nodes - the found instances of the node.
          *
-         * @func
+         * @return {External~Promise} If no callback is given, the result will be provided in a promise
+         * like manner.
+         *
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
          */
         this.loadInstances = core.loadInstances;
     }

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -155,6 +155,18 @@ define([
         }
     }
 
+    function ensureValue(input, nameOfInput, isAsync) {
+        var error;
+        if (input === undefined) {
+            error = new CoreInputError('Parameter \'' + nameOfInput + '\' cannot be undefined.');
+            if (isAsync) {
+                return error;
+            } else {
+                throw error;
+            }
+        }
+    }
+
     function ensureInstanceOf(input, nameOfInput, type, isAsync) {
         var error;
         if (!input instanceof type) {
@@ -845,9 +857,14 @@ define([
          *
          * @return {string[]} The function returns an array of the names of the attributes of the node.
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getAttributeNames = core.getAttributeNames;
+        this.getAttributeNames = function (node) {
+            ensureNode(node, 'node');
+
+            return core.getAttributeNames(node);
+        };
 
         /**
          * Retrieves the value of the given attribute of the given node.
@@ -858,9 +875,15 @@ define([
          * The value can be an object or any primitive type. If the value is undefined that means the node do not have
          * such attribute defined. [The retrieved attribute should not be modified as is - it should be copied first!!]
          *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.getAttribute = core.getAttribute;
+        this.getAttribute = function (node, name) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+
+            return core.getAttribute(node, name);
+        };
 
         /**
          * Sets the value of the given attribute of the given node. It defines the attribute on demand, means that it
@@ -870,22 +893,26 @@ define([
          * @param {object | primitive | null} value - the new of the attribute. Can be any primitive type or object.
          * Undefined is not allowed.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.setAttribute = core.setAttribute;
+        this.setAttribute = function (node, name, value) {
+            ensureNode(node, 'node');
+            ensureType(name, 'name', 'string');
+            ensureValue(value, 'value');
+
+            return core.setAttribute(node, name, value);
+        };
 
         /**
          * Removes the given attributes from the given node.
          * @param {module:Core~Node} node - the node in question.
          * @param {string} name - the name of the attribute.
          *
-         * @return {undefined | Error} If the node is not allowed to be modified, the function returns
-         * an error.
-         *
-         * @func
+         * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
+         * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
         this.delAttribute = core.delAttribute;
 

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -420,7 +420,7 @@ define([
         /**
          * Loads the data object with the given hash and makes it a root of a containment hierarchy.
          * @param {module:Core~ObjectHash} hash - the hash of the data object we like to load as root.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting root node
          *
@@ -449,7 +449,7 @@ define([
          * hierarchy. If there is no such relative id reserved, the call will return with null.
          * @param {module:Core~Node} parent - the container node in question.
          * @param {string} relativeId - the relative id of the child in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting child
          *
@@ -476,7 +476,7 @@ define([
          * and returns the node it finds at the ends of the path. If there is no node, the function will return null.
          * @param {module:Core~Node} node - the starting node of our search.
          * @param {string} relativePath - the relative path - built by relative ids - of the node in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting node
          *
@@ -502,7 +502,7 @@ define([
          * Loads all the children of the given parent. As it first checks the already reserved relative ids of
          * the parent, it only loads the already existing children (so no on-demand empty node creation).
          * @param {module:Core~Node} node - the container node in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.children - the resulting children
          *
@@ -528,7 +528,7 @@ define([
          * the already reserved relative ids of the parent, it only loads the already existing children
          * (so no on-demand empty node creation).
          * @param {module:Core~Node} node - the container node in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting children
          *
@@ -556,7 +556,7 @@ define([
          * finally if the returned value is undefined than there is no such pointer defined for the given node.
          * @param {module:Core~Node} node - the source node in question.
          * @param {string} pointerName - the name of the pointer.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node} callback.node - the resulting target
          *
@@ -590,7 +590,7 @@ define([
          * Loads all the source nodes that has such a pointer and its target is the given node.
          * @param {module:Core~Node} node - the target node in question.
          * @param {string} pointerName - the name of the pointer of the sources.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
@@ -622,7 +622,7 @@ define([
         /**
          * Loads a complete sub-tree of the containment hierarchy starting from the given node.
          * @param {module:Core~Node} node - the node that is the root of the sub-tree in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
@@ -647,7 +647,7 @@ define([
          * Loads a complete sub-tree of the containment hierarchy starting from the given node, but load only those
          * children that has some additional data and not purely inherited.
          * @param {module:Core~Node} node - the container node in question.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution
          * @param {module:Core~Node[]} callback.node - the resulting sources
          *
@@ -672,7 +672,7 @@ define([
          * Loads a complete containment hierarchy using the data object - pointed by the given hash -
          * as the root.
          * @param {module:Core~ObjectHash} hash - hash of the root node.
-         * @param {function} callback
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution.
          * @param {module:Core~Node[]} callback.nodes - the resulting nodes.
          *
@@ -2184,7 +2184,7 @@ define([
          * this function is only advised during the creation of the node.
          * @param {module:Core~Node} node - the node in question.
          * @param {module:Core~GUID} guid - the new globally unique identifier.
-         * @param {function} callback[]
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * result of the execution.
          *
@@ -2924,7 +2924,7 @@ define([
             ensureType(name, 'name', 'string');
 
             return core.getPointerMeta(node, name);
-        }
+        };
 
         /**
          * Sets a valid type for the given aspect of the node.
@@ -3029,7 +3029,7 @@ define([
          * that can modify the source to be identical to the target. The result is in form of a json object.
          * @param {module:Core~Node} sourceRoot - the root node of the source state.
          * @param {module:Core~Node} targetRoot - the root node of the target state.
-         * @param {function} callback[]
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the exectuion.
          * @param {object} callback.treeDiff - the difference between the two containment hierarchies in
          * a special JSON object
@@ -3056,7 +3056,7 @@ define([
          * Apply changes to the current project.
          * @param {module:Core~Node} node - the root of the containment hierarchy where we wish to apply the changes
          * @param {object} patch - the tree structured collection of changes represented with a special JSON object
-         * @param {function} callback[]
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the result of the execution.
          *
          * @throws {CoreInputError} If some of the parameters doesn't match the input criteria.
@@ -3279,7 +3279,7 @@ define([
             }
 
             return core.isFullyOverriddenMember(node, name, path);
-        }
+        };
 
         /**
          * Checks if the mixins allocated with the node can be used.
@@ -3428,11 +3428,11 @@ define([
          * @param {string} name - the name of the library you wish to use as a namespace in your project.
          * @param {string} libraryRootHash - the hash of your library's root
          * (must exist in the project's collection at the time of call).
-         * @param {Object} libraryInfo[] - information about your project.
-         * @param {string} libraryInfo.projectId[] - the projectId of your library.
-         * @param {string} libraryInfo.branchName[] - the branch that your library follows in the origin project.
-         * @param {string} libraryInfo.commitHash[] - the version of your library.
-         * @param {function} callback[]
+         * @param {object} [libraryInfo] - information about your project.
+         * @param {string} [libraryInfo.projectId] - the projectId of your library.
+         * @param {string} [libraryInfo.branchName] - the branch that your library follows in the origin project.
+         * @param {string} [libraryInfo.commitHash] - the version of your library.
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * result of the execution.
          *
@@ -3471,12 +3471,12 @@ define([
          * @param {string} name - the name of the library you want to update.
          * @param {string} libraryRootHash - the hash of your library's new root
          * (must exist in the project's collection at the time of call).
-         * @param {object} libraryInfo[] - information about your project.
-         * @param {string} libraryInfo.projectId[] - the projectId of your library.
-         * @param {string} libraryInfo.branchName[] - the branch that your library follows in the origin project.
-         * @param {string} libraryInfo.commitHash[] - the version of your library.
-         * @param {*} updateInstructions - not yet used parameter.
-         * @param {function} callback[]
+         * @param {object} [libraryInfo] - information about your project.
+         * @param {string} [libraryInfo.projectId] - the projectId of your library.
+         * @param {string} [libraryInfo.branchName] - the branch that your library follows in the origin project.
+         * @param {string} [libraryInfo.commitHash] - the version of your library.
+         * @param updateInstructions - not yet used parameter.
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreIllegalOperationError|CoreAssertError|null} callback.error - the
          * status of the execution.
          *
@@ -3641,7 +3641,7 @@ define([
          * Returns the origin GUID of any library node.
          *
          * @param {module:Core~Node} node - the node in question.
-         * @param {undefined | string} name[] - name of the library where we want to deduct the GUID from. If not given,
+         * @param {undefined | string} [name] - name of the library where we want to deduct the GUID from. If not given,
          * than the GUID is computed from the direct library root of the node
          *
          * @return {module:Core~GUID | Error} - Returns the origin GUID of the node or
@@ -3760,7 +3760,7 @@ define([
          * @param {module:Core~Node} visitFn.node - the node that is being visited.
          * @param {function} visitFn.next - the callback function of the visit function that marks the end
          * of visitation.
-         * @param {function} callback[]
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
          *
          * @return {External~Promise} If no callback is given, the end of traverse is marked in a promise like
@@ -3861,7 +3861,7 @@ define([
         /**
          * Loads all the instances of the given node.
          * @param {module:Core~Node} node - the node in question.
-         * @param {function(string, module:Core~Node[])} callback[]
+         * @param {function} [callback]
          * @param {Error|CoreInputError|CoreAssertError|null} callback.error - the status of the execution.
          * @param {module:Core~Node[]} callback.nodes - the found instances of the node.
          *
@@ -3879,7 +3879,7 @@ define([
                 core.loadInstances(node, callback);
             }
         };
-    };
+    }
 
     return Core;
 });

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -9,7 +9,7 @@
 
 define(['common/util/canon',
     'common/core/tasync',
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/regexp',
     'common/util/random',
     'common/core/constants',

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -6,7 +6,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/core/tasync',
     'common/util/random',
     'common/core/constants',

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -6,7 +6,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/util/key',
     'common/core/tasync',
     'common/util/random',

--- a/src/common/core/coretreeloader.js
+++ b/src/common/core/coretreeloader.js
@@ -5,7 +5,7 @@
  * @author kecso / https://github.com/kecso
  */
 
-define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
+define(['common/core/CoreAssert', 'common/core/tasync'], function (ASSERT, TASYNC) {
     'use strict';
 
     var CoreTreeLoader = function (innerCore, options) {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -6,7 +6,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/core/tasync',
     'common/core/constants'
 ], function (ASSERT, TASYNC, CONSTANTS) {

--- a/src/common/core/coreunwrap.js
+++ b/src/common/core/coreunwrap.js
@@ -5,7 +5,7 @@
  * @author mmaroti / https://github.com/mmaroti
  */
 
-define(['common/util/assert', 'common/core/tasync'], function (ASSERT, TASYNC) {
+define(['common/core/CoreAssert', 'common/core/tasync'], function (ASSERT, TASYNC) {
     'use strict';
 
     // ----------------- CoreUnwrap -----------------

--- a/src/common/core/guidcore.js
+++ b/src/common/core/guidcore.js
@@ -5,7 +5,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/core/tasync',
     'common/regexp',
     'common/util/random',

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -9,8 +9,9 @@ define([
         'common/core/CoreAssert',
         'common/core/tasync',
         'common/core/constants',
-        'common/util/random'
-    ], function (ASSERT, TASYNC, CONSTANTS, RANDOM) {
+        'common/util/random',
+        'common/core/CoreIllegalOperationError'
+    ], function (ASSERT, TASYNC, CONSTANTS, RANDOM, CoreIllegalOperationError) {
         'use strict';
 
         var LibraryCore = function (innerCore, options) {
@@ -483,11 +484,11 @@ define([
 
                 if (parameters && parameters.parent &&
                     (self.isLibraryRoot(parameters.parent) || self.isLibraryElement(parameters.parent))) {
-                    return new Error('Not allowed to create new node inside library.');
+                    throw new CoreIllegalOperationError('Not allowed to create new node inside library.');
                 }
 
                 if (parameters && parameters.base && self.isLibraryRoot(parameters.base)) {
-                    return new Error('Not allowed to instantiate library root.');
+                    throw new CoreIllegalOperationError('Not allowed to instantiate library root.');
                 }
 
                 node = innerCore.createNode(parameters);
@@ -500,7 +501,8 @@ define([
 
             this.deleteNode = function (node, technical) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to remove library node by simply deleting them.');
+                    throw new CoreIllegalOperationError('Not allowed to remove library node by simply deleting them.');
+
                 }
 
                 return innerCore.deleteNode(node, technical);
@@ -508,11 +510,11 @@ define([
 
             this.copyNode = function (node, parent) {
                 if (self.isLibraryRoot(parent) || self.isLibraryElement(parent)) {
-                    return new Error('Not allowed to add nodes inside a library.');
+                    throw new CoreIllegalOperationError('Not allowed to add nodes inside a library.');
                 }
 
                 if (self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to copy library root.');
+                    throw new CoreIllegalOperationError('Not allowed to copy library root.');
                 }
 
                 return innerCore.copyNode(node, parent);
@@ -521,12 +523,12 @@ define([
             this.copyNodes = function (nodes, parent) {
                 var i;
                 if (self.isLibraryRoot(parent) || self.isLibraryElement(parent)) {
-                    return new Error('Not allowed to add nodes inside a library.');
+                    throw new CoreIllegalOperationError('Not allowed to add nodes inside a library.');
                 }
 
                 for (i = 0; i < nodes.length; i += 1) {
                     if (self.isLibraryRoot(nodes[i])) {
-                        return new Error('Not allowed to copy library root.');
+                        throw new CoreIllegalOperationError('Not allowed to copy library root.');
                     }
                 }
 
@@ -535,11 +537,11 @@ define([
 
             this.moveNode = function (node, parent) {
                 if (self.isLibraryRoot(parent) || self.isLibraryElement(parent)) {
-                    return new Error('Not allowed to add nodes inside a library.');
+                    throw new CoreIllegalOperationError('Not allowed to add nodes inside a library.');
                 }
 
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to move library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to move library elements.');
                 }
 
                 return innerCore.moveNode(node, parent);

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -6,7 +6,7 @@
  */
 
 define([
-        'common/util/assert',
+        'common/core/CoreAssert',
         'common/core/tasync',
         'common/core/constants',
         'common/util/random'

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -350,7 +350,8 @@ define([
                     i;
 
                 for (i = 0; i < keys.length; i += 1) {
-                    if (closureInformation.bases[baseGuid].originGuid === self.getLibraryGuid(allMetaNodes[keys[i]]) ||
+                    if ((self.isLibraryElement(allMetaNodes[keys[i]]) &&
+                        closureInformation.bases[baseGuid].originGuid === self.getLibraryGuid(allMetaNodes[keys[i]])) ||
                         closureInformation.bases[baseGuid].originGuid === self.getGuid(allMetaNodes[keys[i]])) {
                         occurrences.push(allMetaNodes[keys[i]]);
                     }
@@ -376,7 +377,7 @@ define([
                     if (!closureInformation.destinationBases[keys[i]]) {
                         occurrences = gatherOccurancesOfType(keys[i], closureInformation, allMetaNodes);
                         if (occurrences.length === 0) {
-                            return new Error('Cannot find necessary base [' +
+                            throw new CoreIllegalOperationError('Cannot find necessary base [' +
                                 closureInformation.bases[keys[i]].fullName + ' : ' + keys[i] + ']');
                         } else if (occurrences.length === 1) {
                             closureInformation.destinationBases[keys[i]] = self.getPath(occurrences[0]);
@@ -388,7 +389,7 @@ define([
                                     ' : ' + self.getPath(occurrences[j]) + '] ';
                             }
                             errorTxt += ')';
-                            return new Error(errorTxt);
+                            throw new CoreIllegalOperationError(errorTxt);
                         }
 
                     }
@@ -549,7 +550,7 @@ define([
 
             this.setAttribute = function (node, name, value) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setAttribute(node, name, value);
@@ -557,7 +558,7 @@ define([
 
             this.delAttribute = function (node, name) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delAttribute(node, name);
@@ -565,7 +566,7 @@ define([
 
             this.setRegistry = function (node, name, value) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setRegistry(node, name, value);
@@ -573,7 +574,7 @@ define([
 
             this.delRegistry = function (node, name) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delRegistry(node, name);
@@ -581,7 +582,7 @@ define([
 
             this.setPointer = function (node, name, target) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setPointer(node, name, target);
@@ -589,7 +590,7 @@ define([
 
             this.deletePointer = function (node, name) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.deletePointer(node, name);
@@ -597,11 +598,11 @@ define([
 
             this.setBase = function (node, base) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 if (base && self.isLibraryRoot(base)) {
-                    return new Error('Not allowed to instantiate library root.');
+                    throw new CoreIllegalOperationError('Not allowed to instantiate library root.');
                 }
 
                 return innerCore.setBase(node, base);
@@ -609,7 +610,7 @@ define([
 
             this.addMember = function (node, name, member) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.addMember(node, name, member);
@@ -617,7 +618,7 @@ define([
 
             this.delMember = function (node, name, path) {
                 if (self.isLibraryElement(node) || self.isLibraryRoot(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delMember(node, name, path);
@@ -625,70 +626,70 @@ define([
 
             this.setMemberAttribute = function (node, setName, memberPath, attrName, value) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.setMemberAttribute(node, setName, memberPath, attrName, value);
             };
 
             this.delMemberAttribute = function (node, setName, memberPath, attrName) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.delMemberAttribute(node, setName, memberPath, attrName);
             };
 
             this.setMemberRegistry = function (node, setName, memberPath, regName, value) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.setMemberRegistry(node, setName, memberPath, regName, value);
             };
 
             this.delMemberRegistry = function (node, setName, memberPath, regName) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.delMemberRegistry(node, setName, memberPath, regName);
             };
 
             this.createSet = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.createSet(node, name);
             };
 
             this.deleteSet = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.deleteSet(node, name);
             };
 
             this.setSetAttribute = function (node, setName, regName, regValue) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.setSetAttribute(node, setName, regName, regValue);
             };
 
             this.delSetAttribute = function (node, setName, regName) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.delSetAttribute(node, setName, regName);
             };
 
             this.setSetRegistry = function (node, setName, regName, regValue) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.setSetRegistry(node, setName, regName, regValue);
             };
 
             this.delSetRegistry = function (node, setName, regName) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.delSetRegistry(node, setName, regName);
             };
@@ -696,7 +697,7 @@ define([
             this.setGuid = function (node, guid) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
                     //FIXME cannot return any error in async functions :/
-                    // /return new Error('Not allowed to modify library elements.');
+                    // /throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 } else {
                     return innerCore.setGuid(node, guid);
                 }
@@ -704,21 +705,21 @@ define([
 
             this.setConstraint = function (node, name, constraint) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.setConstraint(node, name, constraint);
             };
 
             this.delConstraint = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
                 return innerCore.delConstraint(node, name);
             };
 
             this.clearMetaRules = function (node) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.clearMetaRules(node);
@@ -726,7 +727,7 @@ define([
 
             this.setAttributeMeta = function (node, name, rule) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setAttributeMeta(node, name, rule);
@@ -734,7 +735,7 @@ define([
 
             this.delAttributeMeta = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delAttributeMeta(node, name);
@@ -742,11 +743,11 @@ define([
 
             this.setChildMeta = function (node, child, min, max) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 if (self.isLibraryRoot(child)) {
-                    return new Error('Not allowed to use library root as valid child.');
+                    throw new CoreIllegalOperationError('Not allowed to use library root as valid child.');
                 }
 
                 return innerCore.setChildMeta(node, child, min, max);
@@ -754,7 +755,7 @@ define([
 
             this.delChildMeta = function (node, childPath) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delChildMeta(node, childPath);
@@ -762,7 +763,7 @@ define([
 
             this.setChildrenMetaLimits = function (node, min, max) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setChildrenMetaLimits(node, min, max);
@@ -770,7 +771,7 @@ define([
 
             this.setPointerMetaTarget = function (node, name, target, min, max) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setPointerMetaTarget(node, name, target, min, max);
@@ -778,7 +779,7 @@ define([
 
             this.delPointerMetaTarget = function (node, name, targetPath) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delPointerMetaTarget(node, name, targetPath);
@@ -786,7 +787,7 @@ define([
 
             this.setPointerMetaLimits = function (node, name, min, max) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setPointerMetaLimits(node, name, min, max);
@@ -794,7 +795,7 @@ define([
 
             this.delPointerMeta = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delPointerMeta(node, name);
@@ -802,7 +803,7 @@ define([
 
             this.setAspectMetaTarget = function (node, name, target) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.setAspectMetaTarget(node, name, target);
@@ -810,7 +811,7 @@ define([
 
             this.delAspectMetaTarget = function (node, name, targetPath) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delAspectMetaTarget(node, name, targetPath);
@@ -818,7 +819,7 @@ define([
 
             this.delAspectMeta = function (node, name) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delAspectMeta(node, name);
@@ -826,7 +827,7 @@ define([
 
             this.delMixin = function (node, mixinPath) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.delMixin(node, mixinPath);
@@ -837,12 +838,12 @@ define([
                     root = self.getRoot(node);
 
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 for (libraryName in root.libraryRoots) {
                     if (self.getPath(root.libraryRoots[libraryName]) === mixinPath) {
-                        return new Error('Not allowed to use library root as mixin.');
+                        throw new CoreIllegalOperationError('Not allowed to use library root as mixin.');
                     }
                 }
 
@@ -851,7 +852,7 @@ define([
 
             this.clearMixins = function (node) {
                 if (self.isLibraryRoot(node) || self.isLibraryElement(node)) {
-                    return new Error('Not allowed to modify library elements.');
+                    throw new CoreIllegalOperationError('Not allowed to modify library elements.');
                 }
 
                 return innerCore.clearMixins(node);
@@ -907,7 +908,7 @@ define([
                 var libraryRoot;
 
                 if (!self.isLibraryElement(node) && !self.isLibraryRoot(node)) {
-                    return new Error('Node is not a library member');
+                    throw new CoreIllegalOperationError('Node is not a library member');
                 }
 
                 if (!name) {
@@ -917,11 +918,11 @@ define([
                 }
 
                 if (!libraryRoot) {
-                    return new Error('Unknown library was given');
+                    throw new CoreIllegalOperationError('Unknown library was given');
                 }
 
                 if (self.getFullyQualifiedName(node).indexOf(self.getFullyQualifiedName(libraryRoot)) !== 0) {
-                    return new Error('Node is not a member of the library');
+                    throw new CoreIllegalOperationError('Node is not a member of the library');
                 }
 
                 if (self.isLibraryRoot(node) && self.getPath(node) === self.getPath(libraryRoot)) {
@@ -1135,12 +1136,12 @@ define([
                 for (i = 0; i < nodes.length; i += 1) {
                     // The selection cannot contain library elements as that would violate read-only
                     if (this.isLibraryElement(nodes[i]) || this.isLibraryRoot(nodes[i])) {
-                        return new Error('Cannot select node[' +
+                        throw new CoreIllegalOperationError('Cannot select node[' +
                             this.getPath(nodes[i]) + '] because it is library content!'
                         );
                     }
                     if (this.getParent(nodes[i]) === null) {
-                        return new Error('Cannot select the project root!');
+                        throw new CoreIllegalOperationError('Cannot select the project root!');
                     }
                     closureInfo.selection[this.getPath(nodes[i])] = this.getGuid(nodes[i]);
                     closureInfo.hashes[this.getPath(nodes[i])] = this.getHash(nodes[i]);
@@ -1177,7 +1178,7 @@ define([
                 for (path in closureInfo.relations.lost) {
                     if (closureInfo.relations.lost[path][CONSTANTS.BASE_POINTER]) {
                         //we do not allow external non-Meta bases
-                        return new Error('Closure cannot be created due to [' + path +
+                        throw new CoreIllegalOperationError('Closure cannot be created due to [' + path +
                             '] misses its base [' + closureInfo.relations.lost[path][CONSTANTS.BASE_POINTER] + '].');
                     }
                 }

--- a/src/common/core/metacachecore.js
+++ b/src/common/core/metacachecore.js
@@ -6,7 +6,7 @@
  */
 
 define([
-        'common/util/assert',
+        'common/core/CoreAssert',
         'common/core/tasync',
         'common/core/constants'
     ], function (ASSERT, TASYNC, CONSTANTS) {

--- a/src/common/core/metacore.js
+++ b/src/common/core/metacore.js
@@ -6,7 +6,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/core/tasync',
     'common/util/canon',
     'common/core/constants'

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -6,7 +6,7 @@
  */
 
 define([
-    'common/util/assert'
+    'common/core/CoreAssert'
 ], function (ASSERT) {
     'use strict';
 

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -5,7 +5,7 @@
  */
 
 define([
-    'common/util/assert',
+    'common/core/CoreAssert',
     'common/core/tasync',
     'common/util/canon',
     'common/core/constants'

--- a/src/common/core/nullpointercore.js
+++ b/src/common/core/nullpointercore.js
@@ -5,7 +5,7 @@
  * @author kecso / https://github.com/kecso
  */
 
-define(['common/util/assert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
+define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
     'use strict';
 
     function NullPointerCore(innerCore, options) {

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -5,7 +5,7 @@
  * @author kecso / https://github.com/kecso
  */
 
-define(['common/util/assert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
+define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
     'use strict';
 
     function SetCore(innerCore, options) {

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -250,13 +250,13 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
             return names;
         }
 
-        function getOwnPropertyValue(node,  propertyCollectionName, propertyName, setName, memberPath) {
+        function getOwnPropertyValue(node, propertyCollectionName, propertyName, setName, memberPath) {
             var propertyCollectionInfo = getPropertyCollectionInfo(node, propertyCollectionName, setName, memberPath);
 
             return propertyCollectionInfo ? propertyCollectionInfo[propertyName] : undefined;
         }
 
-        function getPropertyValue(node,  propertyCollectionName, propertyName, setName, memberPath) {
+        function getPropertyValue(node, propertyCollectionName, propertyName, setName, memberPath) {
             var value;
 
             do {

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -1493,7 +1493,12 @@ describe('GME client', function () {
         });
 
         it('should return an empty array for an unknown set', function () {
-            expect(clientNode.getMemberIds('unknown_set')).to.empty;
+            try {
+                clientNode.getMemberIds('unknown_set');
+            } catch (e) {
+                expect(e instanceof Error).to.eql(true);
+                expect(e.name).to.eql('CoreIllegalOperationError');
+            }
         });
 
         it('should return a list of available attributes of the set containment', function () {
@@ -1656,7 +1661,7 @@ describe('GME client', function () {
             expect(copy).to.equal(relidPool.length);
         });
 
-        it('should allow access to META nodes even if they are not part of the territory',function(){
+        it('should allow access to META nodes even if they are not part of the territory', function () {
             var metaNode = client.getNode('/1');
             expect(metaNode).not.to.eql(null);
         });
@@ -3487,7 +3492,7 @@ describe('GME client', function () {
 
                         node = client.getNode('/323573539');
                         expect(node).not.to.equal(null);
-                        expect(node.getMemberIds('newSet')).to.empty;
+                        expect(node.getSetNames()).not.to.include.members(['newSet']);
 
                         client.addMember('/323573539', '/1697300825', 'newSet', 'basic add member test');
                         return;

--- a/test/common/core/constraintcore.spec.js
+++ b/test/common/core/constraintcore.spec.js
@@ -12,8 +12,6 @@ describe('constraint.core', function () {
         Q = testFixture.Q,
         storage,
         expect = testFixture.expect,
-        __should = testFixture.should,
-        TASYNC = testFixture.requirejs('common/core/tasync'),
         project,
         projectName = 'coreConstraintTesting',
         projectId = testFixture.projectName2Id(projectName),
@@ -51,7 +49,6 @@ describe('constraint.core', function () {
 
                 project = new testFixture.Project(dbProject, storage, logger, gmeConfig);
                 core = new testFixture.WebGME.core(project, {
-                    usertype: 'tasync',
                     globConf: gmeConfig,
                     logger: logger
                 });
@@ -86,54 +83,56 @@ describe('constraint.core', function () {
     });
 
     it('gives back proper names for own and all constraints', function (done) {
-        TASYNC.call(function (children) {
-            var base, instance, i;
+        Q.nfcall(core.loadChildren,rootNode)
+            .then(function (children) {
+                var base, instance, i;
 
-            children.should.have.length(2);
+                children.should.have.length(2);
 
-            for (i = 0; i < children.length; i++) {
-                if (core.getAttribute(children[i], 'name') === 'base') {
-                    base = children[i];
-                } else {
-                    instance = children[i];
+                for (i = 0; i < children.length; i++) {
+                    if (core.getAttribute(children[i], 'name') === 'base') {
+                        base = children[i];
+                    } else {
+                        instance = children[i];
+                    }
                 }
-            }
 
-            core.getConstraintNames(rootNode).should.be.empty;
-            core.getOwnConstraintNames(rootNode).should.be.empty;
-            core.getConstraintNames(base).should.be.eql(['global']);
-            core.getOwnConstraintNames(base).should.be.eql(['global']);
-            core.getConstraintNames(instance).should.include.members(['global', 'local']);
-            core.getOwnConstraintNames(instance).should.be.eql(['local']);
-            expect(core.getConstraint(instance, 'local')).to.deep.equal({
-                priority: 1,
-                info: 'just another info text',
-                script: 'script text for local constraint'
-            });
+                core.getConstraintNames(rootNode).should.be.empty;
+                core.getOwnConstraintNames(rootNode).should.be.empty;
+                core.getConstraintNames(base).should.be.eql(['global']);
+                core.getOwnConstraintNames(base).should.be.eql(['global']);
+                core.getConstraintNames(instance).should.include.members(['global', 'local']);
+                core.getOwnConstraintNames(instance).should.be.eql(['local']);
+                expect(core.getConstraint(instance, 'local')).to.deep.equal({
+                    priority: 1,
+                    info: 'just another info text',
+                    script: 'script text for local constraint'
+                });
 
-            done();
-        }, core.loadChildren(rootNode));
+            })
+            .nodeify(done);
     });
 
     it('removing constraints', function (done) {
-        TASYNC.call(function (children) {
-            var base, instance, i;
+        Q.nfcall(core.loadChildren,rootNode)
+            .then(function(children){
+                var base, instance, i;
 
-            children.should.have.length(2);
+                children.should.have.length(2);
 
-            for (i = 0; i < children.length; i++) {
-                if (core.getAttribute(children[i], 'name') === 'base') {
-                    base = children[i];
-                } else {
-                    instance = children[i];
+                for (i = 0; i < children.length; i++) {
+                    if (core.getAttribute(children[i], 'name') === 'base') {
+                        base = children[i];
+                    } else {
+                        instance = children[i];
+                    }
                 }
-            }
-            core.delConstraint(base, 'global');
+                core.delConstraint(base, 'global');
 
-            core.getConstraintNames(instance).should.be.eql(['local']);
-            core.getOwnConstraintNames(instance).should.be.eql(['local']);
+                core.getConstraintNames(instance).should.be.eql(['local']);
+                core.getOwnConstraintNames(instance).should.be.eql(['local']);
 
-            done();
-        }, core.loadChildren(rootNode));
+            })
+            .nodeify(done);
     });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -35,7 +35,7 @@ describe('core', function () {
         logger.info = function () {
         };
         logger.fork = function () {
-            return logger
+            return logger;
         };
 
         testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
@@ -137,7 +137,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -145,7 +145,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -157,7 +157,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -169,7 +169,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -181,7 +181,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -193,7 +193,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             expect(myError.message).to.contains('node');
         }
 
@@ -202,7 +202,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             expect(myError.message).to.contains('relativeId');
         }
     });
@@ -215,7 +215,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -227,7 +227,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -239,7 +239,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -247,7 +247,7 @@ describe('core', function () {
         var myError;
 
         core.loadRoot('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid hash');
 
             try {
@@ -255,7 +255,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -267,10 +267,10 @@ describe('core', function () {
         var myError;
 
         core.loadChild('badnode', 'relid', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
             core.loadChild(rootNode, {}, function (e) {
-                expect(e.name).to.eql('CoreInputError');
+                expect(e.name).to.eql('CoreIllegalArgumentError');
                 expect(e.message).to.contains('string');
 
                 try {
@@ -278,7 +278,7 @@ describe('core', function () {
                 } catch (e) {
                     myError = e;
                 } finally {
-                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.name).to.eql('CoreIllegalArgumentError');
                     expect(myError.message).to.contains('function');
                     done();
                 }
@@ -290,10 +290,10 @@ describe('core', function () {
         var myError;
 
         core.loadByPath('badnode', 'relid', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
             core.loadByPath(rootNode, {}, function (e) {
-                expect(e.name).to.eql('CoreInputError');
+                expect(e.name).to.eql('CoreIllegalArgumentError');
                 expect(e.message).to.contains('valid path');
 
                 try {
@@ -301,7 +301,7 @@ describe('core', function () {
                 } catch (e) {
                     myError = e;
                 } finally {
-                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.name).to.eql('CoreIllegalArgumentError');
                     expect(myError.message).to.contains('function');
                     done();
                 }
@@ -313,7 +313,7 @@ describe('core', function () {
         var myError;
 
         core.loadChildren('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
 
             try {
@@ -321,7 +321,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -333,7 +333,7 @@ describe('core', function () {
         var myError;
 
         core.loadOwnChildren('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
 
             try {
@@ -341,7 +341,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -353,27 +353,22 @@ describe('core', function () {
         var myError;
 
         core.loadPointer('badnode', 'relid', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
 
             core.loadPointer(rootNode, {}, function (e) {
-                expect(e.name).to.eql('CoreInputError');
+                expect(e.name).to.eql('CoreIllegalArgumentError');
                 expect(e.message).to.contains('string');
 
-                core.loadPointer(rootNode, 'unknown', function (e) {
-                    expect(e.name).to.eql('CoreIllegalOperationError');
-                    expect(e.message).to.contains('undefined');
-
-                    try {
-                        core.loadPointer(rootNode, {});
-                    } catch (e) {
-                        myError = e;
-                    } finally {
-                        expect(myError.name).to.eql('CoreInputError');
-                        expect(myError.message).to.contains('function');
-                        done();
-                    }
-                });
+                try {
+                    core.loadPointer(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreIllegalArgumentError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
             });
         });
     });
@@ -382,26 +377,21 @@ describe('core', function () {
         var myError;
 
         core.loadCollection('badnode', 'relid', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
             core.loadCollection(rootNode, {}, function (e) {
-                expect(e.name).to.eql('CoreInputError');
+                expect(e.name).to.eql('CoreIllegalArgumentError');
                 expect(e.message).to.contains('string');
 
-                core.loadCollection(rootNode, 'unknown', function (e) {
-                    expect(e.name).to.eql('CoreIllegalOperationError');
-                    expect(e.message).to.contains('undefined');
-
-                    try {
-                        core.loadCollection(rootNode, {});
-                    } catch (e) {
-                        myError = e;
-                    } finally {
-                        expect(myError.name).to.eql('CoreInputError');
-                        expect(myError.message).to.contains('function');
-                        done();
-                    }
-                });
+                try {
+                    core.loadCollection(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreIllegalArgumentError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
             });
         });
     });
@@ -410,7 +400,7 @@ describe('core', function () {
         var myError;
 
         core.loadSubTree('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
 
             try {
@@ -418,7 +408,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -430,7 +420,7 @@ describe('core', function () {
         var myError;
 
         core.loadOwnSubTree('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid node');
 
             try {
@@ -438,7 +428,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -450,7 +440,7 @@ describe('core', function () {
         var myError;
 
         core.loadTree('badhash', function (e) {
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
             expect(e.message).to.contains('valid hash');
 
             try {
@@ -458,7 +448,7 @@ describe('core', function () {
             } catch (e) {
                 myError = e;
             } finally {
-                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.name).to.eql('CoreIllegalArgumentError');
                 expect(myError.message).to.contains('function');
                 done();
             }
@@ -473,7 +463,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -485,7 +475,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -497,7 +487,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -509,7 +499,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -521,7 +511,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -530,7 +520,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -539,7 +529,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -552,7 +542,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -564,7 +554,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -573,7 +563,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -587,7 +577,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -596,7 +586,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -605,7 +595,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -619,7 +609,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -628,7 +618,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -642,7 +632,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -651,7 +641,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -665,7 +655,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -677,7 +667,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -686,7 +676,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -699,7 +689,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -708,7 +698,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -717,7 +707,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -730,7 +720,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -739,16 +729,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
-            core.delAttribute(rootNode, 'nonexistent');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -761,7 +742,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -773,7 +754,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -782,7 +763,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -795,7 +776,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -804,7 +785,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -813,7 +794,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -826,7 +807,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -835,16 +816,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
-            core.delRegistry(rootNode, 'nonexistent');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -857,7 +829,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -869,7 +841,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -878,7 +850,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -891,7 +863,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -900,7 +872,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -909,7 +881,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -922,7 +894,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -931,16 +903,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
-            core.delPointer(rootNode, 'nonexistent');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -953,7 +916,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -965,7 +928,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -974,7 +937,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -987,7 +950,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -999,7 +962,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1011,7 +974,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1023,7 +986,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1035,7 +998,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1047,7 +1010,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1056,7 +1019,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1069,7 +1032,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1078,7 +1041,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1091,7 +1054,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1103,7 +1066,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1112,7 +1075,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1125,7 +1088,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1134,7 +1097,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1147,7 +1110,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1156,7 +1119,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1169,7 +1132,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1181,7 +1144,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1193,7 +1156,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1205,7 +1168,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1214,7 +1177,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1226,7 +1189,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1235,16 +1198,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.delSet(rootNode, 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -1256,7 +1211,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1265,7 +1220,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1286,7 +1241,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1295,7 +1250,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1316,7 +1271,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1325,7 +1280,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1343,7 +1298,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1355,7 +1310,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1364,7 +1319,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1382,7 +1337,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1394,7 +1349,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1403,7 +1358,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1421,7 +1376,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1430,7 +1385,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1442,7 +1397,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1451,7 +1406,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1465,20 +1420,11 @@ describe('core', function () {
         }
 
         try {
-            core.delSetAttribute(rootNode, 'MetaAspectSet', 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-            myError = null;
-        }
-
-        try {
             core.delSetAttribute(rootNode, 'MetaAspectSet', {});
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1490,7 +1436,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1499,7 +1445,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1520,7 +1466,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1529,7 +1475,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1550,7 +1496,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1559,7 +1505,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1577,7 +1523,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1589,7 +1535,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1598,7 +1544,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1616,7 +1562,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1628,7 +1574,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1637,7 +1583,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1655,7 +1601,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1664,7 +1610,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1676,7 +1622,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1685,7 +1631,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1699,20 +1645,11 @@ describe('core', function () {
         }
 
         try {
-            core.delSetRegistry(rootNode, 'MetaAspectSet', 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-            myError = null;
-        }
-
-        try {
             core.delSetRegistry(rootNode, 'MetaAspectSet', {});
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -1724,7 +1661,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1733,7 +1670,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1754,7 +1691,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1763,7 +1700,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1784,7 +1721,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1793,7 +1730,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1802,7 +1739,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1831,7 +1768,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1840,7 +1777,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1849,7 +1786,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -1862,7 +1799,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1871,7 +1808,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1880,7 +1817,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1910,7 +1847,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1919,7 +1856,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1928,7 +1865,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1958,7 +1895,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1967,7 +1904,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1976,7 +1913,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -1985,7 +1922,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2015,7 +1952,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2024,7 +1961,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2033,7 +1970,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2042,7 +1979,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2072,7 +2009,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2081,7 +2018,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2090,7 +2027,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2099,7 +2036,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2108,7 +2045,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2138,7 +2075,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2147,7 +2084,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2156,7 +2093,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2165,7 +2102,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2186,15 +2123,6 @@ describe('core', function () {
             expect(myError.name).to.eql('CoreIllegalOperationError');
             myError = null;
         }
-
-        try {
-            core.delMemberAttribute(rootNode, 'MetaAspectSet', '/1', 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-            myError = null;
-        }
     });
 
     it('should throw @getMemberRegistryNames if not valid parameters are given', function () {
@@ -2205,7 +2133,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2214,7 +2142,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2223,7 +2151,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2242,6 +2170,7 @@ describe('core', function () {
             myError = e;
         } finally {
             expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
         }
     });
 
@@ -2253,7 +2182,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2262,7 +2191,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2271,7 +2200,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2301,7 +2230,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2310,7 +2239,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2319,7 +2248,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2328,7 +2257,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2358,7 +2287,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2367,7 +2296,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2376,7 +2305,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2385,7 +2314,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2415,7 +2344,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2424,7 +2353,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2433,7 +2362,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2442,7 +2371,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2451,7 +2380,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2481,7 +2410,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2490,7 +2419,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2499,7 +2428,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2508,7 +2437,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2529,15 +2458,6 @@ describe('core', function () {
             expect(myError.name).to.eql('CoreIllegalOperationError');
             myError = null;
         }
-
-        try {
-            core.delMemberRegistry(rootNode, 'MetaAspectSet', '/1', 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-            myError = null;
-        }
     });
 
     it('should throw @isMemberOf if not valid node is given', function () {
@@ -2548,7 +2468,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2556,7 +2476,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2568,7 +2488,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2576,7 +2496,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2588,16 +2508,16 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         core.setGuid('string', 'other', function (err) {
             expect(err).not.to.eql(null);
-            expect(err.name).to.eql('CoreInputError');
+            expect(err.name).to.eql('CoreIllegalArgumentError');
 
             core.setGuid(rootNode, 'notguid', function (err) {
                 expect(err).not.to.eql(null);
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
                 done();
             });
         });
@@ -2611,7 +2531,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2620,7 +2540,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2632,7 +2552,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2641,7 +2561,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2650,7 +2570,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2662,7 +2582,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2671,16 +2591,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.delConstraint(rootNode, 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -2692,7 +2604,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2700,7 +2612,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2712,7 +2624,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2720,7 +2632,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2732,7 +2644,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2741,7 +2653,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2753,7 +2665,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2762,7 +2674,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2774,7 +2686,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2782,7 +2694,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2794,7 +2706,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2802,7 +2714,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2814,7 +2726,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2823,7 +2735,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2832,16 +2744,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.isValidTargetOf(rootNode, rootNode, 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -2853,7 +2757,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2861,7 +2765,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2873,7 +2777,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2881,7 +2785,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2893,7 +2797,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2902,7 +2806,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2911,16 +2815,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.isValidAttributeValueOf(rootNode, 'unknown', 0);
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -2932,7 +2828,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2940,7 +2836,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2952,7 +2848,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -2960,7 +2856,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2972,7 +2868,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -2981,7 +2877,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -2993,7 +2889,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3001,7 +2897,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3013,7 +2909,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3021,7 +2917,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3033,7 +2929,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3041,7 +2937,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3053,7 +2949,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3062,7 +2958,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3071,7 +2967,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3080,7 +2976,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3092,7 +2988,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3101,16 +2997,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.delAttributeMeta(rootNode, 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -3122,7 +3010,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3131,7 +3019,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3143,7 +3031,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3151,7 +3039,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3163,7 +3051,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3171,7 +3059,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3183,7 +3071,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3192,7 +3080,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3201,7 +3089,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3210,7 +3098,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3219,7 +3107,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3228,7 +3116,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3240,7 +3128,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3249,16 +3137,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.delChildMeta(rootNode, '/unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -3270,7 +3150,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3279,7 +3159,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3288,7 +3168,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3297,7 +3177,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3306,7 +3186,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3318,52 +3198,61 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
-            core.setPointerMetaTarget(rootNode, 'notAValidPath');
+            core.setPointerMetaTarget(rootNode, {});
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
-            core.setPointerMetaTarget(rootNode, rootNode, 'notNumber');
+            core.setPointerMetaTarget(rootNode, 'myname', 'notnode');
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
-            core.setPointerMetaTarget(rootNode, rootNode, 0.5);
+            core.setPointerMetaTarget(rootNode, 'myname', rootNode, '0.5');
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
-            core.setPointerMetaTarget(rootNode, rootNode, -2);
+            core.setPointerMetaTarget(rootNode, 'myname', rootNode, 0.5);
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
-            core.setPointerMetaTarget(rootNode, rootNode, 0, 'notnumber');
+            core.setPointerMetaTarget(rootNode, 'myname', rootNode, -2);
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, 'myname', rootNode, 0, 'notnumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3375,7 +3264,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3384,7 +3273,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3393,7 +3282,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3405,14 +3294,6 @@ describe('core', function () {
             expect(myError.name).to.eql('CoreIllegalOperationError');
             myError = null;
         }
-
-        try {
-            core.delPointerMetaTarget(setNode, 'setPtr', '/nomember');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-        }
     });
 
     it('should throw @setPointerMetaLimits if not valid parameters are given', function () {
@@ -3423,7 +3304,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3432,7 +3313,43 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, '_nounderscore');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'base');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'ovr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'member');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3441,7 +3358,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3450,7 +3367,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3459,7 +3376,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3468,7 +3385,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3477,7 +3394,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3489,7 +3406,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3498,16 +3415,8 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
-        }
-
-        try {
-            core.delPointerMeta(rootNode, 'unknown');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -3519,7 +3428,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3528,7 +3437,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3541,7 +3450,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3550,7 +3459,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3559,7 +3468,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3567,14 +3476,12 @@ describe('core', function () {
     it('should throw @delAspectMetaTarget if not valid parameters are given', function () {
         var myError;
 
-        core.setAspectMetaTarget(rootNode, 'setAspect', setNode);
-
         try {
             core.delAspectMetaTarget('string');
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3583,7 +3490,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3592,21 +3499,12 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         try {
             core.delAspectMetaTarget(rootNode, 'aspecto', '/path');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
-            myError = null;
-        }
-
-        try {
-            core.delAspectMetaTarget(rootNode, 'setAspect', '/1');
         } catch (e) {
             myError = e;
         } finally {
@@ -3623,7 +3521,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3632,16 +3530,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
-            core.delAspectMeta(rootNode, 'aspecto');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3654,7 +3543,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3662,7 +3551,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3674,7 +3563,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3683,7 +3572,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3696,17 +3585,17 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         core.generateTreeDiff('string', 'string', function (err) {
             expect(err).not.to.eql(null);
-            expect(err.name).to.eql('CoreInputError');
+            expect(err.name).to.eql('CoreIllegalArgumentError');
 
             core.generateTreeDiff(rootNode, 'string', function (err) {
                 expect(err).not.to.eql(null);
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
                 done();
             });
         });
@@ -3720,13 +3609,13 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
         core.applyTreeDiff(rootNode, 'string', function (err) {
             expect(err).not.to.eql(null);
-            expect(err.name).to.eql('CoreInputError');
+            expect(err.name).to.eql('CoreIllegalArgumentError');
             done();
         });
     });
@@ -3739,7 +3628,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3748,7 +3637,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3761,7 +3650,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3774,7 +3663,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3782,7 +3671,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3794,7 +3683,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3802,7 +3691,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3814,7 +3703,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3823,7 +3712,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3832,7 +3721,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3841,7 +3730,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3850,7 +3739,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3859,7 +3748,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3868,7 +3757,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3877,7 +3766,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3890,7 +3779,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3899,7 +3788,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3908,7 +3797,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3917,7 +3806,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3926,7 +3815,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3935,7 +3824,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -3944,7 +3833,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -3957,7 +3846,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3965,7 +3854,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3977,7 +3866,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -3985,7 +3874,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -3997,7 +3886,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4006,7 +3895,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4015,7 +3904,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4037,7 +3926,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4045,7 +3934,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4057,7 +3946,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4065,7 +3954,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4077,7 +3966,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4085,7 +3974,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4097,7 +3986,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4106,16 +3995,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
-            core.delMixin(setNode, '/unknownpath');
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4128,7 +4008,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4137,7 +4017,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4146,7 +4026,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4159,7 +4039,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4167,7 +4047,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4179,7 +4059,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4187,7 +4067,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4199,7 +4079,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4208,7 +4088,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4217,7 +4097,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4230,7 +4110,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
         Q.allSettled([
@@ -4254,7 +4134,7 @@ describe('core', function () {
                 for (var i = 0; i < results.length; i += 1) {
                     expect(results[i].state).to.eql('rejected');
                     expect(results[i].reason instanceof Error).to.eql(true);
-                    expect(results[i].reason.name).to.eql('CoreInputError');
+                    expect(results[i].reason.name).to.eql('CoreIllegalArgumentError');
                 }
             })
             .nodeify(done);
@@ -4268,30 +4148,30 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
         Q.allSettled([
-            Q.nfcall(core.updateLibrary, 'string', 'string', 'string', null),
-            Q.nfcall(core.updateLibrary, rootNode, {}, 'string', null),
-            Q.nfcall(core.updateLibrary, rootNode, 'libname', 'string', null),
-            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', 'nope'),
+            Q.nfcall(core.updateLibrary, 'string', 'string', 'string', null, null),
+            Q.nfcall(core.updateLibrary, rootNode, {}, 'string', null, null),
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', 'string', null, null),
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', 'nope', null),
             Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 projectId: 0
-            }),
+            }, null),
             Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 branchName: 0
-            }),
+            }, null),
             Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 commitHash: 'notahash'
-            }),
+            }, null),
         ])
             .then(function (results) {
                 expect(results).to.have.length(7);
                 for (var i = 0; i < results.length; i += 1) {
                     expect(results[i].state).to.eql('rejected');
                     expect(results[i].reason instanceof Error).to.eql(true);
-                    expect(results[i].reason.name).to.eql('CoreInputError');
+                    expect(results[i].reason.name).to.eql('CoreIllegalArgumentError');
                 }
             })
             .nodeify(done);
@@ -4305,7 +4185,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4313,7 +4193,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4325,7 +4205,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4333,7 +4213,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4345,7 +4225,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4353,7 +4233,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4365,7 +4245,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4373,7 +4253,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4385,7 +4265,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4393,7 +4273,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4405,7 +4285,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4413,7 +4293,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4425,7 +4305,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4434,7 +4314,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4456,7 +4336,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4465,7 +4345,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4478,7 +4358,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4487,7 +4367,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4496,7 +4376,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4509,7 +4389,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4518,7 +4398,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4531,7 +4411,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4540,7 +4420,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4553,7 +4433,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4562,7 +4442,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4571,7 +4451,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4587,7 +4467,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4605,7 +4485,7 @@ describe('core', function () {
                 for (var i = 0; i < results.length; i += 1) {
                     expect(results[i].state).to.eql('rejected');
                     expect(results[i].reason instanceof Error).to.eql(true);
-                    expect(results[i].reason.name).to.eql('CoreInputError');
+                    expect(results[i].reason.name).to.eql('CoreIllegalArgumentError');
                 }
             })
             .nodeify(done);
@@ -4619,7 +4499,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4628,7 +4508,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4641,7 +4521,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
 
@@ -4650,7 +4530,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
     });
@@ -4663,7 +4543,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         try {
@@ -4671,7 +4551,7 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -4683,12 +4563,12 @@ describe('core', function () {
         } catch (e) {
             myError = e;
         } finally {
-            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
         }
 
         core.loadInstances('string', function (err) {
             expect(err).not.to.eql(null);
-            expect(err.name).to.eql('CoreInputError');
+            expect(err.name).to.eql('CoreIllegalArgumentError');
             done();
         });
     });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -2570,4 +2570,210 @@ describe.only('core', function () {
             expect(myError.name).to.eql('CoreInputError');
         }
     });
+
+    it('should throw @getGuid if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getGuid('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getGuid({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setGuid if not valid parameters are given', function (done) {
+        var myError;
+
+        try {
+            core.getGuid('string', 'otherstring', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        core.setGuid('string', 'other', function (err) {
+            expect(err).not.to.eql(null);
+            expect(err.name).to.eql('CoreInputError');
+
+            core.setGuid(rootNode, 'notguid', function (err) {
+                expect(err).not.to.eql(null);
+                expect(err.name).to.eql('CoreInputError');
+                done();
+            });
+        });
+    });
+
+    it('should throw @getConstraint if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getConstraint('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getConstraint(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setConstraint if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setConstraint('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setConstraint(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setConstraint(rootNode, 'newConstraint', 'notObject');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delConstraint if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delConstraint('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delConstraint(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delConstraint(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getConstraintNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getConstraintNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getConstraintNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnConstraintNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnConstraintNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getOwnConstraintNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isTypeOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isTypeOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isTypeOf(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isValidChildOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isValidChildOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidChildOf(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe('core', function () {
+describe.only('core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         projectName = 'core',
@@ -658,6 +658,90 @@ describe('core', function () {
             myError = e;
         } finally {
             expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getAttribute if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @setAttribute if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.setAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAttribute(rootNode, 'name', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @delAttribute if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.delAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAttribute(rootNode, 'nonexistent');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
         }
     });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -116,6 +116,7 @@ describe('core', function () {
             ];
 
         expect(functions).to.have.members(Matches);
+        console.error(Matches.length);
 
         for (i = 0; i < functions.length; i += 1) {
             expect(typeof core[functions[i]]).to.eql('function');
@@ -648,4 +649,15 @@ describe('core', function () {
 
     });
 
+    it('should throw @getAttributeNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -517,15 +517,6 @@ describe('core', function () {
         var myError;
 
         try {
-            core.createNode({});
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreInputError');
-            myError = null;
-        }
-
-        try {
             core.createNode({parent: 'notNode'});
         } catch (e) {
             myError = e;
@@ -1860,14 +1851,6 @@ describe('core', function () {
         } finally {
             expect(myError.name).to.eql('CoreInputError');
             myError = null;
-        }
-
-        try {
-            core.addMember(rootNode, 'unknown', rootNode);
-        } catch (e) {
-            myError = e;
-        } finally {
-            expect(myError.name).to.eql('CoreIllegalOperationError');
         }
     });
 
@@ -3445,7 +3428,7 @@ describe('core', function () {
         }
 
         try {
-            core.setPointerMetaLimits(rootNode, 'notAValidPath');
+            core.setPointerMetaLimits(rootNode, {});
         } catch (e) {
             myError = e;
         } finally {
@@ -3454,7 +3437,7 @@ describe('core', function () {
         }
 
         try {
-            core.setPointerMetaLimits(rootNode, 'notNumber');
+            core.setPointerMetaLimits(rootNode, 'any', 'notAValidPath');
         } catch (e) {
             myError = e;
         } finally {
@@ -3463,7 +3446,7 @@ describe('core', function () {
         }
 
         try {
-            core.setPointerMetaLimits(rootNode, 0.5);
+            core.setPointerMetaLimits(rootNode, 'any', 'notNumber');
         } catch (e) {
             myError = e;
         } finally {
@@ -3472,7 +3455,7 @@ describe('core', function () {
         }
 
         try {
-            core.setPointerMetaLimits(rootNode, -2);
+            core.setPointerMetaLimits(rootNode, 'any', 0.5);
         } catch (e) {
             myError = e;
         } finally {
@@ -3481,7 +3464,16 @@ describe('core', function () {
         }
 
         try {
-            core.setPointerMetaLimits(rootNode, 0, 'notnumber');
+            core.setPointerMetaLimits(rootNode, 'any', -2);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'any', 0, 'notnumber');
         } catch (e) {
             myError = e;
         } finally {
@@ -4234,7 +4226,7 @@ describe('core', function () {
         var myError;
 
         try {
-            core.addLibrary(rootNode, '#0123456789012345678901234567890123456789', null, 'nocallback');
+            core.addLibrary(rootNode, 'name', '#0123456789012345678901234567890123456789', null, 'nocallback');
         } catch (e) {
             myError = e;
         } finally {
@@ -4242,21 +4234,23 @@ describe('core', function () {
             myError = null;
         }
         Q.allSettled([
-            Q.nfcall(core.addLibrary, 'string', 'string', null),
-            Q.nfcall(core.addLibrary, rootNode, 'string', null),
-            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', 'nope'),
-            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.addLibrary, 'string', 'string', 'string', null),
+            Q.nfcall(core.addLibrary, rootNode, {}, 'string', null),
+            Q.nfcall(core.addLibrary, rootNode, 'libname', 'string', null),
+            Q.nfcall(core.addLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', 'nope'),
+            Q.nfcall(core.addLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 projectId: 0
             }),
-            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.addLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 branchName: 0
             }),
-            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.addLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 commitHash: 'notahash'
             }),
         ])
             .then(function (results) {
-                expect(results).to.have.length(6);
+                expect(results).to.have.length(7);
+                console.error(results);
                 for (var i = 0; i < results.length; i += 1) {
                     expect(results[i].state).to.eql('rejected');
                     expect(results[i].reason instanceof Error).to.eql(true);
@@ -4270,7 +4264,7 @@ describe('core', function () {
         var myError;
 
         try {
-            core.updateLibrary(rootNode, '#0123456789012345678901234567890123456789', null, 'nocallback');
+            core.updateLibrary(rootNode, 'libname', '#0123456789012345678901234567890123456789', null, 'nocallback');
         } catch (e) {
             myError = e;
         } finally {
@@ -4278,21 +4272,22 @@ describe('core', function () {
             myError = null;
         }
         Q.allSettled([
-            Q.nfcall(core.updateLibrary, 'string', 'string', null),
-            Q.nfcall(core.updateLibrary, rootNode, 'string', null),
-            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', 'nope'),
-            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.updateLibrary, 'string', 'string', 'string', null),
+            Q.nfcall(core.updateLibrary, rootNode, {}, 'string', null),
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', 'string', null),
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', 'nope'),
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 projectId: 0
             }),
-            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 branchName: 0
             }),
-            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+            Q.nfcall(core.updateLibrary, rootNode, 'libname', '#0123456789012345678901234567890123456789', {
                 commitHash: 'notahash'
             }),
         ])
             .then(function (results) {
-                expect(results).to.have.length(6);
+                expect(results).to.have.length(7);
                 for (var i = 0; i < results.length; i += 1) {
                     expect(results[i].state).to.eql('rejected');
                     expect(results[i].reason instanceof Error).to.eql(true);

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -1,0 +1,191 @@
+/* jshint node:true, mocha: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+var testFixture = require('../../_globals.js');
+
+describe('core', function () {
+    'use strict';
+    var gmeConfig = testFixture.getGmeConfig(),
+        projectName = 'core',
+        Core = testFixture.requirejs('common/core/core'),
+        project,
+        core,
+        rootNode,
+        originalRootHash,
+        commit,
+        Q = testFixture.Q,
+        expect = testFixture.expect,
+        logger = {},
+        lastError = null,
+        storage,
+        gmeAuth;
+
+    before(function (done) {
+        logger.error = function () {
+            lastError = arguments[0];
+        };
+        logger.debug = function () {
+        };
+        logger.warn = function () {
+        };
+        logger.info = function () {
+        };
+        logger.fork = function () {
+            return logger
+        };
+
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                return testFixture.importProject(storage, {
+                    projectSeed: 'seeds/ActivePanels.webgmex',
+                    projectName: projectName,
+                    branchName: 'base',
+                    gmeConfig: gmeConfig,
+                    logger: logger
+                });
+            })
+            .then(function (result) {
+                project = result.project;
+                core = new Core(project, {globConf: gmeConfig, logger: logger});
+                rootNode = result.rootNode;
+                originalRootHash = result.rootHash;
+                commit = result.commitHash;
+            })
+            .nodeify(done);
+    });
+
+    after(function (done) {
+        Q.allDone([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ]).nodeify(done);
+    });
+
+    it('should have all public functions available', function () {
+        var functions = Object.keys(core),
+            i,
+            Matches = ['getParent', 'getRelid', 'getRoot', 'getPath', 'getChild', 'isEmpty', 'getHash',
+                'persist', 'loadRoot', 'loadChild', 'loadByPath', 'loadChildren', 'loadOwnChildren',
+                'loadPointer', 'loadCollection', 'loadSubTree', 'loadOwnSubTree', 'loadTree',
+                'getChildrenRelids', 'getOwnChildrenRelids', 'getChildrenPaths', 'getOwnChildrenPaths',
+                'createNode', 'deleteNode', 'copyNode', 'copyNodes', 'isValidNewParent', 'moveNode',
+                'getAttributeNames', 'getAttribute', 'setAttribute', 'delAttribute', 'getRegistryNames',
+                'getRegistry', 'setRegistry', 'delRegistry', 'getPointerNames', 'getPointerPath',
+                'deletePointer', 'setPointer', 'getCollectionNames', 'getCollectionPaths',
+                'getChildrenHashes', 'getBase', 'getBaseRoot', 'getOwnAttributeNames',
+                'getOwnRegistryNames', 'getOwnAttribute', 'getOwnRegistry', 'getOwnPointerNames',
+                'getOwnPointerPath', 'isValidNewBase', 'setBase', 'getTypeRoot', 'getSetNames',
+                'getOwnSetNames', 'createSet', 'deleteSet', 'getSetAttributeNames',
+                'getOwnSetAttributeNames', 'getSetAttribute', 'getOwnSetAttribute', 'setSetAttribute',
+                'delSetAttribute', 'getSetRegistryNames', 'getOwnSetRegistryNames', 'getSetRegistry',
+                'getOwnSetRegistry', 'setSetRegistry', 'delSetRegistry', 'getMemberPaths',
+                'getOwnMemberPaths', 'delMember', 'addMember', 'getMemberAttributeNames',
+                'getMemberOwnAttributeNames', 'getMemberAttribute', 'getMemberOwnAttribute',
+                'setMemberAttribute', 'delMemberAttribute', 'getMemberRegistryNames',
+                'getMemberOwnRegistryNames', 'getMemberRegistry', 'getMemberOwnRegistry',
+                'setMemberRegistry', 'delMemberRegistry', 'isMemberOf', 'getGuid',
+                'setGuid', 'getConstraint', 'setConstraint', 'delConstraint', 'getConstraintNames',
+                'getOwnConstraintNames', 'isTypeOf', 'isValidChildOf', 'getValidPointerNames',
+                'getValidSetNames', 'isValidTargetOf', 'getValidAttributeNames',
+                'getOwnValidAttributeNames', 'isValidAttributeValueOf', 'getValidAspectNames',
+                'getOwnValidAspectNames', 'getAspectMeta', 'getJsonMeta', 'getOwnJsonMeta',
+                'clearMetaRules', 'setAttributeMeta', 'delAttributeMeta', 'getAttributeMeta',
+                'getValidChildrenPaths', 'getChildrenMeta', 'setChildMeta', 'delChildMeta',
+                'setChildrenMetaLimits', 'setPointerMetaTarget', 'delPointerMetaTarget',
+                'setPointerMetaLimits', 'delPointerMeta', 'getPointerMeta',
+                'setAspectMetaTarget', 'delAspectMetaTarget', 'delAspectMeta', 'getBaseType',
+                'isInstanceOf', 'generateTreeDiff', 'applyTreeDiff', 'tryToConcatChanges',
+                'applyResolution', 'isAbstract', 'isConnection', 'getValidChildrenMetaNodes',
+                'getValidSetElementsMetaNodes', 'getAllMetaNodes', 'isMetaNode',
+                'isFullyOverriddenMember', 'getMixinErrors', 'getMixinPaths',
+                'getMixinNodes', 'delMixin', 'addMixin', 'clearMixins', 'getBaseTypes',
+                'canSetAsMixin', 'addLibrary', 'updateLibrary', 'getLibraryNames', 'getFCO',
+                'isLibraryRoot', 'isLibraryElement', 'getNamespace', 'getFullyQualifiedName',
+                'removeLibrary', 'getLibraryGuid', 'renameLibrary', 'getLibraryInfo',
+                'getLibraryRoot', 'getLibraryMetaNodes', 'traverse', 'getClosureInformation',
+                'importClosure', 'getInstancePaths', 'loadInstances', 'delPointer', 'delSet',
+                'getMetaType'
+            ];
+
+        expect(functions).to.have.members(Matches);
+
+        for (i = 0; i < functions.length; i += 1) {
+            expect(typeof core[functions[i]]).to.eql('function');
+        }
+    });
+
+    it('should throw @getParent if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getParent('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getParent({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getRelid if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getParent('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getRoot if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getParent('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @loadRoot if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.loadRoot('badhash', function () {
+            });
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.message).to.contains('valid hash');
+        }
+
+        try {
+            core.loadRoot(originalRootHash, 'string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.message).to.contains('function');
+        }
+    });
+});

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe('core', function () {
+describe.only('core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         projectName = 'core',
@@ -158,7 +158,7 @@ describe('core', function () {
         var myError;
 
         try {
-            core.getParent('string');
+            core.getRoot('string');
         } catch (e) {
             myError = e;
         } finally {
@@ -166,26 +166,286 @@ describe('core', function () {
         }
     });
 
-    it('should throw @loadRoot if not valid parameters are given', function () {
+    it('should throw @getPath if not valid node is given', function () {
         var myError;
 
         try {
-            core.loadRoot('badhash', function () {
-            });
+            core.getPath('string');
         } catch (e) {
             myError = e;
         } finally {
             expect(myError.name).to.eql('CoreInputError');
-            expect(myError.message).to.contains('valid hash');
+        }
+    });
+
+    it('should throw @getChild if not parameters are given', function () {
+        var myError;
+
+        try {
+            core.getChild('string', 'anything');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            expect(myError.message).to.contains('node');
         }
 
         try {
-            core.loadRoot(originalRootHash, 'string');
+            core.getChild(rootNode, {});
         } catch (e) {
             myError = e;
         } finally {
             expect(myError.name).to.eql('CoreInputError');
-            expect(myError.message).to.contains('function');
+            expect(myError.message).to.contains('relativeId');
         }
     });
+
+    it('should throw @isEmpty if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isEmpty('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getHash if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getHash('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @persist if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getHash('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @loadRoot if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadRoot('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid hash');
+
+            try {
+                core.loadRoot(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
+    it('should throw @loadChild if not parameters are given', function (done) {
+        var myError;
+
+        core.loadChild('badnode', 'relid', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+            core.loadChild(rootNode, {}, function (e) {
+                expect(e.name).to.eql('CoreInputError');
+                expect(e.message).to.contains('string');
+
+                try {
+                    core.loadChild(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
+            });
+        });
+    });
+
+    it('should throw @loadByPath if not parameters are given', function (done) {
+        var myError;
+
+        core.loadByPath('badnode', 'relid', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+            core.loadByPath(rootNode, {}, function (e) {
+                expect(e.name).to.eql('CoreInputError');
+                expect(e.message).to.contains('valid path');
+
+                try {
+                    core.loadByPath(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
+            });
+        });
+    });
+
+    it('should throw @loadChildren if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadChildren('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+
+            try {
+                core.loadChildren(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
+    it('should throw @loadOwnChildren if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadOwnChildren('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+
+            try {
+                core.loadOwnChildren(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
+    it('should throw @loadPointer if not parameters are given', function (done) {
+        var myError;
+
+        core.loadPointer('badnode', 'relid', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+            core.loadPointer(rootNode, {}, function (e) {
+                expect(e.name).to.eql('CoreInputError');
+                expect(e.message).to.contains('string');
+
+                try {
+                    core.loadPointer(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
+            });
+        });
+    });
+
+    it('should throw @loadCollection if not parameters are given', function (done) {
+        var myError;
+
+        core.loadCollection('badnode', 'relid', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+            core.loadCollection(rootNode, {}, function (e) {
+                expect(e.name).to.eql('CoreInputError');
+                expect(e.message).to.contains('string');
+
+                try {
+                    core.loadCollection(rootNode, {});
+                } catch (e) {
+                    myError = e;
+                } finally {
+                    expect(myError.name).to.eql('CoreInputError');
+                    expect(myError.message).to.contains('function');
+                    done();
+                }
+            });
+        });
+    });
+
+    it('should throw @loadSubTree if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadSubTree('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+
+            try {
+                core.loadSubTree(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
+    it('should throw @loadOwnSubTree if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadOwnSubTree('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid node');
+
+            try {
+                core.loadOwnSubTree(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
+    it('should throw @loadTree if not valid parameters are given', function (done) {
+        var myError;
+
+        core.loadTree('badhash', function (e) {
+            expect(e.name).to.eql('CoreInputError');
+            expect(e.message).to.contains('valid hash');
+
+            try {
+                core.loadTree(originalRootHash, 'string');
+            } catch (e) {
+                myError = e;
+            } finally {
+                expect(myError.name).to.eql('CoreInputError');
+                expect(myError.message).to.contains('function');
+                done();
+            }
+        });
+
+    });
+
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -229,7 +229,7 @@ describe.only('core', function () {
         var myError;
 
         try {
-            core.getHash('string');
+            core.persist('string');
         } catch (e) {
             myError = e;
         } finally {
@@ -349,19 +349,25 @@ describe.only('core', function () {
         core.loadPointer('badnode', 'relid', function (e) {
             expect(e.name).to.eql('CoreInputError');
             expect(e.message).to.contains('valid node');
+
             core.loadPointer(rootNode, {}, function (e) {
                 expect(e.name).to.eql('CoreInputError');
                 expect(e.message).to.contains('string');
 
-                try {
-                    core.loadPointer(rootNode, {});
-                } catch (e) {
-                    myError = e;
-                } finally {
-                    expect(myError.name).to.eql('CoreInputError');
-                    expect(myError.message).to.contains('function');
-                    done();
-                }
+                core.loadPointer(rootNode, 'unknown', function (e) {
+                    expect(e.name).to.eql('CoreIllegalOperationError');
+                    expect(e.message).to.contains('undefined');
+
+                    try {
+                        core.loadPointer(rootNode, {});
+                    } catch (e) {
+                        myError = e;
+                    } finally {
+                        expect(myError.name).to.eql('CoreInputError');
+                        expect(myError.message).to.contains('function');
+                        done();
+                    }
+                });
             });
         });
     });
@@ -376,15 +382,20 @@ describe.only('core', function () {
                 expect(e.name).to.eql('CoreInputError');
                 expect(e.message).to.contains('string');
 
-                try {
-                    core.loadCollection(rootNode, {});
-                } catch (e) {
-                    myError = e;
-                } finally {
-                    expect(myError.name).to.eql('CoreInputError');
-                    expect(myError.message).to.contains('function');
-                    done();
-                }
+                core.loadCollection(rootNode, 'unknown', function (e) {
+                    expect(e.name).to.eql('CoreIllegalOperationError');
+                    expect(e.message).to.contains('undefined');
+
+                    try {
+                        core.loadCollection(rootNode, {});
+                    } catch (e) {
+                        myError = e;
+                    } finally {
+                        expect(myError.name).to.eql('CoreInputError');
+                        expect(myError.message).to.contains('function');
+                        done();
+                    }
+                });
             });
         });
     });
@@ -575,7 +586,7 @@ describe.only('core', function () {
         var myError;
 
         try {
-            core.copyNode('string');
+            core.copyNodes('string');
         } catch (e) {
             myError = e;
         } finally {
@@ -584,7 +595,7 @@ describe.only('core', function () {
         }
 
         try {
-            core.copyNode(['string']);
+            core.copyNodes(['string']);
         } catch (e) {
             myError = e;
         } finally {
@@ -593,7 +604,7 @@ describe.only('core', function () {
         }
 
         try {
-            core.copyNode([rootNode], 'invalid');
+            core.copyNodes([rootNode], 'invalid');
         } catch (e) {
             myError = e;
         } finally {
@@ -742,6 +753,735 @@ describe.only('core', function () {
         } finally {
             expect(myError.name).to.eql('CoreIllegalOperationError');
             myError = null;
+        }
+    });
+
+    it('should throw @getRegistryNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getRegistry if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @setRegistry if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.setRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setRegistry(rootNode, 'name', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @delRegistry if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.delRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delRegistry(rootNode, 'nonexistent');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getPointerNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getPointerNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getPointerPath if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getPointerPath('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getPointerPath(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @setPointer if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.setPointer('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointer(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointer(rootNode, 'name', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @delPointer if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.delPointer('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointer(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointer(rootNode, 'nonexistent');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getCollectionNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getCollectionNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getCollectionPaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getCollectionPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getCollectionPaths(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getChildrenHashes if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getChildrenHashes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getBase if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getBase('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getBaseRoot if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getBaseRoot('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnAttributeNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnRegistryNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnAttribute if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getOwnRegistry if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getOwnPointerNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnPointerNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnPointerPath if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnPointerPath('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnPointerPath(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @isValidNewBase if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isValidNewBase('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidNewBase(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @setBase if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.setBase('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setBase(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getTypeRoot if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getTypeRoot('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getSetNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getSetNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnSetNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnSetNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @createSet if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.createSet('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.createSet(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delSet if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delSet('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSet(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSet(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getSetAttributeNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getSetAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetAttributeNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetAttributeNames(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getOwnSetAttributeNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getOwnSetAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetAttributeNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetAttributeNames(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getSetAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getSetAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetAttribute(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getSetAttribute(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnSetAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getOwnSetAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetAttribute(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetAttribute(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setSetAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setSetAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetAttribute(rootNode, 'unknown', 'good', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.setSetAttribute(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetAttribute(rootNode, 'MetaAspectSet', 'any', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delSetAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delSetAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSetAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSetAttribute(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delSetAttribute(rootNode, 'MetaAspectSet', 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delSetAttribute(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
         }
     });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -1484,4 +1484,1090 @@ describe.only('core', function () {
             expect(myError.name).to.eql('CoreInputError');
         }
     });
+
+    it('should throw @getSetRegistryNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getSetRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetRegistryNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetRegistryNames(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getOwnSetRegistryNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getOwnSetRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetRegistryNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetRegistryNames(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getSetRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getSetRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getSetRegistry(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getSetRegistry(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnSetRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getOwnSetRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetRegistry(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnSetRegistry(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setSetRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setSetRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetRegistry(rootNode, 'unknown', 'good', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.setSetRegistry(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setSetRegistry(rootNode, 'MetaAspectSet', 'any', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delSetRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delSetRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSetRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delSetRegistry(rootNode, 'unknown', 'good');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delSetRegistry(rootNode, 'MetaAspectSet', 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delSetRegistry(rootNode, 'MetaAspectSet', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getMemberPaths if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberPaths(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberPaths(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getOwnMemberPaths if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getOwnMemberPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnMemberPaths(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getOwnMemberPaths(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @delMember if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delMember('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMember(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMember(rootNode, 'unknown', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMember(rootNode, 'unknown', '/1/2');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+
+        try {
+            core.delMember(rootNode, 'MetaAspectSet', '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @addMember if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.addMember('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.addMember(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.addMember(rootNode, 'unknown', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.addMember(rootNode, 'unknown', rootNode);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberAttributeNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttributeNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttributeNames(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttributeNames(rootNode, 'unknown', '/1/2');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttributeNames(rootNode, 'MetaAspectSet', '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberOwnAttributeNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberOwnAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttributeNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttributeNames(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttributeNames(rootNode, 'unknown', '/1/2');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttributeNames(rootNode, 'MetaAspectSet', '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttribute(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttribute(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttribute(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberAttribute(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberOwnAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberOwnAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttribute(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttribute(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttribute(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnAttribute(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @setMemberAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setMemberAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, 'setname', '/path', 'attr', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, 'unknown', '/1/2', 'attr', 'value');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberAttribute(rootNode, 'MetaAspectSet', '/unknown', 'attr', 'value');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @delMemberAttribute if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delMemberAttribute('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberAttribute(rootNode, 'MetaAspectSet', '/1', 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getMemberRegistryNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistryNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistryNames(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistryNames(rootNode, 'unknown', '/1/2');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistryNames(rootNode, 'MetaAspectSet', '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberOwnRegistryNames if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberOwnRegistryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistryNames(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistryNames(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistryNames(rootNode, 'unknown', '/1/2');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistryNames(rootNode, 'MetaAspectSet', '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistry(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistry(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistry(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberRegistry(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getMemberOwnRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getMemberOwnRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistry(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistry(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistry(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.getMemberOwnRegistry(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @setMemberRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setMemberRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, 'setname', '/path', 'attr', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, 'unknown', '/1/2', 'attr', 'value');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.setMemberRegistry(rootNode, 'MetaAspectSet', '/unknown', 'attr', 'value');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @delMemberRegistry if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delMemberRegistry('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, 'setname', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, 'setname', '/path', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, 'unknown', '/1/2', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, 'MetaAspectSet', '/unknown', 'attr');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delMemberRegistry(rootNode, 'MetaAspectSet', '/1', 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @isMemberOf if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isMemberOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isMemberOf({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe.only('core', function () {
+describe('core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         projectName = 'core',
@@ -14,6 +14,7 @@ describe.only('core', function () {
         project,
         core,
         rootNode,
+        setNode,
         originalRootHash,
         commit,
         Q = testFixture.Q,
@@ -58,6 +59,11 @@ describe.only('core', function () {
                 rootNode = result.rootNode;
                 originalRootHash = result.rootHash;
                 commit = result.commitHash;
+
+                return Q.ninvoke(core, 'loadByPath', rootNode, '/175547009/1104061497')
+            })
+            .then(function (node) {
+                setNode = node;
             })
             .nodeify(done);
     });
@@ -147,7 +153,7 @@ describe.only('core', function () {
         var myError;
 
         try {
-            core.getParent('string');
+            core.getRelid('string');
         } catch (e) {
             myError = e;
         } finally {
@@ -2775,5 +2781,1920 @@ describe.only('core', function () {
         } finally {
             expect(myError.name).to.eql('CoreInputError');
         }
+    });
+
+    it('should throw @getValidPointerNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getValidPointerNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getValidPointerNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getValidSetNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getValidSetNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getValidSetNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isValidTargetOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isValidTargetOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidTargetOf(rootNode, 'notnode');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidTargetOf(rootNode, rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidTargetOf(rootNode, rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getValidAttributeNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getValidAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getValidAttributeNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnValidAttributeNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnValidAttributeNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getOwnValidAttributeNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isValidAttributeValueOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isValidAttributeValueOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidAttributeValueOf(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidAttributeValueOf(rootNode, 'attr', undefined);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidAttributeValueOf(rootNode, 'unknown', 0);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getValidAspectNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getValidAspectNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getValidAspectNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnValidAspectNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnValidAspectNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getOwnValidAspectNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getAspectMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getAspectMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getAspectMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getJsonMeta if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getJsonMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getJsonMeta({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnJsonMeta if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnJsonMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getOwnJsonMeta({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @clearMetaRules if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.clearMetaRules('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.clearMetaRules({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setAttributeMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setAttributeMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAttributeMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAttributeMeta(rootNode, 'rule', 'notObject');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAttributeMeta(rootNode, 'rule', {noType: 'field'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delAttributeMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delAttributeMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAttributeMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAttributeMeta(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getAttributeMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getAttributeMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getAttributeMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getValidChildrenPaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getValidChildrenPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getValidChildrenPaths({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getChildrenMeta if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getChildrenMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getChildrenMeta({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setChildMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setChildMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildMeta(rootNode, 'notAValidPath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildMeta(rootNode, rootNode, 'notNumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildMeta(rootNode, rootNode, 0.5);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildMeta(rootNode, rootNode, -2);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildMeta(rootNode, rootNode, 0, 'notnumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delChildMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delChildMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delChildMeta(rootNode, 'notAValidPath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delChildMeta(rootNode, '/unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @setChildrenMetaLimits if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setChildrenMetaLimits('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildrenMetaLimits(rootNode, 'notNumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildrenMetaLimits(rootNode, 0.5);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildrenMetaLimits(rootNode, -2);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setChildrenMetaLimits(rootNode, 0, 'notnumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @setPointerMetaTarget if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setPointerMetaTarget('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, 'notAValidPath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, rootNode, 'notNumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, rootNode, 0.5);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, rootNode, -2);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaTarget(rootNode, rootNode, 0, 'notnumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delPointerMetaTarget if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delPointerMetaTarget('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMetaTarget(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMetaTarget(setNode, 'unknown', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMetaTarget(setNode, 'unknown', '/path');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMetaTarget(setNode, 'setPtr', '/nomember');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @setPointerMetaLimits if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setPointerMetaLimits('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'notAValidPath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 'notNumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 0.5);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, -2);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setPointerMetaLimits(rootNode, 0, 'notnumber');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delPointerMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delPointerMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delPointerMeta(rootNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @getPointerMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getPointerMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getPointerMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @setAspectMetaTarget if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.setAspectMetaTarget('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAspectMetaTarget(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.setAspectMetaTarget(rootNode, 'aspecto', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @delAspectMetaTarget if not valid parameters are given', function () {
+        var myError;
+
+        core.setAspectMetaTarget(rootNode, 'setAspect', setNode);
+
+        try {
+            core.delAspectMetaTarget('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMetaTarget(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMetaTarget(rootNode, 'aspecto', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMetaTarget(rootNode, 'aspecto', '/path');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMetaTarget(rootNode, 'setAspect', '/1');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @delAspectMeta if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delAspectMeta('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMeta(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delAspectMeta(rootNode, 'aspecto');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getBaseType if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getBaseType('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getBaseType({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isInstanceOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isInstanceOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isInstanceOf(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @generateTreeDiff if not valid parameters are given', function (done) {
+        var myError;
+
+        try {
+            core.generateTreeDiff('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        core.generateTreeDiff('string', 'string', function (err) {
+            expect(err).not.to.eql(null);
+            expect(err.name).to.eql('CoreInputError');
+
+            core.generateTreeDiff(rootNode, 'string', function (err) {
+                expect(err).not.to.eql(null);
+                expect(err.name).to.eql('CoreInputError');
+                done();
+            });
+        });
+    });
+
+    it('should throw @applyTreeDiff if not valid parameters are given', function (done) {
+        var myError;
+
+        try {
+            core.applyTreeDiff('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        core.applyTreeDiff(rootNode, 'string', function (err) {
+            expect(err).not.to.eql(null);
+            expect(err.name).to.eql('CoreInputError');
+            done();
+        });
+    });
+
+    it('should throw @tryToConcatChanges if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.tryToConcatChanges('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.tryToConcatChanges({}, 'notobject');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @applyResolution if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.applyResolution('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @isAbstract if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isAbstract('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isAbstract({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isConnection if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isConnection('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isConnection({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getValidChildrenMetaNodes if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getValidChildrenMetaNodes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({missingNode: true});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: 'badnode'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: rootNode, children: 'badchildren'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: rootNode, children: ['badelement']});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: rootNode, sensitive: 'bad'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: rootNode, multiplicity: 'bad'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidChildrenMetaNodes({node: rootNode, aspect: {}});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getValidSetElementsMetaNodes if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getValidSetElementsMetaNodes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({missingNode: true});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({node: 'badnode'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({node: rootNode, members: 'badmembers'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({node: rootNode, members: ['badelement']});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({node: rootNode, sensitive: 'bad'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getValidSetElementsMetaNodes({node: rootNode, multiplicity: 'bad'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getAllMetaNodes if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getAllMetaNodes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getAllMetaNodes({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isMetaNode if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isMetaNode('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isMetaNode({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isFullyOverriddenMember if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isFullyOverriddenMember('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isFullyOverriddenMember(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isFullyOverriddenMember(setNode, 'set', 'notpath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isFullyOverriddenMember(setNode, 'unknown', '/path');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getMixinErrors if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getMixinErrors('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getMixinErrors({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getMixinPaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getMixinPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getMixinPaths({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getMixinNodes if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getMixinNodes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getMixinNodes({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @delMixin if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.delMixin('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMixin(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.delMixin(setNode, '/unknownpath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @addMixin if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.addMixin('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.addMixin(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.addMixin(setNode, 'notpath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @clearMixins if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.clearMixins('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.clearMixins({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getBaseTypes if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getBaseTypes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getBaseTypes({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @canSetAsMixin if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.canSetAsMixin('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.canSetAsMixin(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.canSetAsMixin(setNode, 'notpath');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @addLibrary if not valid parameters are given', function (done) {
+        var myError;
+
+        try {
+            core.addLibrary(rootNode, '#0123456789012345678901234567890123456789', null, 'nocallback');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+        Q.allSettled([
+            Q.nfcall(core.addLibrary, 'string', 'string', null),
+            Q.nfcall(core.addLibrary, rootNode, 'string', null),
+            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', 'nope'),
+            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                projectId: 0
+            }),
+            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                branchName: 0
+            }),
+            Q.nfcall(core.addLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                commitHash: 'notahash'
+            }),
+        ])
+            .then(function (results) {
+                expect(results).to.have.length(6);
+                for (var i = 0; i < results.length; i += 1) {
+                    expect(results[i].state).to.eql('rejected');
+                    expect(results[i].reason instanceof Error).to.eql(true);
+                    expect(results[i].reason.name).to.eql('CoreInputError');
+                }
+            })
+            .nodeify(done);
+    });
+
+    it('should throw @updateLibrary if not valid parameters are given', function (done) {
+        var myError;
+
+        try {
+            core.updateLibrary(rootNode, '#0123456789012345678901234567890123456789', null, 'nocallback');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+        Q.allSettled([
+            Q.nfcall(core.updateLibrary, 'string', 'string', null),
+            Q.nfcall(core.updateLibrary, rootNode, 'string', null),
+            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', 'nope'),
+            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                projectId: 0
+            }),
+            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                branchName: 0
+            }),
+            Q.nfcall(core.updateLibrary, rootNode, '#0123456789012345678901234567890123456789', {
+                commitHash: 'notahash'
+            }),
+        ])
+            .then(function (results) {
+                expect(results).to.have.length(6);
+                for (var i = 0; i < results.length; i += 1) {
+                    expect(results[i].state).to.eql('rejected');
+                    expect(results[i].reason instanceof Error).to.eql(true);
+                    expect(results[i].reason.name).to.eql('CoreInputError');
+                }
+            })
+            .nodeify(done);
+    });
+
+    it('should throw @getLibraryNames if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getLibraryNames('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getLibraryNames({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getFCO if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getFCO('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getFCO({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isLibraryRoot if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isLibraryRoot('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isLibraryRoot({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @isLibraryElement if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.isLibraryElement('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.isLibraryElement({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getNamespace if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getNamespace('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getNamespace({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getFullyQualifiedName if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getFullyQualifiedName('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getFullyQualifiedName({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @removeLibrary if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.removeLibrary('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.removeLibrary(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.removeLibrary(setNode, 'unknown');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getLibraryGuid if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getLibraryGuid('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getLibraryGuid(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @renameLibrary if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.renameLibrary('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.renameLibrary(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.renameLibrary(setNode, 'old', {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getLibraryInfo if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getLibraryInfo('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getLibraryInfo(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getLibraryRoot if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getLibraryRoot('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getLibraryRoot(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getLibraryMetaNodes if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getLibraryMetaNodes('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getLibraryMetaNodes(setNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getLibraryMetaNodes(setNode, 'library', 'notbool');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @traverse if not valid parameters are given', function (done) {
+        var myError,
+            goodVisit = function (node, next) {
+                next();
+            };
+
+        try {
+            core.traverse(rootNode, null, goodVisit, 'nocallback');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        Q.allSettled([
+            Q.nfcall(core.traverse, 'string', 'string', null),
+            Q.nfcall(core.traverse, rootNode, 'string', null),
+            Q.nfcall(core.traverse, rootNode, {excludeRoot: 0}, null),
+            Q.nfcall(core.traverse, rootNode, {order: 0}, null),
+            Q.nfcall(core.traverse, rootNode, {order: 'nope'}, null),
+            Q.nfcall(core.traverse, rootNode, {stopOnError: 'nope'}, null),
+            Q.nfcall(core.traverse, rootNode, null, 'nope')
+        ])
+            .then(function (results) {
+                expect(results).to.have.length(7);
+                for (var i = 0; i < results.length; i += 1) {
+                    expect(results[i].state).to.eql('rejected');
+                    expect(results[i].reason instanceof Error).to.eql(true);
+                    expect(results[i].reason.name).to.eql('CoreInputError');
+                }
+            })
+            .nodeify(done);
+    });
+
+    it('should throw @getClosureInformation if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.getClosureInformation('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.getClosureInformation(['badelement']);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @importClosure if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.importClosure('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.importClosure(setNode, 'noobject');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @getInstancePaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getInstancePaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        try {
+            core.getInstancePaths({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @loadInstances if not valid node is given', function (done) {
+        var myError;
+
+        try {
+            core.loadInstances('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+
+        core.loadInstances('string', function (err) {
+            expect(err).not.to.eql(null);
+            expect(err.name).to.eql('CoreInputError');
+            done();
+        });
     });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe.only('core', function () {
+describe('core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         projectName = 'core',
@@ -445,6 +445,206 @@ describe.only('core', function () {
                 done();
             }
         });
+    });
+
+    it('should throw @getChildrenRelids if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getChildrenRelids('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnChildrenRelids if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnChildrenRelids('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getChildrenPaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getChildrenPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @getOwnChildrenPaths if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.getOwnChildrenPaths('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @createNode if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.createNode({});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.createNode({parent: 'notNode'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.createNode({parent: rootNode, base: 'notNode'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.createNode({parent: rootNode, base: rootNode, guid: 'invalidGuid'});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+    });
+
+    it('should throw @deleteNode if not valid node is given', function () {
+        var myError;
+
+        try {
+            core.deleteNode('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+        }
+    });
+
+    it('should throw @copyNode if not valid node or parent is given', function () {
+        var myError;
+
+        try {
+            core.copyNode('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.copyNode(rootNode, 'invalid');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+    });
+
+    it('should throw @copyNodes if not valid nodes or parent is given', function () {
+        var myError;
+
+        try {
+            core.copyNode('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.copyNode(['string']);
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.copyNode([rootNode], 'invalid');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+    });
+
+    it('should throw @isValidNewParent if not valid node or parent is given', function () {
+        var myError;
+
+        try {
+            core.isValidNewParent('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.isValidNewParent(rootNode, 'invalid');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+    });
+
+    it('should throw @moveNode if not valid node or parent is given', function () {
+        var myError;
+
+        try {
+            core.moveNode('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
+
+        try {
+            core.moveNode(rootNode, 'invalid');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreInputError');
+            myError = null;
+        }
 
     });
 

--- a/test/common/core/coreQ.spec.js
+++ b/test/common/core/coreQ.spec.js
@@ -230,7 +230,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.message).to.include('valid node');
             })
             .nodeify(done);
     });
@@ -249,7 +249,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.message).to.include('valid hash');
             })
             .nodeify(done);
     });

--- a/test/common/core/coreQ.spec.js
+++ b/test/common/core/coreQ.spec.js
@@ -70,7 +70,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -93,7 +93,7 @@ describe('CoreQ Async with Promises', function () {
             })
             .catch(function (err) {
                 // expect(err.message).to.include('ASSERT failed');
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -115,7 +115,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -137,7 +137,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -159,7 +159,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -184,7 +184,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });
@@ -208,7 +208,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.name).to.eql('CoreInputError');
+                expect(err.name).to.eql('CoreIllegalArgumentError');
             })
             .nodeify(done);
     });

--- a/test/common/core/coreQ.spec.js
+++ b/test/common/core/coreQ.spec.js
@@ -50,9 +50,9 @@ describe('CoreQ Async with Promises', function () {
 
     after(function (done) {
         Q.allDone([
-                storage.closeDatabase(),
-                gmeAuth.unload()
-            ])
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
             .nodeify(done);
     });
 
@@ -70,7 +70,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -92,7 +92,8 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                // expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -114,7 +115,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -136,7 +137,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -158,7 +159,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -183,7 +184,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });
@@ -207,7 +208,7 @@ describe('CoreQ Async with Promises', function () {
                 throw new Error('Should have failed');
             })
             .catch(function (err) {
-                expect(err.message).to.include('ASSERT failed');
+                expect(err.name).to.eql('CoreInputError');
             })
             .nodeify(done);
     });

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -211,11 +211,16 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.createNode({parent: metaNodes['/L/I'], base: null});
+        try {
+            core.createNode({parent: metaNodes['/L/I'], base: null});
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
     });
 
     it('should prevent library modification via createNode if parent is library root', function () {
@@ -226,11 +231,16 @@ describe('Library core ', function () {
         expect(metaNodes['/L/I']).not.to.equal(null);
 
         libraryRoot = core.getLibraryRoot(metaNodes['/L/I'], 'basicLibrary');
-        error = core.createNode({parent: libraryRoot, base: null});
+        try {
+            core.createNode({parent: libraryRoot, base: null});
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
     });
 
     it('should prevent library root usage as base of new node', function () {
@@ -241,47 +251,85 @@ describe('Library core ', function () {
         expect(metaNodes['/L/I']).not.to.equal(null);
 
         libraryRoot = core.getLibraryRoot(metaNodes['/L/I'], 'basicLibrary');
-        error = core.createNode({parent: root, base: libraryRoot});
+        try {
+            core.createNode({parent: root, base: libraryRoot});
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
     });
 
     it('should prevent to remove library element or root', function () {
         var error;
 
-        error = core.deleteNode(core.getLibraryRoot(root, 'basicLibrary'));
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.deleteNode(core.getLibraryRoot(root, 'basicLibrary'));
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        error = core.deleteNode(core.getAllMetaNodes(root)['/L/I']);
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.deleteNode(core.getAllMetaNodes(root)['/L/I']);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent the copy of library root', function () {
         var error;
 
-        error = core.copyNode(core.getLibraryRoot(root, 'basicLibrary'), root);
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.copyNode(core.getLibraryRoot(root, 'basicLibrary'), root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        error = core.copyNodes([core.getLibraryRoot(root, 'basicLibrary')], root);
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.copyNodes([core.getLibraryRoot(root, 'basicLibrary')], root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent the move of any library element', function () {
         var error;
 
-        error = core.moveNode(core.getLibraryRoot(root, 'basicLibrary'), root);
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.moveNode(core.getLibraryRoot(root, 'basicLibrary'), root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        error = core.moveNode(core.getAllMetaNodes(root)['/L/I'], root);
-        expect(error instanceof Error).to.equal(true);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.moveNode(core.getAllMetaNodes(root)['/L/I'], root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error instanceof Error).to.equal(true);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delAttribute', function () {

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -155,13 +155,25 @@ describe('Library core ', function () {
     });
 
     it('should give error if not a library member is asked for library GUID', function () {
-        var error = core.getLibraryGuid(root);
-        expect(error.message).to.contain('Node is not a library member');
+        var error;
+        try {
+            core.getLibraryGuid(root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error.message).to.contain('Node is not a library member');
+        }
     });
 
     it('should give error if unknown library was given to look for library GUID', function () {
-        var error = core.getLibraryGuid(core.getAllMetaNodes(root)['/L/I'], 'unknown');
-        expect(error.message).to.contain('Unknown library was given');
+        var error;
+        try {
+            core.getLibraryGuid(core.getAllMetaNodes(root)['/L/I'], 'unknown');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error.message).to.contain('Unknown library was given');
+        }
     });
 
     it('should list all library names', function () {
@@ -185,11 +197,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setAttribute(metaNodes['/L/I'], 'anyAttribute', 'anyValue');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('modify library');
+        try {
+            core.setAttribute(metaNodes['/L/I'], 'anyAttribute', 'anyValue');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('modify library');
+        }
     });
 
     it('should prevent library modification via setRegistry', function () {
@@ -198,11 +214,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setRegistry(metaNodes['/L/I'], 'anyAttribute', 'anyValue');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('modify library');
+        try {
+            core.setRegistry(metaNodes['/L/I'], 'anyAttribute', 'anyValue');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('modify library');
+        }
     });
 
     it('should prevent library modification via createNode if parent is library item', function () {
@@ -338,11 +358,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delAttribute(metaNodes['/L/I'], 'name');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delAttribute(metaNodes['/L/I'], 'name');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setRegistry', function () {
@@ -351,11 +375,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setRegistry(metaNodes['/L/I'], 'anyRegistry', 'anyValue');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setRegistry(metaNodes['/L/I'], 'anyRegistry', 'anyValue');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delRegistry', function () {
@@ -364,11 +392,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delRegistry(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delRegistry(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setPointer', function () {
@@ -377,11 +409,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setPointer(metaNodes['/L/I'], 'any', root);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setPointer(metaNodes['/L/I'], 'any', root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via deletePointer', function () {
@@ -390,11 +426,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.deletePointer(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.deletePointer(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setBase', function () {
@@ -403,23 +443,37 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setBase(metaNodes['/L/I'], root);
+        try {
+            core.setBase(metaNodes['/L/I'], root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setBase(core.getLibraryRoot(root, 'basicLibrary'), root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        error = core.setBase(core.getLibraryRoot(root, 'basicLibrary'), root);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
-
-        error = core.setBase(metaNodes['/1'], core.getLibraryRoot(root, 'basicLibrary'));
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setBase(metaNodes['/1'], core.getLibraryRoot(root, 'basicLibrary'));
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via addMember', function () {
@@ -428,11 +482,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.addMember(metaNodes['/L/I'], 'any', root);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.addMember(metaNodes['/L/I'], 'any', root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delMember', function () {
@@ -441,11 +499,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delMember(metaNodes['/L/I'], '');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delMember(metaNodes['/L/I'], '');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setMemberAttribute', function () {
@@ -454,11 +516,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setMemberAttribute(metaNodes['/L/I'], 'any', '', 'any', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setMemberAttribute(metaNodes['/L/I'], 'any', '', 'any', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delMemberAttribute', function () {
@@ -467,11 +533,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delMemberAttribute(metaNodes['/L/I'], 'any', '', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delMemberAttribute(metaNodes['/L/I'], 'any', '', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setMemberRegistry', function () {
@@ -480,11 +550,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setMemberRegistry(metaNodes['/L/I'], 'any', '', 'any', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setMemberRegistry(metaNodes['/L/I'], 'any', '', 'any', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delMemberRegistry', function () {
@@ -493,11 +567,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delMemberRegistry(metaNodes['/L/I'], 'any', '', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delMemberRegistry(metaNodes['/L/I'], 'any', '', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via createSet', function () {
@@ -506,11 +584,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.createSet(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.createSet(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via deleteSet', function () {
@@ -519,11 +601,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.deleteSet(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.deleteSet(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setGuid', function (done) {
@@ -547,11 +633,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setConstraint(metaNodes['/L/I'], 'any', {'any': 'any'});
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setConstraint(metaNodes['/L/I'], 'any', {'any': 'any'});
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delConstraint', function () {
@@ -560,11 +650,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delConstraint(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delConstraint(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via clearMetaRules', function () {
@@ -573,11 +667,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delConstraint(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delConstraint(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setAttributeMeta', function () {
@@ -586,11 +684,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setAttributeMeta(metaNodes['/L/I'], 'any', {});
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setAttributeMeta(metaNodes['/L/I'], 'any', {});
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delAttributeMeta', function () {
@@ -599,11 +701,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delAttributeMeta(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delAttributeMeta(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setChildMeta', function () {
@@ -612,17 +718,26 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setChildMeta(metaNodes['/L/I'], root, 1, 1);
+        try {
+            core.setChildMeta(metaNodes['/L/I'], root, 1, 1);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
-
-        error = core.setChildMeta(root, core.getLibraryRoot(root, 'basicLibrary'), 1, 1);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setChildMeta(root, core.getLibraryRoot(root, 'basicLibrary'), 1, 1);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delChildMeta', function () {
@@ -631,11 +746,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delChildMeta(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delChildMeta(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setChildrenMetaLimits', function () {
@@ -644,11 +763,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setChildrenMetaLimits(metaNodes['/L/I'], 10, 10);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setChildrenMetaLimits(metaNodes['/L/I'], 10, 10);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setPointerMetaTarget', function () {
@@ -657,11 +780,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setPointerMetaTarget(metaNodes['/L/I'], 'any', root, 1, 1);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setPointerMetaTarget(metaNodes['/L/I'], 'any', root, 1, 1);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delPointerMetaTarget', function () {
@@ -670,11 +797,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delPointerMetaTarget(metaNodes['/L/I'], 'any', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delPointerMetaTarget(metaNodes['/L/I'], 'any', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setPointerMetaLimits', function () {
@@ -683,11 +814,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setPointerMetaLimits(metaNodes['/L/I'], 'any', 10, 10);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setPointerMetaLimits(metaNodes['/L/I'], 'any', 10, 10);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delPointerMeta', function () {
@@ -696,11 +831,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delPointerMeta(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delPointerMeta(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via setAspectMetaTarget', function () {
@@ -709,11 +848,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.setAspectMetaTarget(metaNodes['/L/I'], 'any', root);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.setAspectMetaTarget(metaNodes['/L/I'], 'any', root);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delAspectMetaTarget', function () {
@@ -722,11 +865,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delAspectMetaTarget(metaNodes['/L/I'], 'any', 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delAspectMetaTarget(metaNodes['/L/I'], 'any', 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delAspectMeta', function () {
@@ -735,11 +882,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delAspectMeta(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delAspectMeta(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via delMixin', function () {
@@ -748,11 +899,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.delMixin(metaNodes['/L/I'], 'any');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.delMixin(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via addMixin', function () {
@@ -761,17 +916,26 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.addMixin(metaNodes['/L/I'], 'any');
+        try {
+            core.addMixin(metaNodes['/L/I'], 'any');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+            error = null;
+        }
 
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
-
-        error = core.addMixin(root, '/L');
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.addMixin(root, '/L');
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should prevent library modification via clearMixins', function () {
@@ -780,11 +944,15 @@ describe('Library core ', function () {
 
         expect(metaNodes['/L/I']).not.to.equal(null);
 
-        error = core.clearMixins(metaNodes['/L/I']);
-
-        expect(error).not.to.equal(null);
-        expect(error).not.to.equal(undefined);
-        expect(error.message).to.contain('Not allowed to');
+        try {
+            core.clearMixins(metaNodes['/L/I']);
+        } catch (e) {
+            error = e;
+        } finally {
+            expect(error).not.to.equal(null);
+            expect(error).not.to.equal(undefined);
+            expect(error.message).to.contain('Not allowed to');
+        }
     });
 
     it('should rename a library', function (done) {
@@ -1158,12 +1326,15 @@ describe('Library core ', function () {
             shareContext.core.loadByPath(shareContext.rootNode, '/Q/P')
         ])
             .then(function (nodes) {
-                var closure = shareContext.core.getClosureInformation(nodes);
+                shareContext.core.getClosureInformation(nodes);
 
-                expect(closure).not.to.eql(null);
-                expect(closure instanceof Error).to.equal(true);
-                expect(closure.message).to.contains('cannot be created');
-                expect(closure.message).to.contains('base');
+                throw new Error('missing error handling in library core');
+            })
+            .catch(function (error) {
+                expect(error).not.to.eql(null);
+                expect(error instanceof Error).to.equal(true);
+                expect(error.message).to.contains('cannot be created');
+                expect(error.message).to.contains('base');
             })
             .nodeify(done);
     });
@@ -1175,11 +1346,14 @@ describe('Library core ', function () {
             shareContext.core.loadByPath(shareContext.rootNode, '')
         ])
             .then(function (nodes) {
-                var closure = shareContext.core.getClosureInformation(nodes);
+                shareContext.core.getClosureInformation(nodes);
 
-                expect(closure).not.to.eql(null);
-                expect(closure instanceof Error).to.equal(true);
-                expect(closure.message).to.contains('Cannot select the project root!');
+                throw new Error('missing error handling in library core');
+            })
+            .catch(function (error) {
+                expect(error).not.to.eql(null);
+                expect(error instanceof Error).to.equal(true);
+                expect(error.message).to.contains('Cannot select the project root!');
             })
             .nodeify(done);
     });
@@ -1191,12 +1365,15 @@ describe('Library core ', function () {
             shareContext.core.loadByPath(shareContext.rootNode, '/V/G')
         ])
             .then(function (nodes) {
-                var closure = shareContext.core.getClosureInformation(nodes);
+                shareContext.core.getClosureInformation(nodes);
 
-                expect(closure).not.to.eql(null);
-                expect(closure instanceof Error).to.equal(true);
-                expect(closure.message).to.contains('Cannot select node');
-                expect(closure.message).to.contains('library content');
+                throw new Error('missing error handling in library core');
+            })
+            .catch(function (error) {
+                expect(error).not.to.eql(null);
+                expect(error instanceof Error).to.equal(true);
+                expect(error.message).to.contains('Cannot select node');
+                expect(error.message).to.contains('library content');
             })
             .nodeify(done);
     });
@@ -1315,7 +1492,7 @@ describe('Library core ', function () {
                 ]);
 
                 //checking the relations, they all should be valid
-                var names = shareContext.core.getPointerNames(newNodes[0])
+                var names = shareContext.core.getPointerNames(newNodes[0]);
                 for (i = 0; i < names.length; i += 1) {
                     expect(shareContext.core.getPointerPath(newNodes[0], names[i])).not.to.eql(null);
                     expect(shareContext.core.getPointerPath(newNodes[0], names[i])).not.to.eql(undefined);
@@ -1342,10 +1519,14 @@ describe('Library core ', function () {
                 delete closure.bases['6686433f-c77c-61a5-cd70-e12860311fe1'];
                 closure.bases['6686433f-c77c-61a5-cd70-000000000000'].originGuid =
                     '6686433f-c77c-61a5-cd70-000000000000';
-                closure = shareContext.core.importClosure(shareContext.rootNode, closure);
-                expect(closure).not.to.eql(null);
-                expect(closure instanceof Error).to.equal(true);
-                expect(closure.message).to.include('Cannot find necessary base');
+
+                shareContext.core.importClosure(shareContext.rootNode, closure);
+                throw new Error('missing error handling in library core');
+            })
+            .catch(function (error) {
+                expect(error).not.to.eql(null);
+                expect(error instanceof Error).to.equal(true);
+                expect(error.message).to.include('Cannot find necessary base');
             })
             .nodeify(done);
     });
@@ -1379,10 +1560,14 @@ describe('Library core ', function () {
                 closure.bases['6686433f-c77c-61a5-cd70-000000000000'] =
                     closure.bases['6686433f-c77c-61a5-cd70-e12860311fe1'];
                 delete closure.bases['6686433f-c77c-61a5-cd70-e12860311fe1'];
-                closure = shareContext.core.importClosure(newRoot, closure);
-                expect(closure).not.to.eql(null);
-                expect(closure instanceof Error).to.equal(true);
-                expect(closure.message).to.include('Ambiguous occurrences of base');
+
+                shareContext.core.importClosure(newRoot, closure);
+                throw new Error('missing error handling in library core');
+            })
+            .catch(function(error){
+                expect(error).not.to.eql(null);
+                expect(error instanceof Error).to.equal(true);
+                expect(error.message).to.include('Ambiguous occurrences of base');
             })
             .nodeify(done);
     });

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -477,7 +477,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error, 'CoreInputError');
+            checkError(error, 'CoreIllegalArgumentError');
         }
     });
 
@@ -646,7 +646,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreInputError');
+            checkError(error,'CoreIllegalArgumentError');
         }
     });
 
@@ -704,7 +704,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreInputError');
+            checkError(error,'CoreIllegalArgumentError');
         }
     });
 
@@ -751,7 +751,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreInputError');
+            checkError(error,'CoreIllegalArgumentError');
         }
     });
 
@@ -813,7 +813,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreInputError');
+            checkError(error,'CoreIllegalArgumentError');
         }
     });
 

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -57,6 +57,13 @@ describe('Library core ', function () {
         return deferred.promise;
     }
 
+    function checkError(error, errorType) {
+        expect(error).not.to.equal(null);
+        expect(error).not.to.equal(undefined);
+        expect(error instanceof Error).to.eql(true);
+        expect(error.name).to.eql(errorType || 'CoreIllegalOperationError');
+    }
+
     before(function (done) {
         gmeConfig = testFixture.getGmeConfig();
         logger = testFixture.logger.fork('LibraryCore');
@@ -202,9 +209,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('modify library');
+            checkError(error);
         }
     });
 
@@ -219,9 +224,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('modify library');
+            checkError(error);
         }
     });
 
@@ -236,9 +239,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
 
     });
@@ -256,9 +257,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
 
     });
@@ -276,9 +275,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
 
     });
@@ -291,8 +288,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -301,8 +297,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -314,8 +309,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -324,8 +318,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -337,8 +330,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -347,8 +339,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error instanceof Error).to.equal(true);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -363,9 +354,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -380,9 +369,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -397,9 +384,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -414,9 +399,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -431,9 +414,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -448,9 +429,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -459,9 +438,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -470,9 +447,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -487,9 +462,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -504,9 +477,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error, 'CoreInputError');
         }
     });
 
@@ -521,9 +492,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -538,9 +507,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -555,9 +522,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -572,9 +537,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -606,9 +569,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -655,9 +616,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -672,9 +631,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -689,9 +646,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error,'CoreInputError');
         }
     });
 
@@ -706,9 +661,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -751,9 +704,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error,'CoreInputError');
         }
     });
 
@@ -785,9 +736,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -802,9 +751,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error,'CoreInputError');
         }
     });
 
@@ -819,9 +766,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -836,9 +781,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -870,9 +813,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error,'CoreInputError');
         }
     });
 
@@ -887,9 +828,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -900,13 +839,11 @@ describe('Library core ', function () {
         expect(metaNodes['/L/I']).not.to.equal(null);
 
         try {
-            core.delMixin(metaNodes['/L/I'], 'any');
+            core.delMixin(metaNodes['/L/I'], '/1');
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -917,13 +854,11 @@ describe('Library core ', function () {
         expect(metaNodes['/L/I']).not.to.equal(null);
 
         try {
-            core.addMixin(metaNodes['/L/I'], 'any');
+            core.addMixin(metaNodes['/L/I'], '/1');
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
             error = null;
         }
 
@@ -932,9 +867,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            expect(error).not.to.equal(null);
-            expect(error).not.to.equal(undefined);
-            expect(error.message).to.contain('Not allowed to');
+            checkError(error);
         }
     });
 
@@ -1564,7 +1497,7 @@ describe('Library core ', function () {
                 shareContext.core.importClosure(newRoot, closure);
                 throw new Error('missing error handling in library core');
             })
-            .catch(function(error){
+            .catch(function (error) {
                 expect(error).not.to.eql(null);
                 expect(error instanceof Error).to.equal(true);
                 expect(error.message).to.include('Ambiguous occurrences of base');

--- a/test/common/core/metacachecore.spec.js
+++ b/test/common/core/metacachecore.spec.js
@@ -198,7 +198,7 @@ describe('meta cache core', function () {
         var root = core.createNode({}),
             itemBase = core.createNode({parent: root}),
             item = core.createNode({parent: root, base: itemBase}),
-            itemBasePath = core.getPath(itemBase),
+            itemPath = core.getPath(item),
             hash = core.getHash(root);
 
         core.addMember(root, 'MetaAspectSet', itemBase);
@@ -210,18 +210,18 @@ describe('meta cache core', function () {
 
         core.loadRoot(hash)
             .then(function (root) {
-                var itemBase;
+                var item;
                 expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(2);
 
-                itemBase = core.getAllMetaNodes(root)[itemBasePath];
-                core.deleteNode(itemBase, true);
+                item = core.getAllMetaNodes(root)[itemPath];
+                core.deleteNode(item);
                 core.persist(root);
                 hash = core.getHash(root);
 
                 return core.loadRoot(hash);
             })
             .then(function (root) {
-                expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(0);
+                expect(Object.keys(core.getAllMetaNodes(root))).to.have.length(1);
             })
             .nodeify(done);
     });

--- a/test/common/core/metacore.spec.js
+++ b/test/common/core/metacore.spec.js
@@ -122,8 +122,6 @@ describe('meta core', function () {
 
     it('checking attribute values', function () {
 
-        core.isValidAttributeValueOf(attrNode, 'unknown', 'anything').should.be.false;
-
         core.isValidAttributeValueOf(attrNode, 'boolean', 'true').should.be.false;
         core.isValidAttributeValueOf(attrNode, 'boolean', 1).should.be.false;
         core.isValidAttributeValueOf(attrNode, 'boolean', 1.1).should.be.false;
@@ -208,9 +206,6 @@ describe('meta core', function () {
 
         core.isValidTargetOf(attrNode, setNode, 'set').should.be.true;
         core.isValidTargetOf(setNode, setNode, 'set').should.be.true;
-        core.isValidTargetOf(base, setNode, 'set').should.be.false;
-
-        core.isValidTargetOf(attrNode, setNode, 'unknown').should.be.false;
 
         core.isValidTargetOf(attrNode, setNode, 'ptr').should.be.true;
         core.isValidTargetOf(aspectNode, setNode, 'ptr').should.be.true;

--- a/test/common/core/mixincore.spec.js
+++ b/test/common/core/mixincore.spec.js
@@ -494,7 +494,6 @@ describe('mixin core', function () {
             expect(core.isValidTargetOf(M2, A, 'Ms')).to.equal(true);
             expect(core.isValidTargetOf(M3, A, 'FCO')).to.equal(true);
             expect(core.isValidTargetOf(M4, A, 'FCO')).to.equal(true);
-            expect(core.isValidTargetOf(FCO, A, 'unknown')).to.equal(false);
         });
 
         it('should check if a given node is a valid child based on the composed rule-set', function () {

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -425,7 +425,7 @@ describe('set core', function () {
             core.setMemberRegistry(setType, 'set', 'doesNotExist', 'myReg', 'myValue');
         } catch (e) {
             expect(e instanceof Error).to.eql(true);
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
         } finally {
             expect(core.getMemberPaths(setType, 'set')).to.deep.equal([]);
         }
@@ -639,7 +639,7 @@ describe('set core', function () {
             core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath');
         } catch (e) {
             expect(e instanceof Error).to.eql(true);
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
         }
     });
 
@@ -652,7 +652,7 @@ describe('set core', function () {
             core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath');
         } catch (e) {
             expect(e instanceof Error).to.eql(true);
-            expect(e.name).to.eql('CoreInputError');
+            expect(e.name).to.eql('CoreIllegalArgumentError');
         }
     });
 

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -149,7 +149,6 @@ describe('set core', function () {
                 child = core.createNode({parent: proto, relid: 'c'}),
                 member = core.createNode({parent: root});
 
-
             core.createSet(child, 'set');
             core.addMember(child, 'set', member);
 
@@ -172,7 +171,6 @@ describe('set core', function () {
                 derived = core.createNode({parent: root, base: proto, relid: 'd'}),
                 child = core.createNode({parent: proto, relid: 'c'}),
                 member = core.createNode({parent: root});
-
 
             core.createSet(child, 'set');
             core.addMember(child, 'set', member);
@@ -402,7 +400,7 @@ describe('set core', function () {
         ]);
 
         //now override the property
-        core.setMemberAttribute(setInstance,'set',core.getPath(propertyOverriddenMember),'myAttr','myValue');
+        core.setMemberAttribute(setInstance, 'set', core.getPath(propertyOverriddenMember), 'myAttr', 'myValue');
 
         expect(core.getOwnMemberPaths(setInstance, 'set')).to.have.members([
             core.getPath(propertyOverriddenMember),
@@ -419,14 +417,18 @@ describe('set core', function () {
         ]);
     });
 
-
     it('setMemberRegistry should not modify the set if path not a member', function () {
         var setType = core.createNode({parent: root});
 
         core.createSet(setType, 'set');
-        core.setMemberRegistry(setType, 'set', 'doesNotExist', 'myReg', 'myValue');
-
-        expect(core.getMemberPaths(setType, 'set')).to.deep.equal([]);
+        try {
+            core.setMemberRegistry(setType, 'set', 'doesNotExist', 'myReg', 'myValue');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreInputError');
+        } finally {
+            expect(core.getMemberPaths(setType, 'set')).to.deep.equal([]);
+        }
     });
 
     it('getMemberRegistry/Names and getMemberOwnRegistry/Names should return appropriate', function () {
@@ -477,25 +479,6 @@ describe('set core', function () {
         expect(core.getMemberOwnAttribute(setInstance, 'set', mPath, 'instanceAttr')).to.equal('myValue2');
     });
 
-    it('all member getters should return undefined or empty array when no set defined', function () {
-        var node = core.createNode({parent: root}),
-            dummyPath = 'doesNotExist',
-            dummyPropName = 'dummyProp';
-
-        expect(core.getMemberPaths (node, 'set')).to.deep.equal([]);
-        expect(core.getOwnMemberPaths (node, 'set')).to.deep.equal([]);
-
-        expect(core.getMemberAttributeNames(node, 'set', dummyPath)).to.deep.equal([]);
-        expect(core.getMemberOwnAttributeNames(node, 'set', dummyPath)).to.deep.equal([]);
-        expect(core.getMemberAttribute(node, 'set', dummyPath, dummyPropName)).to.equal(undefined);
-        expect(core.getMemberOwnAttribute(node, 'set', dummyPath, dummyPropName)).to.equal(undefined);
-
-        expect(core.getMemberRegistryNames(node, 'set', dummyPath)).to.deep.equal([]);
-        expect(core.getMemberOwnRegistryNames(node, 'set', dummyPath)).to.deep.equal([]);
-        expect(core.getMemberRegistry(node, 'set', dummyPath, dummyPropName)).to.equal(undefined);
-        expect(core.getMemberOwnRegistry(node, 'set', dummyPath, dummyPropName)).to.equal(undefined);
-    });
-
     it('add a memberAttribute/Registry and then delete it twice', function () {
         var setType = core.createNode({parent: root}),
             member = core.createNode({parent: root}),
@@ -520,8 +503,18 @@ describe('set core', function () {
         expect(core.getMemberAttribute(setType, 'set', memberPath, 'myAttr')).to.equal(undefined);
         expect(core.getMemberRegistry(setType, 'set', memberPath, 'myReg')).to.equal(undefined);
 
-        core.delMemberAttribute(setType, 'set', core.getPath(member), 'myAttr');
-        core.delMemberRegistry(setType, 'set', core.getPath(member), 'myReg');
+        try {
+            core.delMemberAttribute(setType, 'set', core.getPath(member), 'myAttr');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.delMemberRegistry(setType, 'set', core.getPath(member), 'myReg');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
     });
 
     it('should set/get/del Set Registries and own should act as expected', function () {
@@ -529,10 +522,30 @@ describe('set core', function () {
             setInstance = core.createNode({parent: root, base: setType});
 
         // Getting before set created
-        expect(core.getSetRegistryNames(setType, 'set')).to.deep.equal([]);
-        expect(core.getOwnSetRegistryNames(setType, 'set')).to.deep.equal([]);
-        expect(core.getSetRegistry(setType, 'set', 'base')).to.equal(undefined);
-        expect(core.getOwnSetRegistry(setType, 'set', 'base')).to.equal(undefined);
+        try {
+            core.getSetRegistryNames(setType, 'set');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getOwnSetRegistryNames(setType, 'set');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getSetRegistry(setType, 'set', 'base');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getOwnSetRegistry(setType, 'set', 'base');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
 
         core.createSet(setType, 'set');
         core.setSetRegistry(setType, 'set', 'base', 'baseValue');
@@ -558,10 +571,30 @@ describe('set core', function () {
             setInstance = core.createNode({parent: root, base: setType});
 
         // Getting before set created
-        expect(core.getSetAttributeNames(setType, 'set')).to.deep.equal([]);
-        expect(core.getOwnSetAttributeNames(setType, 'set')).to.deep.equal([]);
-        expect(core.getSetAttribute(setType, 'set', 'base')).to.equal(undefined);
-        expect(core.getOwnSetAttribute(setType, 'set', 'base')).to.equal(undefined);
+        try {
+            core.getSetAttributeNames(setType, 'set');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getOwnSetAttributeNames(setType, 'set');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getSetAttribute(setType, 'set', 'base');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.getOwnSetAttribute(setType, 'set', 'base');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
 
         core.createSet(setType, 'set');
         core.setSetAttribute(setType, 'set', 'base', 'baseValue');
@@ -599,24 +632,28 @@ describe('set core', function () {
         expect(core.getOwnSetNames(setInstance, 'set')).to.have.members(['setInstance']);
     });
 
-    it('isFullyOverriddenMember should return false if no set', function () {
+    it('isFullyOverriddenMember should throw if no set', function () {
         var setType = core.createNode({parent: root});
 
-        expect(core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath')).to.equal(false);
+        try {
+            core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreInputError');
+        }
     });
 
-    it('isFullyOverriddenMember should return false if no set', function () {
-        var setType = core.createNode({parent: root});
-
-        expect(core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath')).to.equal(false);
-    });
-
-    it('isFullyOverriddenMember should return false if no base', function () {
+    it('isFullyOverriddenMember should throw if no base', function () {
         var setType = core.createNode({parent: root});
 
         core.createSet(setType, 'set');
 
-        expect(core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath')).to.equal(false);
+        try {
+            core.isFullyOverriddenMember(setType, 'set', 'dummyMemberPath');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreInputError');
+        }
     });
 
     it('isFullyOverriddenMember should return false if base does not have set', function () {
@@ -639,7 +676,7 @@ describe('set core', function () {
 
         core.createSet(setType, 'set');
         core.addMember(setType, 'set', member);
-        core.setMemberRegistry(setInstance, 'set', member, 'reg', 'regValue');
+        core.setMemberRegistry(setInstance, 'set', memberPath, 'reg', 'regValue');
 
         expect(core.isFullyOverriddenMember(setInstance, 'set', memberPath)).to.equal(false);
     });
@@ -676,11 +713,12 @@ describe('set core', function () {
         var setType = core.createNode({parent: root}),
             setInstance = core.createNode({parent: root, base: setType}),
             member = core.createNode({parent: root}),
+            memberPath = core.getPath(member),
             compareObj = {};
 
         core.createSet(setType, 'set');
         core.addMember(setType, 'set', member);
-        core.setMemberRegistry(setInstance, 'set', member, 'reg', 'regValue');
+        core.setMemberRegistry(setInstance, 'set', memberPath, 'reg', 'regValue');
 
         compareObj[core.getPath(setType)] = ['set'];
         expect(core.isMemberOf(member)).to.deep.equal(compareObj);
@@ -688,11 +726,12 @@ describe('set core', function () {
 
     it('getCollectionNames should exclude member(ships)', function () {
         var setType = core.createNode({parent: root}),
-            member = core.createNode({parent: root});
+            member = core.createNode({parent: root}),
+            memberPath = core.getPath(member);
 
         core.createSet(setType, 'set');
         core.addMember(setType, 'set', member);
-        core.setMemberRegistry(setType, 'set', member, 'reg', 'regValue');
+        core.setMemberRegistry(setType, 'set', memberPath, 'reg', 'regValue');
         core.setPointer(setType, 'ptr', member);
 
         expect(core.getCollectionNames(member)).to.deep.equal(['ptr']);
@@ -815,8 +854,18 @@ describe('set core', function () {
             persisted;
 
         core.persist(root);
-        core.setSetAttribute(setType, 'set', 'someName', 'someVal');
-        core.setSetRegistry(setType, 'set', 'someName', 'someVal');
+        try {
+            core.setSetAttribute(setType, 'set', 'someName', 'someVal');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.setSetRegistry(setType, 'set', 'someName', 'someVal');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
         persisted = core.persist(root).objects;
         expect(persisted).to.deep.equal({});
     });
@@ -839,8 +888,18 @@ describe('set core', function () {
             persisted;
 
         core.persist(root);
-        core.delSetAttribute(setType, 'set', 'someName');
-        core.delSetRegistry(setType, 'set', 'someName');
+        try {
+            core.delSetAttribute(setType, 'set', 'someName');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+        try {
+            core.delSetRegistry(setType, 'set', 'someName');
+        } catch (e) {
+            expect(e instanceof Error).to.eql(true);
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
         persisted = core.persist(root).objects;
         expect(persisted).to.deep.equal({});
     });

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -678,15 +678,13 @@ describe('Meta Rules', function () {
         it('should return error when set starts with _', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    // TODO: This should throw!
                     c.core.setPointerMetaTarget(c.fco, '_underscore', c.fco, -1, -1);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines a set [_underscore] starting with an underscore');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -694,15 +692,13 @@ describe('Meta Rules', function () {
         it('should return error when set is named ovr', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    // TODO: This should throw!
                     c.core.setPointerMetaTarget(c.fco, 'ovr', c.fco, -1, -1);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines a set [ovr] which is a reserved name');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -710,16 +706,13 @@ describe('Meta Rules', function () {
         it('should return error when aspect starts with _', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    c.core.setChildMeta(c.fco, c.fco, -1, -1);
-                    // TODO: This should throw!
                     c.core.setAspectMetaTarget(c.fco, '_underscore', c.fco);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines an aspect [_underscore] starting with an underscore');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -727,16 +720,13 @@ describe('Meta Rules', function () {
         it('should return error when aspect is named ovr', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    c.core.setChildMeta(c.fco, c.fco, -1, -1);
-                    // TODO: This should throw!
                     c.core.setAspectMetaTarget(c.fco, 'ovr', c.fco);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines an aspect [ovr] which is a reserved name');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -744,16 +734,13 @@ describe('Meta Rules', function () {
         it('should return error when pointer starts with _', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    // TODO: This should throw!
-                    c.core.setPointerMetaTarget(c.fco, '_underscore', c.fco, 1, 1);
                     c.core.setPointerMetaLimits(c.fco, '_underscore', 1, 1);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines a pointer [_underscore] starting with an underscore');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -761,16 +748,13 @@ describe('Meta Rules', function () {
         it('should return error when pointer is named base', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    // TODO: This should throw!
-                    c.core.setPointerMetaTarget(c.fco, 'base', c.fco, 1, 1);
                     c.core.setPointerMetaLimits(c.fco, 'base', 1, 1);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines a pointer [base] which is a reserved name');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });
@@ -778,16 +762,13 @@ describe('Meta Rules', function () {
         it('should return error when pointer is named base', function (done) {
             getContext()
                 .then(function (c) {
-                    var result;
-                    // TODO: This should throw!
                     c.core.setPointerMetaTarget(c.fco, 'base', c.fco, 1, 1);
-                    c.core.setPointerMetaLimits(c.fco, 'base', 1, 1);
 
-                    result = checkMetaConsistency(c.core, c.root);
-
-                    expect(result.length).to.equal(1);
-                    expect(result[0].severity).to.equal('error');
-                    expect(result[0].message).to.include('defines a pointer [base] which is a reserved name');
+                    throw new Error('should have thrown earlier!!!');
+                })
+                .catch(function (e) {
+                    expect(e instanceof Error).to.eql(true);
+                    expect(e.name).to.eql('CoreIllegalArgumentError');
                 })
                 .nodeify(done);
         });


### PR DESCRIPTION
This enhancement introduces extra checks at the upper layers of Core and unifies its behavior regarding errors. Whenever an ASSERTION fails or some check shows invalid inputs, the Core will throw one of the following errors:
- CoreIllegalArgumentError - if the type of the input parameters is not what it should be
- CoreIllegalOperationError - if the set of input parameters are correct but the request or the operation do not apply to the current context. Here we followed the basic javascript principles in terms that whenever the user try to access a 'field' of a 'field' that does not exist, we throw. For example if someone tries to get the member attributes of an non-existing member. Trying to modify read-only nodes are captured within this category.
- CoreAssertError - happens if some internal ASSERTION fails, it triggers some fault inside the core and should typically be checked by the developer team, not the one who uses it.

The throwing behavior is followed in the client as well, meaning the from this enhancement the UI developers should be prepared for exceptions.

It also updates the function descriptions of the core (mentioning the promise like behavior). 