### PR TITLE
Fixes #1269 - Exporting model fails with error about aspect sets missing a base

### DIFF
--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -910,7 +910,7 @@ define([
 
             do {
                 overlays = self.getProperty(node, CONSTANTS.OVERLAYS_PROPERTY);
-                if (overlays && overlays[source] && overlays[source][name] !== undefined) {
+                if (overlays && overlays[source] && typeof overlays[source][name] == 'string') {
                     self.overlayRemove(node, source, name, overlays[source][name]);
                 }
 

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -910,7 +910,7 @@ define([
 
             do {
                 overlays = self.getProperty(node, CONSTANTS.OVERLAYS_PROPERTY);
-                if (overlays && overlays[source] && overlays[source][name]) {
+                if (overlays && overlays[source] && overlays[source][name] !== undefined) {
                     self.overlayRemove(node, source, name, overlays[source][name]);
                 }
 

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -753,13 +753,14 @@ define([
 
         this.copyNode = function (node, parent, relidLength) {
             ASSERT(!node.base || self.getPath(node.base) !== self.getPath(parent));
-            var base = node.base,
-                newnode;
+            var newnode;
 
             relidLength = relidLength || innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
             newnode = innerCore.copyNode(node, parent, self.getChildrenRelids(parent, true), relidLength);
-            newnode.base = base;
-            innerCore.setPointer(newnode, CONSTANTS.BASE_POINTER, base);
+            newnode.base = node.base;
+            if (typeof self.getPointerPath(node, CONSTANTS.BASE_POINTER) === 'string') {
+                innerCore.setPointer(newnode, CONSTANTS.BASE_POINTER, node.base);
+            }
 
             // The copy does not have any instances at this point -> reset the property.
             innerCore.deleteProperty(newnode, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);

--- a/test/common/core/librarycore.spec.js
+++ b/test/common/core/librarycore.spec.js
@@ -646,7 +646,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreIllegalArgumentError');
+            checkError(error, 'CoreIllegalArgumentError');
         }
     });
 
@@ -704,7 +704,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreIllegalArgumentError');
+            checkError(error, 'CoreIllegalArgumentError');
         }
     });
 
@@ -751,7 +751,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreIllegalArgumentError');
+            checkError(error, 'CoreIllegalArgumentError');
         }
     });
 
@@ -813,7 +813,7 @@ describe('Library core ', function () {
         } catch (e) {
             error = e;
         } finally {
-            checkError(error,'CoreIllegalArgumentError');
+            checkError(error, 'CoreIllegalArgumentError');
         }
     });
 
@@ -1346,6 +1346,31 @@ describe('Library core ', function () {
                 ]);
             })
             .nodeify(done);
+    });
+
+    it('should generate a proper closure if sets are involved (#1269)', function () {
+        var core = shareContext.core,
+            root = core.createNode(),
+            fco = core.createNode({parent: root, base: null}),
+            item = core.createNode({parent: root, base: fco}),
+            closureInfo;
+
+        //setting language boundaries
+        core.createSet(root, 'MetaAspectSet');
+        core.addMember(root, 'MetaAspectSet', fco);
+
+        //playing with set entry
+        core.addMember(item, 'anyset', item);
+        core.setMemberRegistry(item, 'anyset', core.getPath(item), 'position', {x: 100, y: 100});
+        core.addMember(item, 'anyset', item);
+
+        expect(core.getMemberRegistry(item, 'anyset', core.getPath(item), 'position')).to.eql({x: 100, y: 100});
+
+        closureInfo = core.getClosureInformation([item]);
+        expect(closureInfo).not.to.eql(null);
+        expect(closureInfo).not.to.eql(undefined);
+        expect(Object.keys(closureInfo.selection)).to.have.length(1);
+        expect(Object.keys(closureInfo.relations.preserved)).to.have.length(1);
     });
 
     it('should import closure without the losses', function (done) {


### PR DESCRIPTION
When copying a node it has to create a pointer connection on demand, but only if the original node has one!
Also, when removing a pointer, we have to be prepared, that the value was an empty string!