### PR TITLE
Component settings can be defined in a javascript file.

### DIFF
--- a/config/components.default.js
+++ b/config/components.default.js
@@ -1,0 +1,8 @@
+/*jshint node:true*/
+
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+var components = require('./components.json');
+
+module.exports = components;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "q": "1.4.1",
     "raml2html": "3.0.1",
     "redis": "2.6.2",
+    "require-uncached": "^1.0.3",
     "requirejs": "2.1.20",
     "socket.io": "1.4.8",
     "socket.io-client": "1.4.8",

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -210,7 +210,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 if (err.message.indexOf('no such user') === 0) {
                     logger.info('Authenticated user did not exist in db, adding:', userId);
                     gmeAuth.addUser(userId, 'em@il', GUID(), false, {overwrite: false})
-                        .then(function (userData) {
+                        .then(function (/*userData*/) {
                             return gmeAuth.getUser(userId);
                         })
                         .then(deferred.resolve)
@@ -366,44 +366,19 @@ function createAPI(app, mountPath, middlewareOpts) {
     });
 
     router.get('/componentSettings', ensureAuthenticated, function (req, res, next) {
-        var componentsPath = path.join(process.cwd(), 'config', 'components.json');
-        logger.debug('Reading in default componentSettings at:', componentsPath);
-        // TODO: Consider using a file watcher and cache the file between updates..
-
-        Q.nfcall(fs.readFile, componentsPath, 'utf8')
-            .then(function (content) {
-                res.json(JSON.parse(content));
+        webgmeUtils.getComponentsJson(logger)
+            .then(function (componentsJson) {
+                res.json(componentsJson);
             })
-            .catch(function (err) {
-                if (err.code === 'ENOENT') {
-                    logger.debug('File did not exist returning empty obj', componentsPath);
-                    res.json({});
-                } else {
-                    logger.error('Errors reading in: ', componentsPath, err);
-                    next(err);
-                }
-            });
+            .catch(next);
     });
 
     router.get('/componentSettings/:componentId', ensureAuthenticated, function (req, res, next) {
-        var componentsPath = path.join(process.cwd(), 'config', 'components.json');
-        logger.debug('Reading in default componentSettings at:', componentsPath);
-        // TODO: Consider using a file watcher and cache the file between updates..
-
-        Q.nfcall(fs.readFile, componentsPath, 'utf8')
-            .then(function (content) {
-                var contentObj = JSON.parse(content);
-                res.json(contentObj[req.params.componentId] || {});
+        webgmeUtils.getComponentsJson(logger)
+            .then(function (componentsJson) {
+                res.json(componentsJson[req.params.componentId] || {});
             })
-            .catch(function (err) {
-                if (err.code === 'ENOENT') {
-                    logger.debug('File did not exist returning empty obj', componentsPath);
-                    res.json({});
-                } else {
-                    logger.error('Errors reading in: ', componentsPath, err);
-                    next(err);
-                }
-            });
+            .catch(next);
     });
 
     router.get('/user/settings', ensureAuthenticated, function (req, res, next) {
@@ -449,7 +424,7 @@ function createAPI(app, mountPath, middlewareOpts) {
             .then(function (/*userData*/) {
                 return gmeAuth.updateUserSettings(userId, {}, true);
             })
-            .then(function (settings) {
+            .then(function (/*settings*/) {
                 res.sendStatus(204);
             })
             .catch(next);
@@ -1806,7 +1781,6 @@ function createAPI(app, mountPath, middlewareOpts) {
     // TODO: These variables should not be defined here.
     // TODO: runningPlugins should be stored in a database.
     var runningPlugins = {};
-    var GUID = requireJS('common/util/guid');
     var PLUGIN_CONSTANTS = {
         RUNNING: 'RUNNING',
         FINISHED: 'FINISHED', // Could still be that result.success=false.
@@ -2110,7 +2084,7 @@ function createAPI(app, mountPath, middlewareOpts) {
     logger.debug('Latest api path: ' + latestAPIPath);
     app.use(latestAPIPath, router);
 
-    return Q();
+    return Q(); //jshint ignore: line
 }
 
 module.exports = {

--- a/test/config/config.spec.js
+++ b/test/config/config.spec.js
@@ -1,15 +1,18 @@
 /*jshint node: true, mocha: true*/
 /**
  * @author lattmann / https://github.com/lattmann
+ * @author pmeijer / https://github.com/pmeijer
  */
 
-describe('configuration', function () {
+describe('configuration and components', function () {
     'use strict';
 
     var should = require('chai').should(),
         expect = require('chai').expect,
         oldNodeEnv = process.env.NODE_ENV || '',
+        oldCwd = process.cwd(),
         path = require('path'),
+        webgme = require('../../webgme'),
         getClientConfig = require('../../config/getclientconfig'),
         configPath = path.join(__dirname, '..', '..', 'config'),
         validateConfig,
@@ -35,10 +38,12 @@ describe('configuration', function () {
     });
 
     beforeEach(function () {
+        process.chdir(oldCwd);
         unloadConfigs();
     });
 
     after(function () {
+        process.chdir(oldCwd);
         unloadConfigs();
         process.env.NODE_ENV = oldNodeEnv;
         // restore config
@@ -184,5 +189,36 @@ describe('configuration', function () {
 
         should.equal(clientConfig.socketIO.hasOwnProperty('serverOptions'), false);
         should.equal(clientConfig.socketIO.hasOwnProperty('adapter'), false);
+    });
+
+    // These really only show up in the coverage..
+    it('getComponentsJson should fallback to default when NODE_ENV is empty', function (done) {
+        process.env.NODE_ENV = '';
+
+        webgme.getComponentsJson()
+            .then(function (json) {
+                expect(json).to.deep.equal({});
+            })
+            .nodeify(done);
+    });
+
+    it('getComponentsJson should fallback to components when NODE_ENV set to non-existing', function (done) {
+        process.env.NODE_ENV = 'noComponentsJsonWithThisNameExists';
+
+        webgme.getComponentsJson()
+            .then(function (json) {
+                expect(json).to.deep.equal({});
+            })
+            .nodeify(done);
+    });
+
+    it('getComponentsJson should fallback to empty object when components.json non-existing', function (done) {
+        process.chdir('./test-tmp');
+
+        webgme.getComponentsJson()
+            .then(function (json) {
+                expect(json).to.deep.equal({});
+            })
+            .nodeify(done);
     });
 });

--- a/webgme.js
+++ b/webgme.js
@@ -209,4 +209,6 @@ exports.getGmeConfig = function () {
     return gmeConfig;
 };
 
+exports.getComponentsJson = webgmeUtils.getComponentsJson;
+
 module.exports = exports;


### PR DESCRIPTION
The deployment defaults for component settings used to be a json file under /config, now the route that returns the settings looks for the settings in the following order:
```
 * 1) config/components.<env>.js
 * 2) config/components.json
 * 3) {}
```
where `env` is the same environment variable (NODE_ENV) used when loading the gmeConfig. (Just like in the case of config it defaults to `'default'` if not set.