### PR TITLE
Pre 2.11.0 release fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 
 *.log
 .idea
+.vscode
 .sass-cache
 .DS_Store
 tmp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "vsicons.presets.angular": false
-}

--- a/src/client/js/Panels/Crosscut/CrosscutPanel.js
+++ b/src/client/js/Panels/Crosscut/CrosscutPanel.js
@@ -108,7 +108,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
-    CrosscutPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+    CrosscutPanel.prototype.getValidTypesInfo = function (/*nodeId, aspect*/) {
         return {};
     };
 

--- a/src/client/js/Panels/GraphViz/GraphVizPanel.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanel.js
@@ -94,7 +94,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
-    GraphVizPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+    GraphVizPanel.prototype.getValidTypesInfo = function (/*nodeId, aspect*/) {
         return {};
     };
 

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -2114,7 +2114,7 @@ define(['js/logger',
         this._radioButtonGroupMetaRelationType.enabled(!isReadOnly);
     };
 
-    MetaEditorControl.prototype.getValidTypesInfo = function (/*nodeId*/) {
+    MetaEditorControl.prototype.getValidTypesInfo = function (/*nodeId, aspect*/) {
         var containerNode = this._client.getNode(CONSTANTS.PROJECT_ROOT_ID);
         if (containerNode) {
             return containerNode.getValidChildrenTypesDetailed(null, true);

--- a/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
@@ -105,8 +105,8 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
-    MetaEditorPanel.prototype.getValidTypesInfo = function (nodeId) {
-        return this.control.getValidTypesInfo(nodeId);
+    MetaEditorPanel.prototype.getValidTypesInfo = function (nodeId, aspect) {
+        return this.control.getValidTypesInfo(nodeId, aspect);
     };
 
     return MetaEditorPanel;

--- a/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
+++ b/src/client/js/Panels/PartBrowser/PartBrowserPanelControl.js
@@ -283,7 +283,7 @@ define(['js/logger',
             activePanel = WebGMEGlobal.PanelManager.getActivePanel();
 
             if (activePanel && typeof activePanel.getValidTypesInfo === 'function') {
-                validInfo = activePanel.getValidTypesInfo(containerNode.getId());
+                validInfo = activePanel.getValidTypesInfo(containerNode.getId(), this._aspect);
             } else {
                 // default is the containment based elements.
                 validInfo = containerNode.getValidChildrenTypesDetailed(this._aspect);

--- a/src/client/js/Panels/SetEditor/SetEditorPanel.js
+++ b/src/client/js/Panels/SetEditor/SetEditorPanel.js
@@ -106,7 +106,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         WebGMEGlobal.Toolbar.refresh();
     };
 
-    SetEditorPanel.prototype.getValidTypesInfo = function (/*nodeId*/) {
+    SetEditorPanel.prototype.getValidTypesInfo = function (/*nodeId, aspect*/) {
         return {};
     };
 

--- a/src/server/storage/storage.js
+++ b/src/server/storage/storage.js
@@ -161,10 +161,17 @@ Storage.prototype.getLatestCommitData = function (data, callback) {
         })
         .then(function (commitObject) {
             result.commitObject = commitObject;
-            return project.loadObject(commitObject.root);
+            return storageHelpers.loadObject(project, commitObject.root);
         })
         .then(function (rootObject) {
-            result.coreObjects.push(rootObject);
+            var hash;
+            if ((rootObject || {}).multipleObjects === true) {
+                for (hash in rootObject.objects) {
+                    result.coreObjects.push(rootObject.objects[hash]);
+                }
+            } else {
+                result.coreObjects.push(rootObject);
+            }
             return result;
         })
         .nodeify(callback);
@@ -452,7 +459,7 @@ Storage.prototype.loadObjects = function (data, callback) {
         .then(function (project) {
 
             function loadObject(hash) {
-                return storageHelpers.loadObject(project,hash);
+                return storageHelpers.loadObject(project, hash);
             }
 
             Q.allSettled(data.hashes.map(loadObject))

--- a/test/common/storage/storageclasses/simpleapi.spec.js
+++ b/test/common/storage/storageclasses/simpleapi.spec.js
@@ -169,8 +169,13 @@ describe('storage storageclasses simpleapi', function () {
     it('should getProjects', function (done) {
         Q.ninvoke(storage, 'getProjects', {})
             .then(function (projects) {
-                expect(projects.length).to.equal(1);
-                expect(projects[0]._id).to.equal(projectName2Id(projectName));
+                var ids = [];
+
+                expect(projects.length).to.equal(2);
+
+                ids.push(projects[0]._id);
+                ids.push(projects[1]._id);
+                expect(ids).to.have.members([projectName2Id(projectName), projectName2Id(shardedProjectName)]);
             })
             .nodeify(done);
     });


### PR DESCRIPTION
- #1332 pass current aspect in `getValidTypesInfo`
- #1333 `getLatestCommitData` and REST api `/projects/.../tree/<path>` should account for sharded overlays.
- #1341 gitignore vscode-idea settings