### PR TITLE
Fixes #1313 Add option for writing blobs to dir from run_plugin

### DIFF
--- a/src/bin/run_plugin.js
+++ b/src/bin/run_plugin.js
@@ -50,6 +50,7 @@ main = function (argv, callback) {
         .option('-u, --user [string]', 'the user of the command [if not given we use the default user]',
             gmeConfig.authentication.guestAccount)
         .option('-o, --owner [string]', 'the owner of the project [by default, the user is the owner]')
+        .option('-w, --writeBlobFilesDir [string]', 'If defined will also write blob-files to %cwd%/%writeBlobFilesDir%')
         .option('-j, --pluginConfigPath [string]',
             'Path to json file with plugin options that should be overwritten.', '')
 
@@ -63,6 +64,7 @@ main = function (argv, callback) {
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -a /1/b');
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -s /1,/1/c,/d');
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -c #123..');
+            console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -w plugin-blobs');
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -b b1 -c ' +
                 '#def8861ca16237e6756ee22d27678d979bd2fcde');
             console.log();
@@ -141,7 +143,9 @@ main = function (argv, callback) {
             return project.getBranchHash(program.branchName);
         })
         .then(function (commitHash) {
-            var pluginManager = new PluginCliManager(project, logger, gmeConfig),
+            var pluginManager = new PluginCliManager(project, logger, gmeConfig, {
+                    writeBlobFilesDir: program.writeBlobFilesDir
+            }),
                 context = {
                     activeNode: program.activeNode,
                     activeSelection: program.activeSelection || [],

--- a/src/plugin/climanager.js
+++ b/src/plugin/climanager.js
@@ -13,11 +13,13 @@ var PluginManagerBase = requireJS('plugin/managerbase'),
  * @param {UserProject} [project] - optional default project, can be passed during initialization of plugin too.
  * @param {object} - mainLogger - logger for manager, plugin-logger will fork from this logger.
  * @param {object} gmeConfig - global configuration
+ * @param {object} [opts] - Optional options
+ * @param {object} [opts.writeBlobFilesDir] - If defined will put blob files with their name inside %cwd%/%writeBlobFilesDir%
  * @constructor
  * @ignore
  */
-function PluginCliManager(project, mainLogger, gmeConfig) {
-    var blobClient = new BlobClientWithFSBackend(gmeConfig, mainLogger);
+function PluginCliManager(project, mainLogger, gmeConfig, opts) {
+    var blobClient = new BlobClientWithFSBackend(gmeConfig, mainLogger, opts);
 
     PluginManagerBase.call(this, blobClient, project, mainLogger, gmeConfig);
 }

--- a/src/server/middleware/blob/BlobClientWithFSBackend.js
+++ b/src/server/middleware/blob/BlobClientWithFSBackend.js
@@ -9,9 +9,9 @@ var Q = require('q'),
     BlobFSBackend = require('./BlobFSBackend'),
     BlobRunPluginClient = require('./BlobRunPluginClient');
 
-function BlobClientWithFSBackend(gmeConfig, logger) {
+function BlobClientWithFSBackend(gmeConfig, logger, opts) {
     var blobBackend = new BlobFSBackend(gmeConfig, logger),
-        blobClient = new BlobRunPluginClient(blobBackend, logger);
+        blobClient = new BlobRunPluginClient(blobBackend, logger, opts);
 
     blobClient.listObjects = function (bucket, callback) {
         var deferred = Q.defer();

--- a/src/server/util/ensureDir.js
+++ b/src/server/util/ensureDir.js
@@ -9,7 +9,8 @@
 'use strict';
 
 var path = require('path'),
-    fs = require('fs');
+    fs = require('fs'),
+    Q = require('q');
 
 function _ensureDir(dir, mode, callback) {
     var existsFunction = fs.exists || path.exists;
@@ -54,6 +55,8 @@ function _ensureDir(dir, mode, callback) {
  */
 
 function ensureDir(dir, mode, callback) {
+    var deferred = Q.defer();
+
     if (mode && typeof mode === 'function') {
         callback = mode;
         mode = null;
@@ -63,10 +66,15 @@ function ensureDir(dir, mode, callback) {
     mode = mode || parseInt('0777', 8) & (~process.umask());
     //jshint bitwise: true
 
-    callback = callback || function () {
-    };
+    _ensureDir(dir, mode, function (err) {
+        if (err) {
+            deferred.reject(err);
+        } else {
+            deferred.resolve();
+        }
+    });
 
-    _ensureDir(dir, mode, callback);
+    return deferred.promise.nodeify(callback);
 }
 
 module.exports = ensureDir;

--- a/test/bin/run_plugin.spec.js
+++ b/test/bin/run_plugin.spec.js
@@ -209,5 +209,30 @@ describe('Run plugin CLI', function () {
                 .nodeify(done);
         });
 
+        it('should run the AddOnGenerator and put files in plugin-blobs if -w specified', function (done) {
+            testFixture.rimraf(testFixture.path.join(process.cwd(), 'test-tmp/plugin-blobs'), function (err) {
+                if (err) {
+                    done(err);
+                    return;
+                }
+
+                runPlugin.main(['node', filename, 'AddOnGenerator', projectName, '-w', 'test-tmp/plugin-blobs'],
+                    function (err, result) {
+                        if (err) {
+                            done(new Error(err));
+                            return;
+                        }
+                        expect(result.success).to.equal(true);
+                        expect(result.error).to.equal(null);
+
+                        expect(testFixture.fs.existsSync(
+                            testFixture.path.join(process.cwd(), 'test-tmp/plugin-blobs/NewAddOn.js'))
+                        ).to.equal(true);
+                        done();
+                    }
+                );
+            });
+        });
+
     });
 });


### PR DESCRIPTION
Example:
```
node ./src/bin/run_plugin.js AddOnGenerator MyProject -w plugin-blobs
```

From the console:
```
warn: [gme:bin:runplugin] writeBlobFilesDir given, will also write blobs to c:\GIT\webgme\plugin-blobs
...
info: [gme:bin:runplugin] Wrote file to c:\GIT\webgme\plugin-blobs\NewAddOn.js
```
