### PR TITLE
Fixes #1295 Inverse overlay in cache can get mutated at changes

### DIFF
--- a/src/client/js/Controls/PropertyGrid/Widgets/LabelWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/LabelWidget.js
@@ -4,7 +4,7 @@
  * @author rkereskenyi / https://github.com/rkereskenyi
  */
 
-define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
+define(['clipboard', 'js/Controls/PropertyGrid/Widgets/WidgetBase'], function (Clipboard, WidgetBase) {
 
     'use strict';
 
@@ -15,6 +15,13 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
         WidgetBase.call(this, propertyDesc);
 
         this.__label = LABEL_BASE.clone();
+        this.__clipboard = propertyDesc.clipboard;
+
+        if (this.__clipboard === true) {
+            new Clipboard(this.__label[0]);
+            this.__label.attr('title', 'Copy to clipboard');
+            this.__label.css('cursor', 'copy');
+        }
 
         this.updateDisplay();
 
@@ -26,7 +33,13 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
     LabelWidget.prototype.updateDisplay = function () {
         this.__label.text(this.propertyValue);
-        this.__label.attr('title', this.propertyValue);
+
+        if (this.__clipboard) {
+            this.__label.attr('data-clipboard-text', this.propertyValue);
+        } else {
+            this.__label.attr('title', this.propertyValue);
+        }
+
         return WidgetBase.prototype.updateDisplay.call(this);
     };
 

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -224,7 +224,8 @@ define(['js/logger',
                 value: selectedObjIDs[0],
                 valueType: 'string',
                 isCommon: true,
-                readOnly: true
+                readOnly: true,
+                clipboard: true
             };
 
             cNode = self._client.getNode(selectedObjIDs[0]);
@@ -234,7 +235,8 @@ define(['js/logger',
                     value: cNode.getGuid(),
                     valueType: 'string',
                     isCommon: true,
-                    readOnly: true
+                    readOnly: true,
+                    clipboard: true
                 };
 
                 if (cNode.isLibraryElement()) {
@@ -243,7 +245,8 @@ define(['js/logger',
                         value: cNode.getLibraryGuid(),
                         valueType: 'string',
                         isCommon: true,
-                        readOnly: true
+                        readOnly: true,
+                        clipboard: true
                     };
                 }
 
@@ -571,7 +574,12 @@ define(['js/logger',
             ptrTo;
 
         while (len--) {
-            ptrTo = node.getPointer(availablePointers[len]).to;
+            if (availablePointers[len] === CONSTANTS.POINTER_BASE) {
+                ptrTo = node.getBaseId();
+            } else {
+                ptrTo = node.getPointerId(availablePointers[len]);
+            }
+
             ptrTo = ptrTo === null ? CONSTANTS.CORE.NULLPTR_RELID : ptrTo;
             result[availablePointers[len]] = ptrTo || '';
         }

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -813,6 +813,9 @@ define([
          */
         this.deleteNode = function (node) {
             ensureNode(node, 'node');
+            if (core.getParent(node) === null) {
+                throw new CoreIllegalOperationError('Not allowed to delete node without a parent.');
+            }
 
             return core.deleteNode(node, false);
         };

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -329,7 +329,7 @@ define([
                 }
             }
 
-        }
+        };
 
         this.overlayQuery = function (node, prefix) {
             ASSERT(self.isValidNode(node) && innerCore.isValidPath(prefix));

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -312,10 +312,11 @@ define([
             }
 
             //Now we check if some mutation happened
-            if (inverseOverlays && !node.inverseOverlays) {
+            if (inverseOverlays && node.mutable === false) {
                 inverseOverlays = JSON.parse(JSON.stringify(inverseOverlays));
                 node.inverseOverlays = inverseOverlays;
             }
+
             if (inverseOverlays && inverseOverlays[target] && inverseOverlays[target][name]) {
                 index = inverseOverlays[target][name].indexOf(source);
                 if (index !== -1) {
@@ -344,10 +345,10 @@ define([
                     for (name in overlays[path]) {
                         if (self.isPointerName(name)) {
                             list.push({
-                                s: path,
-                                n: name,
-                                t: overlays[path][name],
-                                p: true
+                                s: path,                // source
+                                n: name,                // name
+                                t: overlays[path][name],// target
+                                p: true                 // is forward relation
                             });
                         }
                     }

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1264,5 +1264,4 @@ define([
     };
 
     return CoreType;
-})
-;
+});


### PR DESCRIPTION
The computed inverse overlay should be mutated just like the base data of the node, so the items in the cache may never change.