### PR TITLE
Extract meta-inconsistency-widget and improve the meta-rules results.

### DIFF
--- a/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
+++ b/src/client/js/Dialogs/ConstraintCheckResults/ConstraintCheckResultsDialog.js
@@ -39,7 +39,7 @@ define(['js/util',
     //jscs:enable maximumLineLength
         MESSAGE_ENTRY_BASE = $('<div class="msg"><div class="msg-title"></div><div class="msg-body"></div></div>');
 
-    ConstraintCheckResultsDialog.prototype.show = function (client, pluginResults) {
+    ConstraintCheckResultsDialog.prototype.show = function (client, results) {
         var self = this;
 
         this._dialog = $(pluginResultsDialogTemplate);
@@ -47,7 +47,7 @@ define(['js/util',
             this._dialog.find('h3').first().text(this._dialogTitle);
         }
         this._client = client;
-        this._initDialog(pluginResults);
+        this._initDialog(results);
 
         this._dialog.on('hidden.bs.modal', function () {
             self._dialog.remove();
@@ -65,6 +65,7 @@ define(['js/util',
             resultEntry,
             body = dialog.find('.modal-body'),
             UNREAD_CSS = 'unread',
+            messagesEl,
             result,
             resultHeader,
             spanResultTitle,
@@ -78,7 +79,8 @@ define(['js/util',
             constraintEntry,
             i,
             j,
-            k;
+            k,
+            ii;
 
         for (i = 0; i < results.length; i += 1) {
             result = results[i];
@@ -151,7 +153,20 @@ define(['js/util',
                 for (k = 0; k < constraintNames.length; k++) {
                     constraintEntry = MESSAGE_ENTRY_BASE.clone();
                     constraintEntry.find('.msg-title').text(constraintNames[k]);
-                    constraintEntry.find('.msg-body').html(result[nodeGuids[j]][constraintNames[k]].message);
+                    if (result[nodeGuids[j]][constraintNames[k]].messages instanceof Array &&
+                        result[nodeGuids[j]][constraintNames[k]].messages.length > 0) {
+                        // If messages array is given - show list of violations.
+                        messagesEl = $('<ul class="messages-array"/>');
+                        for (ii = 0; ii < result[nodeGuids[j]][constraintNames[k]].messages.length; ii += 1) {
+                            messagesEl.append($('<li/>', {
+                                text: result[nodeGuids[j]][constraintNames[k]].messages[ii]
+                            }));
+                        }
+
+                        constraintEntry.find('.msg-body').append(messagesEl);
+                    } else {
+                        constraintEntry.find('.msg-body').html(result[nodeGuids[j]][constraintNames[k]].message);
+                    }
 
                     constraintContainer.append(constraintEntry);
                 }

--- a/src/client/js/Dialogs/ConstraintCheckResults/styles/ConstraintCheckResultsDialog.css
+++ b/src/client/js/Dialogs/ConstraintCheckResults/styles/ConstraintCheckResultsDialog.css
@@ -24,7 +24,7 @@
     font-size: 9px; }
   .constraint-check-results-dialog .modal-body div.constraint-check-result .messages .msg {
     margin-bottom: 5px;
-    padding-bottom: 15px; }
+    padding-bottom: 5px; }
     .constraint-check-results-dialog .modal-body div.constraint-check-result .messages .msg .msg-title {
       margin-top: 5px;
       font-weight: bold;

--- a/src/client/js/Dialogs/ConstraintCheckResults/styles/ConstraintCheckResultsDialog.scss
+++ b/src/client/js/Dialogs/ConstraintCheckResults/styles/ConstraintCheckResultsDialog.scss
@@ -41,7 +41,7 @@
       .messages {
         .msg {
           margin-bottom: 5px;
-          padding-bottom: 15px;
+          padding-bottom: 5px;
 
           .msg-title {
             margin-top: 5px;

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.css
@@ -3,35 +3,20 @@
  */
 .meta-editor-widget.w-tabs .diagram-designer-zoom-container {
   top: 45px; }
-.meta-editor-widget.show-meta-consistency-results {
+.meta-editor-widget.show-meta-consistency-result {
   display: inline-flex; }
-  .meta-editor-widget.show-meta-consistency-results .panel-body {
+  .meta-editor-widget.show-meta-consistency-result .panel-body {
     width: 50%; }
-  .meta-editor-widget.show-meta-consistency-results .meta-consistency-results {
+  .meta-editor-widget.show-meta-consistency-result .meta-consistency-result-container {
     width: 50%;
     overflow-y: scroll;
     margin-top: 30px;
     border-left: 1px gray solid; }
-    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-header {
+    .meta-editor-widget.show-meta-consistency-result .meta-consistency-result-container .meta-inconsistency-header {
       margin-left: 8px; }
-      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-header i {
+      .meta-editor-widget.show-meta-consistency-result .meta-consistency-result-container .meta-inconsistency-header i {
         margin-left: 10px;
         cursor: pointer; }
-    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency-divider {
-      border-top: 3px lightgray solid;
-      margin: 20px 20px 20px 20px; }
-    .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency {
-      margin-left: 10px;
-      margin-right: 10px; }
-      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dt {
-        width: 100px; }
-      .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd {
-        margin-left: 120px; }
-        .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd.path-link {
-          cursor: pointer;
-          color: blue; }
-          .meta-editor-widget.show-meta-consistency-results .meta-consistency-results .meta-inconsistency dd.path-link:hover {
-            color: orange; }
 
 div.filterPanel {
   position: absolute;

--- a/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
+++ b/src/client/js/Widgets/MetaEditor/styles/MetaEditorWidget.scss
@@ -17,13 +17,13 @@ $filterPanel-header-min-width: 100px;
     }
   }
 
-  &.show-meta-consistency-results {
+  &.show-meta-consistency-result {
     display: inline-flex;
     .panel-body {
       width: 50%;
     }
 
-    .meta-consistency-results {
+    .meta-consistency-result-container {
       width: 50%;
       overflow-y: scroll;
       margin-top: 30px;
@@ -33,27 +33,6 @@ $filterPanel-header-min-width: 100px;
         i {
           margin-left: 10px;
           cursor: pointer;
-        }
-      }
-      .meta-inconsistency-divider {
-        border-top: 3px lightgray solid;
-        margin: 20px 20px 20px 20px;
-      }
-      .meta-inconsistency {
-        margin-left: 10px;
-        margin-right: 10px;
-        dt {
-          width: 100px;
-        }
-        dd {
-          margin-left: 120px;
-          &.path-link {
-            cursor: pointer;
-            color: blue;
-            &:hover {
-              color: orange;
-            }
-          }
         }
       }
     }

--- a/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
+++ b/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
@@ -1,0 +1,96 @@
+/*globals define, $*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+define([], function () {
+    'use strict';
+
+    function MetaInconsistencyResultWidget(parentEl, options) {
+        this._el = $('<div/>', {
+            class: 'meta-inconsistency-results'
+        });
+
+        this._dividerAtTop = options.dividerAtTop || false;
+        this._dividerAtBottom = options.dividerAtBottom || false;
+
+        this._onLinkClick = function () {
+            var path = $(this).data('gme-id');
+
+            if (typeof options.onLinkClick === 'function') {
+                options.onLinkClick(path);
+            }
+        };
+
+        parentEl.append(this._el);
+    }
+
+    MetaInconsistencyResultWidget.prototype.showResults = function(results) {
+        var resEl,
+            dl,
+            i,j;
+
+        results.sort(function (r1, r2) {
+            if (r1.message > r2.message) {
+                return 1;
+            } else if (r1.message < r2.message) {
+                return -1;
+            }
+
+            return 0;
+        });
+
+        for (i = 0; i < results.length; i += 1) {
+            if (i > 0 || this._dividerAtTop) {
+                this._el.append($('<div>', {class: 'meta-inconsistency-divider'}));
+            }
+
+            resEl = $('<div>', {
+                class: 'meta-inconsistency',
+            });
+
+            dl = $('<dl>', {class: 'dl-horizontal'});
+
+            dl.append($('<dt>', {text: 'Inconsistency'}));
+            dl.append($('<dd>', {text: results[i].message}));
+
+            dl.append($('<dt>', {text: 'Description'}));
+            dl.append($('<dd>', {text: results[i].description}));
+
+            dl.append($('<dt>', {text: 'Hint'}));
+            dl.append($('<dd>', {text: results[i].hint}));
+
+            dl.append($('<dt>', {text: 'Node path'}));
+            dl.append($('<dd>', {text: results[i].path, class: 'path-link'})
+                .data('gme-id', results[i].path)
+                .on('click', this._onLinkClick)
+            );
+
+            if (results[i].relatedPaths.length > 0) {
+                dl.append($('<dt>', {text: 'Related paths'}));
+                for (j = 0; j < results[i].relatedPaths.length; j += 1) {
+                    dl.append($('<dd>', {
+                        text: results[i].relatedPaths[j],
+                        class: 'path-link'
+                    }).data('gme-id', results[i].relatedPaths[j]));
+                }
+            }
+
+            resEl.append(dl);
+            this._el.append(resEl);
+
+            if (i === results.length -1 && this._dividerAtBottom) {
+                this._el.append($('<div>', {class: 'meta-inconsistency-divider'}));
+            }
+        }
+    };
+
+    MetaInconsistencyResultWidget.prototype.destroy = function () {
+        this._el.find('dd.path-link').off('click');
+        this._el.find('i.close-result').off('click');
+
+        this._el.empty();
+    };
+
+    return MetaInconsistencyResultWidget;
+});

--- a/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
+++ b/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
@@ -3,32 +3,33 @@
  * @author pmeijer / https://github.com/pmeijer
  */
 
-define([], function () {
+define(['css!./styles/MetaInconsistencyResultWidget.css'], function () {
     'use strict';
 
     function MetaInconsistencyResultWidget(parentEl, options) {
         this._el = $('<div/>', {
-            class: 'meta-inconsistency-results'
+            class: 'meta-inconsistency-result'
         });
 
         this._dividerAtTop = options.dividerAtTop || false;
         this._dividerAtBottom = options.dividerAtBottom || false;
 
-        this._onLinkClick = function () {
-            var path = $(this).data('gme-id');
-
-            if (typeof options.onLinkClick === 'function') {
-                options.onLinkClick(path);
-            }
-        };
+        this._onLinkClickHandler = options.onLinkClick || function () {
+            };
 
         parentEl.append(this._el);
     }
 
-    MetaInconsistencyResultWidget.prototype.showResults = function(results) {
-        var resEl,
+    MetaInconsistencyResultWidget.prototype.showResults = function (results) {
+        var self = this,
+            resEl,
             dl,
-            i,j;
+            i, j;
+
+        function onClick() {
+            var path = $(this).data('gme-id');
+            self._onLinkClickHandler(path);
+        }
 
         results.sort(function (r1, r2) {
             if (r1.message > r2.message) {
@@ -63,7 +64,7 @@ define([], function () {
             dl.append($('<dt>', {text: 'Node path'}));
             dl.append($('<dd>', {text: results[i].path, class: 'path-link'})
                 .data('gme-id', results[i].path)
-                .on('click', this._onLinkClick)
+                .on('click', onClick)
             );
 
             if (results[i].relatedPaths.length > 0) {
@@ -72,14 +73,14 @@ define([], function () {
                     dl.append($('<dd>', {
                         text: results[i].relatedPaths[j],
                         class: 'path-link'
-                    }).data('gme-id', results[i].relatedPaths[j]));
+                    }).data('gme-id', results[i].relatedPaths[j]).on('click', onClick));
                 }
             }
 
             resEl.append(dl);
             this._el.append(resEl);
 
-            if (i === results.length -1 && this._dividerAtBottom) {
+            if (i === results.length - 1 && this._dividerAtBottom) {
                 this._el.append($('<div>', {class: 'meta-inconsistency-divider'}));
             }
         }

--- a/src/client/js/Widgets/MetaInconsistencyResult/styles/MetaInconsistencyResultWidget.css
+++ b/src/client/js/Widgets/MetaInconsistencyResult/styles/MetaInconsistencyResultWidget.css
@@ -1,0 +1,15 @@
+.meta-inconsistency-result .meta-inconsistency-divider {
+  border-top: 3px lightgray solid;
+  margin: 20px 20px 20px 20px; }
+.meta-inconsistency-result .meta-inconsistency {
+  margin-left: 10px;
+  margin-right: 10px; }
+  .meta-inconsistency-result .meta-inconsistency dt {
+    width: 100px; }
+  .meta-inconsistency-result .meta-inconsistency dd {
+    margin-left: 120px; }
+    .meta-inconsistency-result .meta-inconsistency dd.path-link {
+      cursor: pointer;
+      color: blue; }
+      .meta-inconsistency-result .meta-inconsistency dd.path-link:hover {
+        color: orange; }

--- a/src/client/js/Widgets/MetaInconsistencyResult/styles/MetaInconsistencyResultWidget.scss
+++ b/src/client/js/Widgets/MetaInconsistencyResult/styles/MetaInconsistencyResultWidget.scss
@@ -1,0 +1,23 @@
+.meta-inconsistency-result {
+  .meta-inconsistency-divider {
+    border-top: 3px lightgray solid;
+    margin: 20px 20px 20px 20px;
+  }
+  .meta-inconsistency {
+    margin-left: 10px;
+    margin-right: 10px;
+    dt {
+      width: 100px;
+    }
+    dd {
+      margin-left: 120px;
+      &.path-link {
+        cursor: pointer;
+        color: blue;
+        &:hover {
+          color: orange;
+        }
+      }
+    }
+  }
+}

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -229,7 +229,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('more');
+                expect(result.message).to.contain('More children');
             })
             .nodeify(done);
     });
@@ -255,7 +255,8 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('not an allowed dst target');
+                expect(result.message).to.contain('Illegal node');
+                expect(result.message).to.contain('as "dst" target');
             })
             .nodeify(done);
     });
@@ -268,7 +269,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('attribute that is not part of any meta');
+                expect(result.message).to.contain('Illegal attribute');
             })
             .nodeify(done);
     });
@@ -281,7 +282,8 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('not an allowed ref target');
+                expect(result.message).to.contain('Illegal node');
+                expect(result.message).to.contain('as "ref" target');
             })
             .nodeify(done);
     });
@@ -294,7 +296,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('more');
+                expect(result.message).to.contain('More "ModelRefs"-members');
             })
             .nodeify(done);
     });
@@ -307,7 +309,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('fewer');
+                expect(result.message).to.contain('Fewer children than');
             })
             .nodeify(done);
     });
@@ -320,7 +322,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('Invalid pointer');
+                expect(result.message).to.contain('Illegal pointer');
             })
             .nodeify(done);
     });
@@ -333,7 +335,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('Invalid set');
+                expect(result.message).to.contain('Illegal set');
             })
             .nodeify(done);
     });


### PR DESCRIPTION
The messages are written in better English and returned as arrays (with many messages concatenating the messages is not very user friendly). Also the passed checks are not returned - heavily reducing the size of the communicated data.

The the widget is extracted to be used in dialog or other pieces than the MetaEditor. For instance from the commit-badge in the [constraint-checker](https://github.com/webgme/constraint-checker).