### PR TITLE
Add method on client to get a core instance (for e.g. queries)

### DIFF
--- a/config/config.test.js
+++ b/config/config.test.js
@@ -39,23 +39,6 @@ config.server.log = {
             handleExceptions: true,
             depth: 2
         }
-    }, {
-        transportType: 'File',
-        options: {
-            name: 'info-file',
-            filename: './test-tmp/server.log',
-            level: 'info',
-            json: false
-        }
-    }, {
-        transportType: 'File',
-        options: {
-            name: 'error-file',
-            filename: './test-tmp/server-error.log',
-            level: 'error',
-            handleExceptions: true,
-            json: false
-        }
     }]
 };
 

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -1303,6 +1303,19 @@ define([
             return state.project;
         };
 
+        /**
+         * Creates a new core instance using the state of the client and loads the root node.
+         * @param {object} [options]
+         * @param {string} [options.commitHash=%state.commitHash%] - If a different commit-hash should be loaded.
+         * @param {GmeLogger} [options.logger=%clientLogger%] - Logger passed to the core instance.
+         * @param {function} callback
+         * @param {Error|null} callback.error - Non-null if failed to retrieve result.
+         * @param {object} callback.result - The result object
+         * @param {Core} callback.result.core - Newly created core instance
+         * @param {Core~Node} callback.result.rootNode - The root-node that was loaded.
+         * @param {string} callback.result.commitHash - The commitHash used as basis for loading root-node.
+         * @param {Project} callback.result.project - A reference to the project.
+         */
         this.getCoreInstance = function (options, callback) {
             options = options || {};
             options.logger = options.logger || logger.fork('core');

--- a/test-karma/client/js/branchstatus.spec.js
+++ b/test-karma/client/js/branchstatus.spec.js
@@ -157,7 +157,7 @@ describe('branch status', function () {
                     expect(events.length).to.equal(2);
                     client.removeUI(userGuid);
 
-                    client.setAttributes('', 'name', 'newRootName',
+                    client.setAttribute('', 'name', 'newRootName',
                         'should go from SYNC to AHEAD_SYNC to SYNC when making changes.');
                 }
             }
@@ -275,7 +275,7 @@ describe('branch status', function () {
                                     function (err, result) {
                                         expect(err).to.equal(null);
                                         expect(result.status).to.equal(client.CONSTANTS.STORAGE.SYNCED);
-                                        client.setAttributes('', 'name', 'newRootyName', 'conflicting change');
+                                        client.setAttribute('', 'name', 'newRootyName', 'conflicting change');
                                         client.completeTransaction('sync_aheadSync_aheadNotSync__stop');
                                     }
                                 );
@@ -314,7 +314,7 @@ describe('branch status', function () {
                     prevStatus = eventData.status;
                     expect(eventData.status).to.equal(client.CONSTANTS.BRANCH_STATUS.AHEAD_NOT_SYNC);
                     expect(eventData.commitQueue.length).to.equal(1);
-                    client.setAttributes('', 'name', 'newRootyName2Test2', 'change when ahead not sync');
+                    client.setAttribute('', 'name', 'newRootyName2Test2', 'change when ahead not sync');
                 } else if (prevStatus === client.CONSTANTS.BRANCH_STATUS.AHEAD_NOT_SYNC) {
                     expect(eventData.status).to.equal(client.CONSTANTS.BRANCH_STATUS.AHEAD_NOT_SYNC);
                     expect(eventData.commitQueue.length).to.equal(2);
@@ -355,7 +355,7 @@ describe('branch status', function () {
                                     function (err, result) {
                                         expect(err).to.equal(null);
                                         expect(result.status).to.equal(client.CONSTANTS.STORAGE.SYNCED);
-                                        client.setAttributes('', 'name', 'newRootyNameTest2', 'conflicting change');
+                                        client.setAttribute('', 'name', 'newRootyNameTest2', 'conflicting change');
                                         client.completeTransaction('sync_aheadSync_aheadNotSync_aheadNotSync__stop');
                                     }
                                 );

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -125,8 +125,8 @@ describe('GME client', function () {
             expect(client).to.include.keys(
                 'startTransaction',
                 'completeTransaction',
-                'setAttributes',
-                'delAttributes',
+                'setAttribute',
+                'delAttribute',
                 'setRegistry',
                 'delRegistry',
                 'copyMoreNodes',
@@ -134,7 +134,7 @@ describe('GME client', function () {
                 'delMoreNodes',
                 'createChild',
                 'createChildren',
-                'makePointer',
+                'setPointer',
                 'delPointer',
                 'addMember',
                 'removeMember',
@@ -802,7 +802,6 @@ describe('GME client', function () {
 
                     expect(commits).to.have.length.least(1);
                     expect(commits[0]).to.contain.keys('_id', 'root', 'updater', 'time', 'message', 'type');
-                    expect(commits[0]._id).to.equal(client.getActiveCommitHash());
                     done();
                 });
             });
@@ -1370,7 +1369,7 @@ describe('GME client', function () {
                                 expect(events.length).to.equal(2);
                                 client.removeUI(userGuid);
 
-                                client.setAttributes('', 'name', 'newRootName',
+                                client.setAttribute('', 'name', 'newRootName',
                                     'should raise BRANCH_HASH_UPDATED when the branch is updated.');
                             }
                         }
@@ -1499,12 +1498,12 @@ describe('GME client', function () {
                 number: 1
             };
 
-            client.setAttributes(clientNodePath, 'newAttr', attribute);
+            client.setAttribute(clientNodePath, 'newAttr', attribute);
             expect(clientNode.getAttributeNames()).to.include.members(['newAttr']);
             expect(clientNode.getAttribute('newAttr')).to.eql(attribute);
             expect(clientNode.getEditableAttribute('newAttr')).to.eql(attribute);
             expect(clientNode.getOwnEditableAttribute('newAttr')).to.eql(attribute);
-            client.delAttributes(clientNodePath, 'newAttr');
+            client.delAttribute(clientNodePath, 'newAttr');
         });
 
         it('in case of unknown attribute the result should be undefined', function () {
@@ -1650,7 +1649,7 @@ describe('GME client', function () {
         });
 
         it('should return a list of paths of the possible child node types', function () {
-            expect(clientNode.getValidChildrenTypes()).to.deep.equal(['/701504349']);
+            expect(clientNode.getValidChildrenIds()).to.deep.equal(['/701504349']);
         });
 
         it('should list the names of the defined constraints', function () {
@@ -1745,7 +1744,7 @@ describe('GME client', function () {
                 copyParams[childrenIds[0]] = {attributes: {'name': 'copy'}};
 
                 //we aslo set the name
-                client.setAttributes(childrenIds[0], 'name', childrenIds[0]);
+                client.setAttribute(childrenIds[0], 'name', childrenIds[0]);
             }
             expect(childrenIds).to.have.length(62);
 
@@ -2251,7 +2250,7 @@ describe('GME client', function () {
                         expect(events[i].etype).to.equal('update');
                     }
 
-                    node = client.delMoreNodes([childPath]);
+                    node = client.deleteNodes([childPath]);
                 } else if (tOneState === 'tRemove') {
                     tOneState = null;
                     // Root, parent and child should be updated,
@@ -2310,7 +2309,7 @@ describe('GME client', function () {
                         expect(events[i].etype).to.equal('load');
                     }
                     childPath = '/' + newNodeRelid + '/' + baseChildRelid;
-                    node = client.delMoreNodes([childPath]);
+                    node = client.deleteNodes([childPath]);
                 } else if (tOneState === 'tRemove') {
                     tOneState = null;
                     // Only the root should have an event.
@@ -2453,7 +2452,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getAttribute('name')).to.equal('check');
 
-                    client.setAttributes(events[1].eid, 'name', 'checkModified', 'basic set attribute test');
+                    client.setAttribute(events[1].eid, 'name', 'checkModified', 'basic set attribute test');
                     return;
                 }
 
@@ -2490,7 +2489,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getAttribute('name')).to.equal('check');
 
-                    client.delAttributes(events[1].eid, 'name', 'basic delete attribute test');
+                    client.delAttribute(events[1].eid, 'name', 'basic delete attribute test');
                     return;
                 }
 
@@ -2623,8 +2622,8 @@ describe('GME client', function () {
                     expect(node.getAttribute('name')).to.equal('FCO');
 
                     client.startTransaction('starting a transaction');
-                    client.setAttributes('/1', 'name', 'FCOmodified', 'change without commit');
-                    client.setAttributes('/1', 'newAttribute', 42, 'another change without commit');
+                    client.setAttribute('/1', 'name', 'FCOmodified', 'change without commit');
+                    client.setAttribute('/1', 'newAttribute', 42, 'another change without commit');
                     client.setRegistry('/1', 'position', {x: 50, y: 50});
                     client.completeTransaction('now will the events get generated');
                 }
@@ -2672,7 +2671,7 @@ describe('GME client', function () {
                     node = client.getNode(events[1].eid);
                     expect(node).not.to.equal(null);
 
-                    client.delMoreNodes([events[1].eid], 'basic delete node test');
+                    client.deleteNodes([events[1].eid], 'basic delete node test');
                     return;
                 }
 
@@ -2749,7 +2748,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getPointer('ptr')).to.deep.equal({to: '/323573539', from: []});
 
-                    client.makePointer('/1697300825', 'ptr', null, 'make null pointer test');
+                    client.setPointer('/1697300825', 'ptr', null, 'make null pointer test');
                     return;
                 }
 
@@ -4213,7 +4212,7 @@ describe('GME client', function () {
                     expect(node).not.to.equal(null);
                     expect(node.getOwnEditableAttribute('name')).to.equal('check');
 
-                    client.setAttributes(events[1].eid, 'name', 'cm', 'undo test - modify something');
+                    client.setAttribute(events[1].eid, 'name', 'cm', 'undo test - modify something');
                     return;
                 }
 
@@ -4352,7 +4351,7 @@ describe('GME client', function () {
             prepareBranchForTest('simpleGet', null, function (err) {
                 expect(err).to.equal(null);
 
-                expect(client.getMeta('/1')).to.deep.equal({
+                expect(client.getNode('/1').getJsonMeta()).to.deep.equal({
                     attributes: {
                         name: {
                             type: 'string'
@@ -4381,8 +4380,7 @@ describe('GME client', function () {
         it('should return the flattened meta rules of a node in json format', function (done) {
             prepareBranchForTest('inheritedGet', null, function (err) {
                 expect(err).to.equal(null);
-                var metaRules = client.getMeta('/1865460677');
-                //FIXME: this fails on my machine /patrik
+                var metaRules = client.getNode('/1865460677').getJsonMeta();
 
                 expect(metaRules).to.have.keys('attributes', 'aspects', 'pointers', 'children', 'constraints');
                 expect(metaRules.attributes).to.deep.equal({
@@ -4404,15 +4402,6 @@ describe('GME client', function () {
             });
         });
 
-        it('should return null if the object is not loaded', function (done) {
-            prepareBranchForTest('unknownGet', null, function (err) {
-                expect(err).to.equal(null);
-
-                expect(client.getMeta('/42/42')).to.equal(null);
-                done();
-            });
-        });
-
         it('modify an empty ruleset to empty', function (done) {
             var branchStatusHandler = function (status/*, commitQueue, updateQueue*/) {
                 if (status === client.CONSTANTS.BRANCH_STATUS.SYNC) {
@@ -4422,9 +4411,9 @@ describe('GME client', function () {
             prepareBranchForTest('noChangeSet', branchStatusHandler, function (err) {
                 expect(err).to.equal(null);
 
-                var old = client.getMeta('/1730437907');
+                var old = client.getNode('/1730437907').getJsonMeta();
                 client.setMeta('/1730437907', {});
-                expect(client.getMeta('/1730437907')).to.deep.equal(old);
+                expect(client.getNode('/1730437907').getJsonMeta()).to.deep.equal(old);
             });
         });
 
@@ -4437,12 +4426,12 @@ describe('GME client', function () {
             prepareBranchForTest('addWithSet', branchStatusHandler, function (err) {
                 expect(err).to.equal(null);
 
-                var old = client.getMeta('/1730437907'),
+                var old = client.getNode('/1730437907').getJsonMeta(),
                     newAttribute = {type: 'string'};
                 client.setMeta('/1730437907', {attributes: {newAttr: newAttribute}});
                 //we extend our json format as well
                 old.attributes.newAttr = newAttribute;
-                expect(client.getMeta('/1730437907')).to.deep.equal(old);
+                expect(client.getNode('/1730437907').getJsonMeta()).to.deep.equal(old);
             });
         });
 
@@ -4455,12 +4444,12 @@ describe('GME client', function () {
             prepareBranchForTest('removeWithSet', branchStatusHandler, function (err) {
                 expect(err).to.equal(null);
 
-                var meta = client.getMeta('/1');
+                var meta = client.getNode('/1').getJsonMeta();
 
                 expect(meta.attributes).to.contain.keys('name');
                 delete meta.attributes.name;
                 client.setMeta('/1', meta);
-                expect(client.getMeta('/1').attributes).not.to.include.keys('name');
+                expect(client.getNode('/1').getJsonMeta().attributes).not.to.include.keys('name');
 
             });
         });

--- a/test-karma/client/js/plugin.spec.js
+++ b/test-karma/client/js/plugin.spec.js
@@ -247,7 +247,7 @@ describe('Plugin', function () {
                     expect(events.length).to.equal(2);
                     client.removeUI(userGuid);
                     setTimeout(function () {
-                        client.setAttributes('', 'name', 'PluginForkedNameFromClient', 'conflicting change');
+                        client.setAttribute('', 'name', 'PluginForkedNameFromClient', 'conflicting change');
                     }, 50);
                 }
             }


### PR DESCRIPTION
This PR also cleans-up in the karma tests.

```
        /**
         * Creates a new core instance using the state of the client and loads the root node.
         * @param {object} [options]
         * @param {string} [options.commitHash=%state.commitHash%] - If a different commit-hash should be loaded.
         * @param {GmeLogger} [options.logger=%clientLogger%] - Logger passed to the core instance.
         * @param {function} callback
         * @param {Error|null} callback.error - Non-null if failed to retrieve result.
         * @param {object} callback.result - The result object
         * @param {Core} callback.result.core - Newly created core instance
         * @param {Core~Node} callback.result.rootNode - The root-node that was loaded.
         * @param {string} callback.result.commitHash - The commitHash used as basis for loading root-node.
         * @param {Project} callback.result.project - A reference to the project.
         */
        this.getCoreInstance = function (options, callback) {

```