### PR TITLE
Closes #1337 Core traverse should not invoke visit on null nodes.

### DIFF
--- a/src/common/core/coretreeloader.js
+++ b/src/common/core/coretreeloader.js
@@ -86,18 +86,23 @@ define(['common/core/CoreAssert', 'common/core/tasync'], function (ASSERT, TASYN
                     }
 
                 },
-                nodeLoaded = function (err, node) {
-                    error = error || err;
-                    if (!err && node) {
-                        extendLoadQueue(node);
-                    }
-                    visitFn(node, visitNext);
-                },
                 visitNext = function (err) {
                     error = error || err;
                     ongoingVisits -= 1;
                     if (error && options.stopOnError) {
                         loadQueue = [];
+                    }
+                },
+                nodeLoaded = function (err, node) {
+                    error = error || err;
+                    if (!err && node) {
+                        extendLoadQueue(node);
+                    }
+
+                    if (!node) {
+                        visitNext(err);
+                    } else {
+                        visitFn(node, visitNext);
                     }
                 };
 

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -309,7 +309,7 @@ describe('Meta Rules', function () {
             })
             .then(function (result) {
                 expect(result.hasViolation).to.equal(true);
-                expect(result.message).to.contain('Fewer children than');
+                expect(result.message).to.contain('Fewer children (FCO) than');
             })
             .nodeify(done);
     });


### PR DESCRIPTION
When a base is removed the instances might still be reported as children-paths in their parent. The traverse should not return these nodes.

This PR also adds the meta name to cardinality violations.