### PR TITLE
Sharded copy fix

### DIFF
--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -944,6 +944,7 @@ define([
             newNode.inverseOverlaysMutable = node.inverseOverlaysMutable;
 
             if (hasShardedOverlays(node)) {
+                // Copy the shards-info for nodes with sharded overlay #1343
                 newNode.overlays = JSON.parse(JSON.stringify(node.overlays));
                 newNode.overlayMutations = JSON.parse(JSON.stringify(node.overlayMutations));
                 newNode.minimalOverlayShardId = node.minimalOverlayShardId;

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -169,8 +169,8 @@ define([
         }
 
         function hasShardedOverlays(node) {
-            return (self.getProperty(node, CONSTANTS.OVERLAYS_PROPERTY) || {})[CONSTANTS.OVERLAY_SHARD_INDICATOR]
-                === true;
+            return (self.getProperty(node, CONSTANTS.OVERLAYS_PROPERTY) ||
+                {})[CONSTANTS.OVERLAY_SHARD_INDICATOR] === true;
         }
 
         // We only shard regular GME nodes, technical sub-nodes do not get sharded
@@ -942,6 +942,12 @@ define([
                 newNode.inverseOverlays = node.inverseOverlays;
             }
             newNode.inverseOverlaysMutable = node.inverseOverlaysMutable;
+
+            if (hasShardedOverlays(node)) {
+                newNode.overlays = JSON.parse(JSON.stringify(node.overlays));
+                newNode.overlayMutations = JSON.parse(JSON.stringify(node.overlayMutations));
+                newNode.minimalOverlayShardId = node.minimalOverlayShardId;
+            }
 
             var root = self.getRoot(newNode);
             root.initial[self.getPath(newNode)] = root.initial[self.getPath(node)];

--- a/test/common/core/corerel.spec.js
+++ b/test/common/core/corerel.spec.js
@@ -541,5 +541,27 @@ describe('corerel', function () {
             shardCore.persist(root);
             expect(Object.keys(root.overlays)).to.have.length(2);
         });
+
+        it('should copy the shards of a sharded node', function () {
+            var root = shardCore.createNode(),
+                sourceParent = shardCore.createNode({parent: root, relid: 'source'}),
+                targetParent,
+                children = [],
+                i;
+
+            for (i = 0; i < 8; i += 1) {
+                children.unshift(shardCore.createNode({parent: sourceParent}));
+                shardCore.setPointer(children[0], 'pA', sourceParent);
+                shardCore.setPointer(children[0], 'pB', sourceParent);
+            }
+            expect(Object.keys(sourceParent.overlays)).to.have.length(3);
+            targetParent = shardCore.copyNode(sourceParent, root);
+            expect(Object.keys(targetParent.overlays)).to.have.length(3);
+            expect(shardCore.getCollectionPaths(sourceParent, 'pA')).to.have
+                .length(shardCore.getCollectionPaths(targetParent, 'pA').length);
+            expect(shardCore.getChildrenRelids(sourceParent)).to.have
+                .members(shardCore.getChildrenRelids(targetParent));
+
+        });
     });
 });


### PR DESCRIPTION
When copying a node with overlay shards, the copy should also contain the (in memory) shards-info: `overlays`, `overlayMutations` and `minimalOverlayShardId`.