### PR TITLE
Allow visualizer to defined getValidTypesInfo to list part-browser nodes.

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -420,6 +420,8 @@ define(['js/logger',
 
                 this._updateSelectedMemberListMembersTerritoryPatterns();
             } else {
+                this._widget.clear();
+                this._displayContainerObjectName();
                 this.displayNoTabMessage();
             }
         }

--- a/src/client/js/Panels/Crosscut/CrosscutPanel.js
+++ b/src/client/js/Panels/Crosscut/CrosscutPanel.js
@@ -108,5 +108,9 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
+    CrosscutPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+        return {};
+    };
+
     return CrosscutPanel;
 });

--- a/src/client/js/Panels/GraphViz/GraphVizPanel.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanel.js
@@ -94,5 +94,9 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
+    GraphVizPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+        return {};
+    };
+
     return GraphVizPanel;
 });

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -2114,6 +2114,16 @@ define(['js/logger',
         this._radioButtonGroupMetaRelationType.enabled(!isReadOnly);
     };
 
+    MetaEditorControl.prototype.getValidTypesInfo = function (/*nodeId*/) {
+        var containerNode = this._client.getNode(CONSTANTS.PROJECT_ROOT_ID);
+        if (containerNode) {
+            return containerNode.getValidChildrenTypesDetailed(null, true);
+        } else {
+            // Root node is not loaded.
+            return {};
+        }
+    };
+
     MetaEditorControl.getDefaultConfig = function () {
         return {
             autoCheckMetaConsistency: true

--- a/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
@@ -105,5 +105,9 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
+    MetaEditorPanel.prototype.getValidTypesInfo = function (nodeId) {
+        return this.control.getValidTypesInfo(nodeId);
+    };
+
     return MetaEditorPanel;
 });

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -241,6 +241,7 @@ define(['js/logger',
         var containerNode = this._client.getNode(this._containerNodeId),
             metaNodes = this._client.getAllMetaNodes(),
             descriptorCollection = {},
+            activePanel,
             descriptor,
             validInfo,
             keys,
@@ -279,23 +280,12 @@ define(['js/logger',
         }
 
         if (containerNode) {
-            if (this._visualizer === 'GraphViz') {
-                //do nothing as partBrowser should not have any element in GraphViz
-                validInfo = {};
-            } else if (this._visualizer === 'SetEditor') {
-                //i = getSetName();
-                //if (i) {
-                //    validInfo = containerNode.getValidSetMemberTypesDetailed(i);
-                //} else {
-                //    validInfo = {};
-                //} //TODO now we cannot create elements in set editor
-                validInfo = {};
-            } else if (this._visualizer === 'METAAspect') {
-                //here we should override the container node to the META container node - ROOT as of now
-                containerNode = this._client.getNode(CONSTANTS.PROJECT_ROOT_ID);
-                validInfo = containerNode.getValidChildrenTypesDetailed(null, true);
+            activePanel = WebGMEGlobal.PanelManager.getActivePanel();
+
+            if (activePanel && typeof activePanel.getValidTypesInfo === 'function') {
+                validInfo = activePanel.getValidTypesInfo(containerNode.getId());
             } else {
-                //default is the containment based elements
+                // default is the containment based elements.
                 validInfo = containerNode.getValidChildrenTypesDetailed(this._aspect);
             }
 

--- a/src/client/js/Panels/SetEditor/SetEditorPanel.js
+++ b/src/client/js/Panels/SetEditor/SetEditorPanel.js
@@ -106,5 +106,9 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
+    SetEditorPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+        return {};
+    };
+
     return SetEditorPanel;
 });


### PR DESCRIPTION
If `Panel.getValidTypesInfo` is not defined and a function - the containment behavior based on the meta-rules is applied.

This gets rid of the hard-coding of visualizers in the part-browser and enables visualizers to defined their own behavior based on the context.

This PR also fixes #1331 
