### PR TITLE
Fixes #1271 Show clickable notification when plugin finishes

### DIFF
--- a/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
+++ b/src/client/js/Dialogs/PluginResults/PluginResultsDialog.js
@@ -45,12 +45,12 @@ define(['js/util',
         this.logger = Logger.create('gme:Dialogs:PluginResults:PluginResultsDialog', WebGMEGlobal.gmeConfig.client.log);
     };
 
-    PluginResultsDialog.prototype.show = function (client, pluginResults) {
+    PluginResultsDialog.prototype.show = function (client, pluginResults, expandedId) {
         var self = this;
 
         this._dialog = $(pluginResultsDialogTemplate);
         this._client = client;
-        this._initDialog(pluginResults);
+        this._initDialog(pluginResults, expandedId || null);
 
         this._dialog.on('hidden.bs.modal', function () {
             self._dialog.remove();
@@ -62,7 +62,7 @@ define(['js/util',
     };
 
 
-    PluginResultsDialog.prototype._initDialog = function (pluginResults) {
+    PluginResultsDialog.prototype._initDialog = function (pluginResults, expandedId) {
         var self = this,
             dialog = this._dialog,
             client = this._client,
@@ -149,6 +149,14 @@ define(['js/util',
             return historyContainer;
         }
 
+        function toggleCollapsed(resultDiv) {
+            var messagesPanel = resultDiv.find('.messages'),
+                artifactsPanel = resultDiv.find('.artifacts');
+
+            messagesPanel.toggleClass('in');
+            artifactsPanel.toggleClass('in');
+        }
+
         for (i = 0; i < pluginResults.length; i += 1) {
             result = pluginResults[i];
 
@@ -233,6 +241,10 @@ define(['js/util',
 
             resultEntry.append(messageContainer);
 
+            if (result.__id === expandedId) {
+                toggleCollapsed(resultEntry);
+            }
+
             body.append(resultEntry);
         }
 
@@ -242,12 +254,7 @@ define(['js/util',
         });
 
         dialog.on('click', '.btn-details', function (event) {
-            var detailsBtn = $(this),
-                messagesPanel = detailsBtn.parent().parent().find('.messages'),
-                artifactsPanel = detailsBtn.parent().parent().find('.artifacts');
-
-            messagesPanel.toggleClass('in');
-            artifactsPanel.toggleClass('in');
+            toggleCollapsed($(this).parent().parent());
 
             event.stopPropagation();
             event.preventDefault();

--- a/src/client/js/Panels/Header/PluginToolbar.js
+++ b/src/client/js/Panels/Header/PluginToolbar.js
@@ -8,6 +8,7 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResults
     'use strict';
 
     var PluginToolbar,
+        DEFAULT_ICON_CLASS = 'glyphicon glyphicon-cog',
         BADGE_BASE = $('<span class="label label-info"></span>');
 
     PluginToolbar = function (client) {
@@ -78,7 +79,7 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResults
                 } else if (metadata.icon.class) {
                     params.icon.addClass(metadata.icon.class);
                 } else {
-                    params.icon.addClass('glyphicon glyphicon-cog');
+                    params.icon.addClass(DEFAULT_ICON_CLASS);
                 }
 
                 params.icon.addClass('plugin-icon');
@@ -98,10 +99,48 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResults
                     // Aborted in dialog.
                     return;
                 }
+
+                var metadata = WebGMEGlobal.allPluginsMetadata[result.pluginId],
+                    msg = ' ' + metadata.id + ' ',
+                    note;
+
                 result.__unread = true;
                 self._results.splice(0, 0, result);
                 self.$btnExecutePlugin.el.find('.btn').disable(false);
                 unreadResults += 1;
+
+                if (result.success) {
+                    msg += 'finished with success! (click for details)';
+                } else {
+                    msg += 'failed (click for details), error: ' + result.error;
+                }
+
+                note = $.notify({
+                    icon: metadata.icon.class ? metadata.icon.class : DEFAULT_ICON_CLASS,
+                    message: msg
+                },{
+                    delay: 10000,
+                    type: result.success ? 'success' : 'danger',
+                    offset: {
+                        x: 20,
+                        y: 37
+                    },
+                    mouse_over: 'pause',
+                    onClose: function () {
+                        note.$ele.off();
+                    }
+                });
+
+                note.$ele.css('cursor', 'pointer');
+
+                note.$ele.on('click', function () {
+                    if (self._results.length > 0) {
+                        showResults();
+                    }
+
+                    note.close();
+                });
+
                 if (unreadResults > 0) {
                     setBadgeText(unreadResults);
                 }

--- a/src/client/js/Panels/Header/PluginToolbar.js
+++ b/src/client/js/Panels/Header/PluginToolbar.js
@@ -4,7 +4,7 @@
  * @author rkereskenyi / https://github.com/rkereskenyi
  */
 
-define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResultsDialog) {
+define(['js/Dialogs/PluginResults/PluginResultsDialog', 'common/util/guid'], function (PluginResultsDialog, GUID) {
     'use strict';
 
     var PluginToolbar,
@@ -105,6 +105,8 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResults
                     note;
 
                 result.__unread = true;
+                result.__id = GUID();
+
                 self._results.splice(0, 0, result);
                 self.$btnExecutePlugin.el.find('.btn').disable(false);
                 unreadResults += 1;
@@ -147,9 +149,9 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog'], function (PluginResults
             });
         };
 
-        showResults = function () {
+        showResults = function (resultId) {
             var dialog = new PluginResultsDialog();
-            dialog.show(client, self._results);
+            dialog.show(client, self._results, resultId);
             unreadResults = 0;
             setBadgeText('');
         };

--- a/src/client/js/Panels/Header/PluginToolbar.js
+++ b/src/client/js/Panels/Header/PluginToolbar.js
@@ -51,7 +51,12 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog', 'common/util/guid'], fun
                     title: 'Show results...',
                     text: 'Show results...',
                     clickFn: function () {
-                        showResults();
+                        var resultId;
+                        if (unreadResults === 1 && self._results.length > 0) {
+                            resultId = self._results[0].__id;
+                        }
+
+                        showResults(resultId);
                     }
                 });
                 if (pluginIds.length > 0) {
@@ -137,7 +142,7 @@ define(['js/Dialogs/PluginResults/PluginResultsDialog', 'common/util/guid'], fun
 
                 note.$ele.on('click', function () {
                     if (self._results.length > 0) {
-                        showResults();
+                        showResults(result.__id);
                     }
 
                     note.close();

--- a/src/client/js/Utils/InterpreterManager.js
+++ b/src/client/js/Utils/InterpreterManager.js
@@ -28,12 +28,13 @@ define([
 
     InterpreterManager.prototype.GLOBAL_OPTIONS = 'Global Options';
 
-    InterpreterManager.prototype.getPluginErrorResult = function (pluginName, message, startTime, projectId) {
+    InterpreterManager.prototype.getPluginErrorResult = function (pluginId, pluginName, message, startTime, projectId) {
         var pluginResult = new PluginResult(),
             pluginMessage = new PluginMessage();
         pluginMessage.severity = 'error';
         pluginMessage.message = message;
         pluginResult.setSuccess(false);
+        pluginResult.setPluginId(pluginId);
         pluginResult.setPluginName(pluginName);
         pluginResult.setProjectId(projectId || this._client.getActiveProjectId() || 'N/A');
         pluginResult.addMessage(pluginMessage);
@@ -70,7 +71,7 @@ define([
                         if (result) {
                             callback(new PluginResult(result));
                         } else {
-                            callback(self.getPluginErrorResult(metadata.id, err.message, startTime,
+                            callback(self.getPluginErrorResult(metadata.id, metadata.name, err.message, startTime,
                                 context.managerConfig.project.projectId));
                         }
                     } else {
@@ -102,7 +103,7 @@ define([
                         self._client.getBranchStatus() !== self._client.CONSTANTS.BRANCH_STATUS.SYNC;
 
                 if (!readOnlyClient && isOutOfSync) {
-                    callback(self.getPluginErrorResult(metadata.id, 'Not allowed ' +
+                    callback(self.getPluginErrorResult(metadata.id, metadata.name, 'Not allowed ' +
                         'to invoke server plugin while local branch is AHEAD or ' +
                         'PULLING changes from server.', startTime));
                     return;
@@ -179,7 +180,8 @@ define([
         }
 
         if (errorMessage) {
-            return this.getPluginErrorResult(pluginMetadata.id, errorMessage, (new Date()).toISOString());
+            return this.getPluginErrorResult(pluginMetadata.id, pluginMetadata.name, errorMessage,
+                (new Date()).toISOString());
         } else {
             result.push(runOption);
             namespace.valueItems = this._client.getLibraryNames();

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -141,11 +141,24 @@ define([
      *
      * @returns {string}
      */
+    PluginBase.prototype.getId = function () {
+        if (this.pluginMetadata) {
+            return this.pluginMetadata.id;
+        } else {
+            throw new Error('pluginMetadata is not defined - implement this function in the derived class');
+        }
+    };
+
+    /**
+     * Readable name of this plugin that can contain spaces.
+     *
+     * @returns {string}
+     */
     PluginBase.prototype.getName = function () {
         if (this.pluginMetadata) {
             return this.pluginMetadata.name;
         } else {
-            throw new Error('If pluginMetadata is not defined - implement this function in the derived class');
+            throw new Error('pluginMetadata is not defined - implement this function in the derived class');
         }
     };
 
@@ -379,6 +392,7 @@ define([
                 projectId: self.projectId,
                 branchName: self.branchName,
                 pluginName: self.getName(),
+                pluginId: self.getId(),
                 pluginVersion: self.getVersion()
             };
 

--- a/src/plugin/PluginResult.js
+++ b/src/plugin/PluginResult.js
@@ -24,6 +24,7 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
         if (config) {
             this.success = config.success;
             this.pluginName = config.pluginName;
+            this.pluginId = config.pluginId;
             this.startTime = config.startTime;
             this.finishTime = config.finishTime;
             this.messages = [];
@@ -49,6 +50,7 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
             this.finishTime = null;
             this.error = null;
             this.projectId = null;
+            this.pluginId = null;
             this.commits = [];
         }
     };
@@ -135,6 +137,15 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
     };
 
     /**
+     * Sets the name of the plugin to which the result object belongs to.
+     *
+     * @param {string} pluginName - name of the plugin
+     */
+    PluginResult.prototype.setPluginId = function (pluginId) {
+        this.pluginId = pluginId;
+    };
+
+    /**
      * Sets the name of the projectId the result was generated from.
      *
      * @param {string} projectId - id of the project
@@ -214,6 +225,7 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
             commits: this.commits,
             artifacts: this.artifacts,
             pluginName: this.pluginName,
+            pluginId: this.pluginId,
             startTime: this.startTime,
             finishTime: this.finishTime,
             error: this.error

--- a/src/plugin/managerbase.js
+++ b/src/plugin/managerbase.js
@@ -79,7 +79,7 @@ define([
                     self.runPluginMain(plugin, callback);
                 })
                 .catch(function (err) {
-                    var pluginResult = self.getPluginErrorResult(pluginId, 'Exception was raised, err: ' + err.stack,
+                    var pluginResult = self.getPluginErrorResult(pluginId, pluginId, 'Exception was raised, err: ' + err.stack,
                         plugin && plugin.projectId);
                     self.logger.error(err.stack);
                     callback(err.message, pluginResult);
@@ -194,7 +194,7 @@ define([
             self.logger.debug('plugin configured, invoking main');
 
             if (plugin.isConfigured === false) {
-                callback('Plugin is not configured.', self.getPluginErrorResult(plugin.getName(),
+                callback('Plugin is not configured.', self.getPluginErrorResult(plugin.getId(), plugin.getName(),
                     'Plugin is not configured.', project && project.projectId));
                 return;
             }
@@ -212,6 +212,7 @@ define([
                 result.setStartTime(startTime);
 
                 result.setPluginName(plugin.getName());
+                result.setPluginId(plugin.getId());
 
                 if (mainCallbackCalls > 1) {
                     stackTrace = new Error().stack;
@@ -264,13 +265,14 @@ define([
             return deferred.promise.nodeify(callback);
         }
 
-        this.getPluginErrorResult = function (pluginName, message, projectId) {
+        this.getPluginErrorResult = function (pluginId, pluginName, message, projectId) {
             var pluginResult = new PluginResult(),
                 pluginMessage = new PluginMessage();
             pluginMessage.severity = 'error';
             pluginMessage.message = message;
             pluginResult.setSuccess(false);
             pluginResult.setPluginName(pluginName);
+            pluginResult.setPluginId(pluginId);
             pluginResult.setProjectId(projectId || 'N/A');
             pluginResult.addMessage(pluginMessage);
             pluginResult.setStartTime((new Date()).toISOString());

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -130,7 +130,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
                     err = err instanceof Error ? err : new Error(err);
                     logger.error('plugin [' + pluginName + '] failed with error', err);
                     if (!result) {
-                        result = pluginManager.getPluginErrorResult(pluginName, err.message,
+                        result = pluginManager.getPluginErrorResult(pluginName, pluginName, err.message,
                             context && context.managerConfig && context.managerConfig.project);
                     } else if (!result.error) {
                         result.error = err.message;
@@ -144,13 +144,14 @@ function WorkerRequests(mainLogger, gmeConfig) {
             };
 
         if (gmeConfig.plugin.allowServerExecution === false) {
-            errResult = pluginManager.getPluginErrorResult(pluginName, 'plugin execution on server side is disabled');
+            errResult = pluginManager.getPluginErrorResult(pluginName, pluginName,
+                'plugin execution on server side is disabled');
             callback(null, errResult);
             return;
         }
 
         if (typeof pluginName !== 'string' || typeof context !== 'object') {
-            errResult = pluginManager.getPluginErrorResult(pluginName, 'invalid parameters');
+            errResult = pluginManager.getPluginErrorResult(pluginName, pluginName, 'invalid parameters');
             callback(new Error('invalid parameters'), errResult);
             return;
         }

--- a/test/plugin/PluginResult.spec.js
+++ b/test/plugin/PluginResult.spec.js
@@ -119,6 +119,7 @@ describe('Plugin Result', function () {
         pluginResult.addArtifact('hash1');
         pluginResult.addArtifact('hash2');
         pluginResult.setPluginName('test plugin 11');
+        pluginResult.setPluginId('testplugin11');
         pluginResult.setProjectId('guest+Test');
         pluginResult.setStartTime('2015-03-09T19:32:10.202Z');
         pluginResult.setFinishTime('2015-03-09T19:32:10.202Z');
@@ -153,6 +154,7 @@ describe('Plugin Result', function () {
                 }
             ],
             pluginName: 'test plugin 11',
+            pluginId: 'testplugin11',
             projectId: 'guest+Test',
             startTime: '2015-03-09T19:32:10.202Z',
             success: true
@@ -185,6 +187,7 @@ describe('Plugin Result', function () {
                     }
                 ],
                 pluginName: 'test plugin 11',
+                pluginId: 'testplugin11',
                 projectId: 'guest+Test',
                 startTime: '2015-03-09T19:32:10.202Z',
                 success: true
@@ -226,6 +229,7 @@ describe('Plugin Result', function () {
                 }
             ],
             pluginName: 'test plugin 11',
+            pluginId: 'testplugin11',
             projectId: 'guest+Test',
             startTime: '2015-03-09T19:32:10.202Z',
             success: true


### PR DESCRIPTION
When clicking the notification the plugin result dialog expands the targeted result.

This PR also adds the plugin id as a field for plugin-result and the plugin itself.

![image](https://cloud.githubusercontent.com/assets/6518904/21697665/069bae0e-d359-11e6-9b2e-a6e635145b2f.png)
