### PR TITLE
Fixes potential GUID collisions among copied nodes

### DIFF
--- a/src/common/core/guidcore.js
+++ b/src/common/core/guidcore.js
@@ -192,6 +192,7 @@ define([
         this.copyNode = function (node, parent) {
             var newNode = innerCore.copyNode(node, parent);
 
+            // Generate new guid at copy #1344
             setDataGuid(newNode, GUID());
 
             return newNode;
@@ -201,6 +202,7 @@ define([
             var newNodes = innerCore.copyNodes(nodes, parent),
                 i;
 
+            // Generate new guids at copy #1344
             for (i = 0; i < newNodes.length; i += 1) {
                 setDataGuid(newNodes[i], GUID());
             }

--- a/src/common/core/guidcore.js
+++ b/src/common/core/guidcore.js
@@ -188,6 +188,25 @@ define([
                 return CONSTANTS.NULL_GUID;
             }
         };
+
+        this.copyNode = function (node, parent) {
+            var newNode = innerCore.copyNode(node, parent);
+
+            setDataGuid(newNode, GUID());
+
+            return newNode;
+        };
+
+        this.copyNodes = function (nodes, parent) {
+            var newNodes = innerCore.copyNodes(nodes, parent),
+                i;
+
+            for (i = 0; i < newNodes.length; i += 1) {
+                setDataGuid(newNodes[i], GUID());
+            }
+
+            return newNodes;
+        };
         //</editor-fold>
     }
 

--- a/src/plugin/coreplugins/GuidCollider/GuidCollider.js
+++ b/src/plugin/coreplugins/GuidCollider/GuidCollider.js
@@ -3,8 +3,8 @@
 
 /**
  * Plugin mainly used for testing.
- * @author lattmann / https://github.com/lattmann
- * @module CorePlugins:MinimalWorkingExample
+ * @author kecso / https://github.com/kecso
+ * @module CorePlugins:GuidCollider
  */
 
 define([
@@ -80,7 +80,7 @@ define([
         Q.ninvoke(self.core, 'traverse', self.rootNode, null, visitFn)
             .then(function () {
                 if (hasCollision && currentConfiguration.checkOnly === false) {
-                    return Q.ninvoke(self, 'save', 'guid collision fix');
+                    return self.save('guid collision fix');
                 } else {
                     return {};
                 }

--- a/src/plugin/coreplugins/GuidCollider/GuidCollider.js
+++ b/src/plugin/coreplugins/GuidCollider/GuidCollider.js
@@ -1,0 +1,101 @@
+/*globals define*/
+/*jshint node:true, browser:true*/
+
+/**
+ * Plugin mainly used for testing.
+ * @author lattmann / https://github.com/lattmann
+ * @module CorePlugins:MinimalWorkingExample
+ */
+
+define([
+    'plugin/PluginConfig',
+    'plugin/PluginBase',
+    'common/util/guid',
+    'q',
+    'text!./metadata.json'
+], function (PluginConfig, PluginBase, GUID, Q, pluginMetadata) {
+    'use strict';
+
+    pluginMetadata = JSON.parse(pluginMetadata);
+
+    /**
+     * Initializes a new instance of MinimalWorkingExample.
+     * @class
+     * @augments {PluginBase}
+     * @classdesc This class represents the plugin MinimalWorkingExample.
+     * @constructor
+     */
+    function GuidCollider() {
+        // Call base class' constructor.
+        PluginBase.call(this);
+        this.pluginMetadata = pluginMetadata;
+
+        // we do not know the meta types, will be populated during run time
+        this.metaTypes = {};
+    }
+
+    GuidCollider.metadata = pluginMetadata;
+
+    // Prototypical inheritance from PluginBase.
+    GuidCollider.prototype = Object.create(PluginBase.prototype);
+    GuidCollider.prototype.constructor = GuidCollider;
+
+    /**
+     * Main function for the plugin to execute. This will perform the execution.
+     * Notes:
+     * - Always log with the provided logger.[error,warn,info,debug].
+     * - Do NOT put any user interaction logic UI, etc. inside this method.
+     * - callback always has to be called even if error happened.
+     *
+     * @param {function(Error, plugin.PluginResult)} callback - the result callback
+     */
+    GuidCollider.prototype.main = function (callback) {
+        // Use self to access core, project, result, logger etc from PluginBase.
+        // These are all instantiated at this point.
+        var self = this,
+            currentConfiguration = self.getCurrentConfig(),
+            guids = {},
+            hasCollision = false,
+            visitFn = function (node, next) {
+                var oldGuid = self.core.getGuid(node),
+                    newGuid;
+                if (guids.hasOwnProperty(oldGuid)) {
+                    hasCollision = true;
+                    if (currentConfiguration.checkOnly) {
+                        self.createMessage(node, 'guid collision with: ' + guids[oldGuid]);
+                    } else {
+                        newGuid = GUID();
+                        self.core.setGuid(node, newGuid);
+                        self.createMessage(node, 'guid changed [' + oldGuid + ']->[' + newGuid + ']');
+                        guids[newGuid] = self.core.getPath(node);
+                    }
+                } else {
+                    guids[oldGuid] = self.core.getPath(node);
+                }
+                next(null);
+            };
+
+        self.updateMETA(self.metaTypes);
+
+        Q.ninvoke(self.core, 'traverse', self.rootNode, null, visitFn)
+            .then(function () {
+                if (hasCollision && currentConfiguration.checkOnly === false) {
+                    return Q.ninvoke(self, 'save', 'guid collision fix');
+                } else {
+                    return {};
+                }
+            })
+            .then(function (status) {
+                self.result.setSuccess(true);
+            })
+            .catch(function (err) {
+                self.result.setError('Failed execution: ', err.message);
+                self.result.setSuccess(false);
+            })
+            .finally(function () {
+                callback(null, self.result);
+            });
+    };
+
+    return GuidCollider;
+});

--- a/src/plugin/coreplugins/GuidCollider/metadata.json
+++ b/src/plugin/coreplugins/GuidCollider/metadata.json
@@ -1,0 +1,23 @@
+{
+  "id": "GuidCollider",
+  "name": "Guid Collision Check and Resolver",
+  "version": "1.0.0",
+  "description": "Plugin for checking the health of a given project regarding GUIDs.",
+  "icon": {
+    "src": "",
+    "class": "glyphicon glyphicon-search"
+  },
+  "disableServerSideExecution": false,
+  "disableBrowserSideExecution": true,
+  "writeAccessRequired": true,
+  "configStructure": [
+    {
+      "name": "checkOnly",
+      "displayName": "Checking only",
+      "description": "If set, there will be no corrective action taken.",
+      "value": false,
+      "valueType": "boolean",
+      "readOnly": false
+    }
+  ]
+}

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -36,7 +36,8 @@ describe('CorePlugins', function () {
             'ConstraintEvaluator',
             'FastForward',
             'RestRouterGenerator',
-            'CustomPluginConfig'
+            'CustomPluginConfig',
+            'GuidCollider'
         ],
 
         pluginsShouldFail = [
@@ -55,7 +56,7 @@ describe('CorePlugins', function () {
         gmeAuth,
         safeStorage,
 
-    //guestAccount = testFixture.getGmeConfig().authentication.guestAccount,
+        //guestAccount = testFixture.getGmeConfig().authentication.guestAccount,
         serverBaseUrl,
         server,
 


### PR DESCRIPTION
As a result of having shorter relids, the possible collision of node GUIDs (that only differ in their places in the containment tree, but copies of each other) increased.
Because in a majority of copy use-cases, the node is modified as well (for example getting a new position) the structural reuse would not work anyhow, so we generate a new GUID for the copy to avoid collisions.

As it is still unlikely that existing projects have colliding GUIDs (it would require a great amount of copies on from and to specific levels of the containment), we do not require checks for existing projects, but we provide a plugin, `GuidCollider`, that can find and, if needed, eliminate collisions. 