### PR TITLE
Load members shorthand function

### DIFF
--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1727,7 +1727,7 @@ define([
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
             var names = core.getSetNames(node).concat(core.getValidSetNames(node));
-            ;
+
             if (names.indexOf(name) === -1) {
                 throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
             }

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1726,7 +1726,8 @@ define([
         this.getOwnMemberPaths = function (node, name) {
             ensureNode(node, 'node');
             ensureType(name, 'name', 'string');
-            var names = core.getSetNames(node).concat(core.getValidSetNames(node));;
+            var names = core.getSetNames(node).concat(core.getValidSetNames(node));
+            ;
             if (names.indexOf(name) === -1) {
                 throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
             }
@@ -3811,6 +3812,54 @@ define([
                 callback(error);
             } else {
                 core.loadInstances(node, callback);
+            }
+        };
+
+        /**
+         * Loads all the members of the given set of the node.
+         * @param {module:Core~Node} node - the node in question.
+         * @param {string} setName - the name of the set in question.
+         * @param {function} [callback]
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the status of the execution.
+         * @param {module:Core~Node[]} callback.nodes - the found members of the set of the node.
+         *
+         * @return {External~Promise} If no callback is given, the result will be provided in a promise
+         * like manner.
+         *
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
+         */
+        this.loadMembers = function (node, setName, callback) {
+            ensureType(setName, 'setName', 'string');
+            ensureType(callback, 'callback', 'function');
+            var error = ensureNode(node, 'node', true);
+            if (error) {
+                callback(error);
+            } else {
+                core.loadMembers(node, setName, callback);
+            }
+        };
+
+        /**
+         * Loads all the own members of the given set of the node.
+         * @param {module:Core~Node} node - the node in question.
+         * @param {string} setName - the name of the set in question.
+         * @param {function} [callback]
+         * @param {Error|CoreIllegalArgumentError|CoreAssertError|null} callback.error - the status of the execution.
+         * @param {module:Core~Node[]} callback.nodes - the found own members of the set of the node.
+         *
+         * @return {External~Promise} If no callback is given, the result will be provided in a promise
+         * like manner.
+         *
+         * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
+         */
+        this.loadOwnMembers = function (node, setName, callback) {
+            ensureType(setName, 'setName', 'string');
+            ensureType(callback, 'callback', 'function');
+            var error = ensureNode(node, 'node', true);
+            if (error) {
+                callback(error);
+            } else {
+                core.loadOwnMembers(node, setName, callback);
             }
         };
     }

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -188,11 +188,11 @@ define(['common/util/canon',
                         data[names[i]] = {attr: {}, reg: {}};
                         keys = self.getOwnSetAttributeNames(node, names[i]);
                         for (j = 0; j < keys.length; j += 1) {
-                            data[names[i]].attr[keys[j]] = self.getSetAttribute(node, names[i], keys[j]);
+                            data[names[i]].attr[keys[j]] = self.getOwnSetAttribute(node, names[i], keys[j]);
                         }
                         keys = self.getOwnSetRegistryNames(node, names[i]);
                         for (j = 0; j < keys.length; j += 1) {
-                            data[names[i]].reg[keys[j]] = self.getSetRegistry(node, names[i], keys[j]);
+                            data[names[i]].reg[keys[j]] = self.getOwnSetRegistry(node, names[i], keys[j]);
                         }
 
                         targets = self.getMemberPaths(node, names[i]);
@@ -1192,7 +1192,7 @@ define(['common/util/canon',
                     self.deleteSet(node, setNames[i]);
                 } else {
                     self.createSet(node, setNames[i]);
-                    if ((Object.keys(setDiff[setNames[i]].attr || {})).length > 0) {
+                    if (Object.keys(setDiff[setNames[i]].attr || {}).length > 0) {
                         elements = Object.keys(setDiff[setNames[i]].attr);
                         for (j = 0; j < elements.length; j += 1) {
                             if (setDiff[setNames[i]].attr[elements[j]] === CONSTANTS.TO_DELETE_STRING) {

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -1718,6 +1718,29 @@ define(['common/util/canon',
                 conflict = _conflictTheirs;
                 opposingConflict = _conflictMine[opposingPath];
             }
+
+            //set attributes and registry entries
+            keys = Object.keys(diffSet.attr || {});
+            for (j = 0; j < keys.length; j++) {
+                conflict[path + '/attr/' + keys[j]] =
+                    conflict[path + '/attr/' + keys[j]] || {
+                        value: diffSet.attr[keys[j]],
+                        conflictingPaths: {}
+                    };
+                conflict[path + '/attr/' + keys[j]].conflictingPaths[opposingPath] = true;
+                opposingConflict.conflictingPaths[path + '/attr/' + keys[j]] = true;
+            }
+            keys = Object.keys(diffSet.reg || {});
+            for (j = 0; j < keys.length; j++) {
+                conflict[path + '/reg/' + keys[j]] =
+                    conflict[path + '/reg/' + keys[j]] || {
+                        value: diffSet.reg[keys[j]],
+                        conflictingPaths: {}
+                    };
+                conflict[path + '/reg/' + keys[j]].conflictingPaths[opposingPath] = true;
+                opposingConflict.conflictingPaths[path + '/reg/' + keys[j]] = true;
+            }
+
             for (i = 0; i < relids.length; i++) {
                 if (diffSet[relids[i]] === CONSTANTS.TO_DELETE_STRING) {
                     //single conflict as the element was removed
@@ -1797,6 +1820,19 @@ define(['common/util/canon',
                             };
                             gatherFullSetConflicts(base[names[i]], true, path + '/' + names[i], path + '/' + names[i]);
                         } else {
+                            //now check the set attribute and registry differences
+                            if (base[names[i]].attr && extension[names[i]].attr) {
+                                concatSingleKeyValuePairs(path + '/' +
+                                    names[i] + '/attr',
+                                    base[names[i]].attr,
+                                    extension[names[i]].attr);
+                            }
+                            if (base[names[i]].reg && extension[names[i]].reg) {
+                                concatSingleKeyValuePairs(path + '/' +
+                                    names[i] + '/reg',
+                                    base[names[i]].reg,
+                                    extension[names[i]].reg);
+                            }
                             //now we can only have member or sub-member conflicts...
                             members = getDiffChildrenRelids(extension[names[i]]);
                             for (j = 0; j < members.length; j++) {

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -451,6 +451,7 @@ define([
         this.deleteChild = function (parent, relid) {
             var prefix = '/' + relid;
             innerCore.deleteProperty(parent, relid);
+            innerCore.removeChildFromCache(parent, relid);
             if (parent.childrenRelids) {
                 parent.childrenRelids = null;
             }

--- a/src/common/core/coreunwrap.js
+++ b/src/common/core/coreunwrap.js
@@ -99,6 +99,8 @@ define(['common/core/CoreAssert', 'common/core/tasync'], function (ASSERT, TASYN
             return TASYNC.call(checkNodes, innercore.loadInstances(node));
         });
 
+        core.loadMembers = TASYNC.unwrap(innercore.loadMembers);
+        core.loadOwnMembers = TASYNC.unwrap(innercore.loadOwnMembers);
 
         return core;
     };

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -292,7 +292,15 @@ define([
                 for (i = 0; i < paths.length; i += 1) {
                     nodes[i] = self.loadByPath(root, paths[i]);
                 }
-                return TASYNC.lift(nodes);
+                return TASYNC.call(function (n) {
+                    var newn = [];
+                    for (var i = 0; i < n.length; i++) {
+                        if (n[i] !== null) {
+                            newn.push(n[i]);
+                        }
+                    }
+                    return newn;
+                }, TASYNC.lift(nodes));
             }, self.loadPaths(rootHash, paths));
         }
 

--- a/src/common/core/setcore.js
+++ b/src/common/core/setcore.js
@@ -5,7 +5,11 @@
  * @author kecso / https://github.com/kecso
  */
 
-define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
+define([
+    'common/core/CoreAssert',
+    'common/core/constants',
+    'common/core/tasync'
+], function (ASSERT, CONSTANTS, TASYNC) {
     'use strict';
 
     function SetCore(innerCore, options) {
@@ -260,7 +264,7 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
             var value;
 
             do {
-                value = getOwnPropertyValue(node,  propertyCollectionName, propertyName, setName, memberPath);
+                value = getOwnPropertyValue(node, propertyCollectionName, propertyName, setName, memberPath);
                 if (value !== undefined) {
                     return value;
                 }
@@ -278,6 +282,20 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
                 self.createSet(node, setName);
             }
         }
+
+        function loadNodesOfPaths(root, paths) {
+            var nodes = [],
+                i,
+                rootHash = self.getHash(root);
+
+            return TASYNC.call(function () {
+                for (i = 0; i < paths.length; i += 1) {
+                    nodes[i] = self.loadByPath(root, paths[i]);
+                }
+                return TASYNC.lift(nodes);
+            }, self.loadPaths(rootHash, paths));
+        }
+
         //</editor-fold>
 
         //<editor-fold=Modified Methods>
@@ -569,6 +587,13 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
             }
         };
 
+        this.loadMembers = function (node, setName) {
+            return loadNodesOfPaths(self.getRoot(node), self.getMemberPaths(node, setName));
+        };
+
+        this.loadOwnMembers = function (node, setName) {
+            return loadNodesOfPaths(self.getRoot(node), self.getOwnMemberPaths(node, setName));
+        };
         //</editor-fold>
     }
 

--- a/src/common/util/random.js
+++ b/src/common/util/random.js
@@ -7,7 +7,7 @@
  * collection of functions that uses random Numbers in WebGME
  */
 
-define(['chance'], function (ChanceJs) {
+define(['chance', 'common/Constants'], function (ChanceJs, CONSTANTS) {
     'use strict';
 
     function _generateRelidRegexp() {
@@ -70,6 +70,31 @@ define(['chance'], function (ChanceJs) {
         return relidRegexp.test(relid);
     }
 
+    function isValidPath(path) {
+        var relid;
+
+        if (path === CONSTANTS.PROJECT_ROOT_ID) {
+            return true;
+        }
+
+        path = path.split(CONSTANTS.CORE.PATH_SEP);
+
+        relid = path.shift();
+
+        if (relid !== CONSTANTS.PROJECT_ROOT_ID) {
+            return false;
+        }
+
+        do {
+            relid = path.shift();
+            if (typeof relid === 'string' && relidRegexp.test(relid) === false) {
+                return false;
+            }
+        } while (relid);
+
+        return true;
+    }
+
     function relidToInteger(relid) {
         var num = 'NaN',
             negative = false,
@@ -104,6 +129,7 @@ define(['chance'], function (ChanceJs) {
             generateGuid: generateGuid,
             generateRelid: generateRelid,
             isValidRelid: isValidRelid,
+            isValidPath: isValidPath,
             relidToInteger: relidToInteger
         };
 

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -118,7 +118,7 @@ describe('core', function () {
                 'removeLibrary', 'getLibraryGuid', 'renameLibrary', 'getLibraryInfo',
                 'getLibraryRoot', 'getLibraryMetaNodes', 'traverse', 'getClosureInformation',
                 'importClosure', 'getInstancePaths', 'loadInstances', 'delPointer', 'delSet',
-                'getMetaType'
+                'getMetaType', 'loadMembers', 'loadOwnMembers'
             ];
 
         expect(functions).to.have.members(Matches);

--- a/test/common/core/corediff.spec.js
+++ b/test/common/core/corediff.spec.js
@@ -242,6 +242,122 @@ describe('core diff', function () {
             });
         });
 
+        it('should generate diff if set attribute or registry changes', function (done) {
+            var patch = {
+                1303043463: {
+                    2119137141: {
+                        set: {
+                            setPtr: {
+                                attr: {
+                                    something: 'newValue'
+                                },
+                                reg: {
+                                    other: 42
+                                }
+                            }
+                        },
+                        guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5',
+                        oGuids: {
+                            '45657d4d-f82d-13ce-1acb-0aadebb5c8b5': true,
+                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                            'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
+                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                            'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
+                        }
+                    },
+                    guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
+                    oGuids: {
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                    }
+                },
+                guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
+                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+            };
+
+            core.applyTreeDiff(rootNode, patch, function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                var persisted = core.persist(rootNode);
+
+                core.generateTreeDiff(originalRootNode, rootNode, function (err, diff) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    expect(diff).to.deep.equal(patch);
+                    done();
+                });
+            });
+        });
+
+        it('should generate complex set related diff', function (done) {
+            var patch = {
+                1303043463: {
+                    2119137141: {
+                        set: {
+                            setPtr: {
+                                attr: {
+                                    something: 'newValue'
+                                },
+                                '/1303043463/1448030591': {
+                                    attr: {
+                                        elevation: 'high'
+                                    }
+                                },
+                                '/1303043463/1044885565':{
+                                    reg:{
+                                        position:'*to*delete*'
+                                    }
+                                }
+                            }
+                        },
+                        guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5',
+                        oGuids: {
+                            '45657d4d-f82d-13ce-1acb-0aadebb5c8b5': true,
+                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                            'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
+                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                            'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
+                        }
+                    },
+                    guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
+                    oGuids: {
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                    }
+                },
+                guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
+                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+            };
+
+            core.applyTreeDiff(rootNode, patch, function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                var persisted = core.persist(rootNode);
+
+                core.generateTreeDiff(originalRootNode, rootNode, function (err, diff) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    expect(diff).to.deep.equal(patch);
+                    done();
+                });
+            });
+        });
     });
 
     describe('tryToConcatChanges', function () {

--- a/test/common/core/corediff.spec.js
+++ b/test/common/core/corediff.spec.js
@@ -311,9 +311,9 @@ describe('core diff', function () {
                                         elevation: 'high'
                                     }
                                 },
-                                '/1303043463/1044885565':{
-                                    reg:{
-                                        position:'*to*delete*'
+                                '/1303043463/1044885565': {
+                                    reg: {
+                                        position: '*to*delete*'
                                     }
                                 }
                             }
@@ -818,6 +818,243 @@ describe('core diff', function () {
                 .to.equal('/1303043463/2119137141/set/setPtr//1303043463/1448030591//reg/position');
             expect(result.items[0].theirs.path).to.equal('/1303043463/2119137141/set/setPtr');
             expect(result.items[0].theirs.value).to.equal('*to*delete*');
+        });
+
+        it('should handle complex set changes without conflict', function () {
+            var result,
+                diff1 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'two'},
+                                    reg: {three: 'four'},
+                                    '/1303043463/1448030591': {
+                                        reg: {
+                                            position: {
+                                                x: 500,
+                                                y: 200
+                                            }
+                                        },
+                                        attr: {
+                                            one: 'two'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                },
+                diff2 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'two'},
+                                    reg: {five: 'six'},
+                                    '/1303043463/1448030591': {
+                                        attr: {
+                                            one: 'two',
+                                            five: 'six'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                };
+
+            result = core.tryToConcatChanges(diff1, diff2);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(0);
+            expect(result.merge[1303043463][2119137141].set.setPtr).to.eql({
+                attr: {one: 'two'},
+                reg: {
+                    three: 'four',
+                    five: 'six'
+                },
+                '/1303043463/1448030591': {
+                    attr: {
+                        one: 'two',
+                        five: 'six'
+                    },
+                    reg: {
+                        position: {
+                            x: 500,
+                            y: 200
+                        }
+                    }
+                }
+            });
+
+            result = core.tryToConcatChanges(diff2, diff1);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(0);
+            expect(result.merge[1303043463][2119137141].set.setPtr).to.eql({
+                attr: {one: 'two'},
+                reg: {
+                    three: 'four',
+                    five: 'six'
+                },
+                '/1303043463/1448030591': {
+                    attr: {
+                        one: 'two',
+                        five: 'six'
+                    },
+                    reg: {
+                        position: {
+                            x: 500,
+                            y: 200
+                        }
+                    }
+                }
+            });
+        });
+
+        it('should handle complex set changes with conflict', function () {
+            var result,
+                diff1 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'two'},
+                                    reg: {three: '*to*delete*'},
+                                    '/1303043463/1448030591': {
+                                        reg: {
+                                            position: {
+                                                x: 500,
+                                                y: 200
+                                            }
+                                        },
+                                        attr: {
+                                            one: 'two'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                },
+                diff2 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'four'},
+                                    reg: {three: 'six'},
+                                    '/1303043463/1448030591': {
+                                        attr: {
+                                            one: 'two',
+                                            five: '*to*delete*'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                };
+
+            result = core.tryToConcatChanges(diff1, diff2);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(2);
+            expect(result.items[0].mine.value).to.equal('two');
+            expect(result.items[0].theirs.value).to.equal('four');
+            expect(result.items[1].mine.value).to.equal('*to*delete*');
+            expect(result.items[1].theirs.value).to.equal('six');
+
+            result = core.tryToConcatChanges(diff2, diff1);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(2);
+            expect(result.items[0].mine.value).to.equal('four');
+            expect(result.items[0].theirs.value).to.equal('two');
+            expect(result.items[1].theirs.value).to.equal('*to*delete*');
+            expect(result.items[1].mine.value).to.equal('six');
+        });
+
+        it('should handle complex ,whole set conflicts', function () {
+            var result,
+                diff1 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: '*to*delete*'
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                },
+                diff2 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'four'},
+                                    reg: {three: 'six'},
+                                    '/1303043463/1448030591': {
+                                        attr: {
+                                            one: 'two',
+                                            five: '*to*delete*'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                };
+
+            result = core.tryToConcatChanges(diff1, diff2);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(4);
+            expect(result.items[0].mine.value).to.equal('*to*delete*');
+            expect(result.items[1].mine.value).to.equal('*to*delete*');
+            expect(result.items[2].mine.value).to.equal('*to*delete*');
+            expect(result.items[3].mine.value).to.equal('*to*delete*');
+            expect(result.items[0].theirs.value).to.equal('four');
+            expect(result.items[1].theirs.value).to.equal('six');
+            expect(result.items[2].theirs.value).to.equal('two');
+            expect(result.items[3].theirs.value).to.equal('*to*delete*');
+
+            result = core.tryToConcatChanges(diff2, diff1);
+
+            expect(result).not.to.equal(null);
+            expect(result).to.include.keys('items');
+            expect(result.items).to.have.length(4);
+            expect(result.items[0].mine.value).to.equal('four');
+            expect(result.items[1].mine.value).to.equal('six');
+            expect(result.items[2].mine.value).to.equal('two');
+            expect(result.items[3].mine.value).to.equal('*to*delete*');
+            expect(result.items[0].theirs.value).to.equal('*to*delete*');
+            expect(result.items[1].theirs.value).to.equal('*to*delete*');
+            expect(result.items[2].theirs.value).to.equal('*to*delete*');
+            expect(result.items[3].theirs.value).to.equal('*to*delete*');
         });
 
         //it('should tryToConcatChanges does nothing, and delete the set pointer', function () {
@@ -1634,6 +1871,68 @@ describe('core diff', function () {
             expect(resultPatch['1303043463']).to.include.keys('1763546084');
             expect(resultPatch['1303043463']['1763546084']).not.to.include.keys('1823288916');
 
+        });
+
+        it('should combine and resolve complex set conflicts', function () {
+            var resultConflict,
+                resultPatch,
+                diff1 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'two'},
+                                    reg: {three: '*to*delete*'},
+                                    '/1303043463/1448030591': {
+                                        reg: {
+                                            position: {
+                                                x: 500,
+                                                y: 200
+                                            }
+                                        },
+                                        attr: {
+                                            one: 'two'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                },
+                diff2 = {
+                    1303043463: {
+                        2119137141: {
+                            set: {
+                                setPtr: {
+                                    attr: {one: 'four'},
+                                    reg: {three: 'six'},
+                                    '/1303043463/1448030591': {
+                                        attr: {
+                                            one: 'two',
+                                            five: '*to*delete*'
+                                        }
+                                    }
+                                }
+                            },
+                            guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                        },
+                        guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+                };
+
+            resultConflict = core.tryToConcatChanges(diff1, diff2);
+            resultConflict.items[0].selected = 'theirs';
+            resultPatch = core.applyResolution(resultConflict);
+
+            expect(resultPatch).not.to.equal(null);
+            expect(resultPatch).to.include.keys('1303043463');
+            expect(resultPatch['1303043463']).to.include.keys('2119137141');
+            expect(resultPatch['1303043463']['2119137141'].set.setPtr.attr.one).to.equal('four');
+            expect(resultPatch['1303043463']['2119137141'].set.setPtr.reg.three).to.equal('*to*delete*');
         });
     });
 
@@ -2461,6 +2760,105 @@ describe('core diff', function () {
                 })
                 .then(function (node) {
                     expect(core.getValidPointerNames(node)).to.have.length(0);
+                })
+                .nodeify(done);
+        });
+
+        it('should apply set removal', function (done) {
+            var patch = {
+                1303043463: {
+                    2119137141: {
+                        set: {
+                            setPtr: '*to*delete*'
+                        },
+                        guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                    },
+                    guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                },
+                guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+            };
+
+            Q.nfcall(core.applyTreeDiff, rootNode, patch) // FIXME: what if it results in an error?
+                .then(function () {
+                    return Q.nfcall(core.loadByPath, rootNode, '/1303043463/2119137141');
+                })
+                .then(function (node) {
+                    expect(core.getOwnSetNames(node)).to.have.length(0);
+                })
+                .nodeify(done);
+        });
+
+        it('should apply set attribute and registry changes', function (done) {
+            var patch = {
+                1303043463: {
+                    2119137141: {
+                        set: {
+                            setPtr: {
+                                attr: {
+                                    one: 'two'
+                                },
+                                reg: {
+                                    three: 'four'
+                                }
+                            }
+                        },
+                        guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                    },
+                    guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                },
+                guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+            };
+
+            Q.nfcall(core.applyTreeDiff, rootNode, patch) // FIXME: what if it results in an error?
+                .then(function () {
+                    return Q.nfcall(core.loadByPath, rootNode, '/1303043463/2119137141');
+                })
+                .then(function (node) {
+                    expect(core.getSetAttributeNames(node, 'setPtr')).to.eql(['one']);
+                    expect(core.getSetAttribute(node, 'setPtr', 'one')).to.eql('two');
+                    expect(core.getSetRegistryNames(node, 'setPtr')).to.eql(['three']);
+                    expect(core.getSetRegistry(node, 'setPtr', 'three')).to.eql('four');
+
+                    patch[1303043463][2119137141].set.setPtr.attr.one = '*to*delete*';
+                    patch[1303043463][2119137141].set.setPtr.reg.three = '*to*delete*';
+
+                    return Q.nfcall(core.applyTreeDiff, rootNode, patch);
+                })
+                .then(function () {
+                    return Q.nfcall(core.loadByPath, rootNode, '/1303043463/2119137141');
+                })
+                .then(function (node) {
+                    expect(core.getSetAttributeNames(node, 'setPtr')).to.eql([]);
+                    expect(core.getSetAttribute(node, 'setPtr', 'one')).to.eql(undefined);
+                    expect(core.getSetRegistryNames(node, 'setPtr')).to.eql([]);
+                    expect(core.getSetRegistry(node, 'setPtr', 'three')).to.eql(undefined);
+
+                })
+                .nodeify(done);
+        });
+
+        it('should apply set member removal', function (done) {
+            var patch = {
+                1303043463: {
+                    2119137141: {
+                        set: {
+                            setPtr: {
+                                '/1303043463/1448030591': '*to*delete*'
+                            }
+                        },
+                        guid: '45657d4d-f82d-13ce-1acb-0aadebb5c8b5'
+                    },
+                    guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42'
+                },
+                guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0'
+            };
+
+            Q.nfcall(core.applyTreeDiff, rootNode, patch) // FIXME: what if it results in an error?
+                .then(function () {
+                    return Q.nfcall(core.loadByPath, rootNode, '/1303043463/2119137141');
+                })
+                .then(function (node) {
+                    expect(core.getMemberPaths(node, 'setPtr')).not.to.have.members(['/1303043463/1448030591']);
                 })
                 .nodeify(done);
         });

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -918,4 +918,70 @@ describe('set core', function () {
         persisted = core.persist(root).objects;
         expect(persisted).to.deep.equal({});
     });
+
+    it('should load members correctly', function (done) {
+        var set = core.createNode({parent: root}),
+            memberOne = core.createNode({parent: root, relid: 'm1'}),
+            memberTwo = core.createNode({parent: root, relid: 'm2'});
+
+        core.addMember(set, 'members', memberOne);
+        core.addMember(set, 'members', memberTwo);
+
+        core.loadMembers(set, 'members', function (err, members) {
+            expect(err === null || err === undefined).to.equal(true);
+
+            var memberPaths = [],
+                i;
+
+            expect(members).to.have.length(2);
+            for (i = 0; i < members.length; i += 1) {
+                memberPaths.push(core.getPath(members[i]));
+            }
+            expect(core.getMemberPaths(set, 'members')).to.have.members(memberPaths);
+            done();
+        });
+
+    });
+
+    it('should load own members correctly', function (done) {
+        var set = core.createNode({parent: root}),
+            memberOne = core.createNode({parent: root, relid: 'm1'}),
+            memberTwo = core.createNode({parent: root, relid: 'm2'}),
+            setInstance = core.createNode({parent: root, base: set}),
+            memberThree = core.createNode({parent: root, relid: 'm3'});
+
+        core.addMember(set, 'members', memberOne);
+        core.addMember(set, 'members', memberTwo);
+
+        core.addMember(setInstance, 'members', memberThree);
+
+        core.loadOwnMembers(setInstance, 'members', function (err, members) {
+            expect(err === null || err === undefined).to.equal(true);
+
+            expect(members).to.have.length(1);
+            expect(core.getRelid(members[0])).to.equal('m3');
+
+            core.loadMembers(setInstance, 'members', function (err, members) {
+                expect(err === null || err === undefined).to.equal(true);
+
+                expect(members).to.have.length(3);
+
+                done();
+            });
+        });
+
+    });
+
+    it('should return empty array for loading members of unknown set', function (done) {
+        var set = core.createNode({parent: root});
+
+        core.loadMembers(set, 'anything', function (err, members) {
+            expect(err === null || err === undefined).to.equal(true);
+
+            expect(members).to.have.length(0);
+
+            done();
+        });
+
+    });
 });


### PR DESCRIPTION
The enhancement implements the loadMembers and loadOwnMembers shorthand functions on the core API. They collect the members of a given set of the given node.
Also it takes care of the missing handling of set registry and set attribute changes (during diff generation, conflict management and merging). 
