### PR TITLE
Fixes #1277 Some links in generated documentation is broken

### DIFF
--- a/jsdoc_conf.json
+++ b/jsdoc_conf.json
@@ -23,7 +23,9 @@
       "src/common/storage/project/project.js",
       "src/common/storage/project/interface.js",
       "src/server/storage/safestorage.js",
-      "src/server/storage/userproject.js"
+      "src/server/storage/userproject.js",
+      "src/common/storage/constants.js",
+      "src/common/storage/storageclasses"
     ]
   },
   "opts": {

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -20,7 +20,7 @@
  * @typedef {object} GmePersisted - the result object of a persist which contains information about the newly
  * created data objects.
  * @prop {module:Core~ObjectHash} rootHash - Hash of the root node.
- * @prop {Object.<module:Core~ObjectHash, module:Core~DataObject>} objects - Hash of the root node.
+ * @prop {object.<module:Core~ObjectHash, module:Core~DataObject>} objects - Hash of the root node.
  */
 
 /**
@@ -86,7 +86,7 @@
  * 'severity': 'error',
  * 'type': 'missing',
  * 'targetInfo': '/E/b',
- * 'message': '[MyObject]: mixin node \'E/b\' is missing from the Meta',
+ * 'message': '[MyObject]: mixin node "E/b" is missing from the Meta',
  * 'hint': 'Remove mixin or add to the Meta'
  * }'
  * @example
@@ -96,7 +96,7 @@
  * 'ruleName': 'value',
  * 'collisionPaths': ['/E/a','/E/Z'],
  * 'collisionNodes': [Object,Object],
- * 'message':'[MyObject]: inherits attribute definition \'value'\ from [TypeA] and [TypeB]',
+ * 'message':'[MyObject]: inherits attribute definition "value" from [TypeA] and [TypeB]',
  * 'hint': 'Remove one of the mixin relations'
  * }'
  */

--- a/src/docs/def.doc.js
+++ b/src/docs/def.doc.js
@@ -62,6 +62,18 @@
  */
 
 /**
+ * @description Javascript Number class. For more information, look up the
+ * [reference]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number}.
+ * @typedef {number} number
+ */
+
+/**
+ * @description Represents an integer from the Number class of Javascript. For more information, look up the
+ * [reference]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number}.
+ * @typedef {integer} integer
+ */
+
+/**
  * @description The main configuration object of the WebGME. For detailed information about the individual
  * options, look up the [wiki]{@link https://github.com/webgme/webgme/tree/master/config/README.md} pages.
  * @typedef {object} GmeConfig


### PR DESCRIPTION
Missing modules were included into document generation.
Also some missing basic type references were added.