### PR TITLE
Version and add bundled dist files to browsers' app-cache.

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html manifest="webgme.dist.appcache">
 <head>
     <title>WebGME</title>
     <!-- Load main.js with RequireJS and launch the app from there -->

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -6,7 +6,7 @@
     <script data-main="js/main" src="lib/require/require.min.js"></script>
     <!-- favicon -->
     <link rel="shortcut icon" type="image/x-icon" href="img/favicon.ico">
-
+    <meta property="webgme-version" content="<%=webgmeVersion%>">
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="WebGME"/>
     <meta property="og:description" content="Web-based Generic Modeling Environment"/>

--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -1,4 +1,4 @@
-/*globals require*/
+/*globals require, document*/
 /*jshint browser:true, camelcase:false*/
 /**
  * N.B. This and mainDEBUG.js should only differ w.r.t. using minified versions or not and
@@ -9,9 +9,17 @@
 
 
 var DEBUG = false,
-    WebGMEGlobal = WebGMEGlobal || {};
+    WebGMEGlobal = WebGMEGlobal || {},
+    metaElms = document.getElementsByTagName('meta'),
+    i;
 
-WebGMEGlobal.version = 'x';
+for (i = 0; i < metaElms.length; i += 1) {
+    if (metaElms[i].getAttribute('property') === 'webgme-version') {
+        WebGMEGlobal.version = metaElms[i].getAttribute('content');
+        break;
+    }
+}
+
 WebGMEGlobal.SUPPORTS_TOUCH = 'ontouchstart' in window || navigator.msMaxTouchPoints;
 
 
@@ -137,15 +145,15 @@ require.config({
 });
 
 require([
-    'css!/dist/webgme.dist.main.css',
+    'css!/dist/webgme.' + WebGMEGlobal.version + '.dist.main.css',
 ], function () {
     'use strict';
 
     require([
-        '/dist/webgme.lib.build.js'
+        '/dist/webgme.' + WebGMEGlobal.version + '.lib.build.js'
     ], function () {
         require([
-            '/dist/webgme.dist.build.js'
+            '/dist/webgme.' + WebGMEGlobal.version + '.dist.build.js'
         ], function () {
 
         });

--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -26,6 +26,7 @@ WebGMEGlobal.SUPPORTS_TOUCH = 'ontouchstart' in window || navigator.msMaxTouchPo
 // configure require path and modules
 require.config({
     baseUrl: './',
+    waitSeconds: 12,
     map: {
         '*': {
             //layout

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -94,7 +94,9 @@ function StandAloneServer(gmeConfig) {
         clientConfig = getClientConfig(gmeConfig),
         excludeRegExs = [],
         routeComponents = [],
-        sockets = [];
+        sockets = [],
+        nmpPackageJson = webgmeUtils.getPackageJsonSync(),
+        cacheManifest;
 
     self.id = Math.random().toString(36).slice(2, 11);
 
@@ -774,6 +776,15 @@ function StandAloneServer(gmeConfig) {
 
     //client contents - js/html/css
     __app.get(/^\/.*\.(css|ico|ttf|woff|woff2|js|cur)$/, Express.static(__clientBaseDir));
+
+    cacheManifest = 'CACHE MANIFEST\n\n#' + nmpPackageJson.version +
+        '/dist/webgme.dist.main.css\n/dist/webgme.lib.build.js\n/dist/webgme.dist.build.js\n' +
+        'NETWORK:\n*';
+
+    __app.get('/webgme.dist.appcache', function (req, res) {
+        res.set('Content-Type', 'text/cache-manifest');
+        res.send(cacheManifest);
+    });
 
     __app.get('/package.json', ensureAuthenticated, Express.static(path.join(__baseDir, '..')));
     __app.get(/^\/.*\.(_js|html|gif|png|bmp|svg|json|map)$/, ensureAuthenticated, Express.static(__clientBaseDir));

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -631,6 +631,7 @@ function StandAloneServer(gmeConfig) {
             } else {
                 res.contentType('text/html');
                 res.send(ejs.render(indexTemp, {
+                    webgmeVersion: nmpPackageJson.version,
                     url: url,
                     imageUrl: imageUrl,
                     projectId: projectId ? projectId.replace('+', '/') : 'WebGME'
@@ -777,8 +778,10 @@ function StandAloneServer(gmeConfig) {
     //client contents - js/html/css
     __app.get(/^\/.*\.(css|ico|ttf|woff|woff2|js|cur)$/, Express.static(__clientBaseDir));
 
-    cacheManifest = 'CACHE MANIFEST\n\n#' + nmpPackageJson.version +
-        '/dist/webgme.dist.main.css\n/dist/webgme.lib.build.js\n/dist/webgme.dist.build.js\n' +
+    cacheManifest = 'CACHE MANIFEST\n\n#' + nmpPackageJson.version + '\n' +
+        '/dist/webgme.' + nmpPackageJson.version + '.dist.main.css\n' +
+        '/dist/webgme.' + nmpPackageJson.version + '.lib.build.js\n'+
+        '/dist/webgme.' + nmpPackageJson.version + '.dist.build.js\n' +
         'NETWORK:\n*';
 
     __app.get('/webgme.dist.appcache', function (req, res) {

--- a/utils/build/dist/build.js
+++ b/utils/build/dist/build.js
@@ -13,7 +13,9 @@
 
 var requirejs = require('requirejs'),
     path = require('path'),
+    fs = require('fs'),
     Q = require('q'),
+    webgmeVersion = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf8')).version,
     config = {
         baseUrl: path.join(__dirname, '../../../src'),
         paths: {
@@ -80,7 +82,7 @@ var requirejs = require('requirejs'),
         include: [
             '../utils/build/dist/includes',
         ],
-        out: path.join(__dirname, '../../../dist/webgme.dist.build.js'),
+        out: path.join(__dirname, '../../../dist/webgme.' + webgmeVersion + '.dist.build.js'),
         optimize: 'uglify2',
         //optimize: 'none',
         generateSourceMaps: true,
@@ -93,7 +95,7 @@ var requirejs = require('requirejs'),
     cssConfig = {
         optimizeCss: 'standard',
         cssIn: path.join(__dirname, '../../../src/client/css/main.css'),
-        out: path.join(__dirname, '../../../dist/webgme.dist.main.css'),
+        out: path.join(__dirname, '../../../dist/webgme.' + webgmeVersion + '.dist.main.css'),
     },
     libConfig = {
         baseUrl: path.join(__dirname, '../../../src'),
@@ -161,7 +163,7 @@ var requirejs = require('requirejs'),
         exclude: ['normalize'],
         optimize: 'uglify2',
         preserveLicenseComments: false,
-        out: path.join(__dirname, '../../../dist/webgme.lib.build.js')
+        out: path.join(__dirname, '../../../dist/webgme.' + webgmeVersion + '.lib.build.js')
     };
 
 function doBuilds(callback) {

--- a/utils/postinstall.js
+++ b/utils/postinstall.js
@@ -9,7 +9,8 @@
 var prepublish = require('./prepublish'),
     path = require('path'),
     fs = require('fs'),
-    fName = path.join(__dirname, '..', 'dist', 'webgme.dist.build.js'),
+    webgmeVersion = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version,
+    fName = path.join(__dirname, '..', 'dist', 'webgme.' + webgmeVersion + '.dist.build.js'),
     exists = true;
 
 try {


### PR DESCRIPTION
This PR introduces app-caching as described here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache

The files being cached are the bundled distribution files located at (`/dist`). These are pretty large files and loaded step-by-step to ensure that the dependencies are loaded first. This however slows down the loading process as those request cannot be made in parallel - thus caching can significantly speed things up.

![image](https://cloud.githubusercontent.com/assets/6518904/22226826/b4948a66-e18d-11e6-9c6a-0ac7ac94d183.png)

To ensure that wrong versions aren't accidentally used (at the point of cache re-evaluation) generated dist-files are now version controlled using the npm version.

N.B. In the link above it says that app-cache is deprecated and will be replaced by:
https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers

However the later is still experimental has poorer browser support. At a transition point, all that needs to be removed for the app-cache is the manifest tag in the index.html. Also note that this PR does not try to solve the working off-line problem - but rather speed up initial loading of large bundles for slow connections.