### PR TITLE
Third option conflict

### DIFF
--- a/src/client/js/Dialogs/Merge/MergeDialog.js
+++ b/src/client/js/Dialogs/Merge/MergeDialog.js
@@ -128,6 +128,7 @@ define([
                 '</div>'),
             conflictItemE,
             pathObject,
+            path,
             text,
             value,
             link,
@@ -174,13 +175,14 @@ define([
                 conflictItemE = conflictItemTemplate.clone();
 
                 pathObject = DIFF.pathToObject(conflictItem.theirs.path);
+                path = conflictItem.originalNodePath || pathObject.node;
                 conflictItemE.find('.path').text('"' + pathObject.node + '" [' +
                     pathObject.full.substr(pathObject.node.length) + ']');
 
                 link = '?project=' + encodeURIComponent(self._client.getActiveProjectId()) +
                     '&commit=' + encodeURIComponent(mergeResult.theirCommitHash) +
-                    '&node=' + encodeURIComponent(getParentPath(pathObject.node)) +
-                    '&selection=' + encodeURIComponent(pathObject.node);
+                    '&node=' + encodeURIComponent(getParentPath(path)) +
+                    '&selection=' + encodeURIComponent(path);
 
                 value = $('<div>' +
                     '<a class="glyphicon glyphicon-link" href="' + link +
@@ -199,10 +201,11 @@ define([
                 }
 
                 pathObject = DIFF.pathToObject(conflictItem.mine.path);
+                path = conflictItem.originalNodePath || pathObject.node;
                 link = '?project=' + encodeURIComponent(self._client.getActiveProjectId()) +
                     '&commit=' + encodeURIComponent(mergeResult.myCommitHash) +
-                    '&node=' + encodeURIComponent(getParentPath(pathObject.node)) +
-                    '&selection=' + encodeURIComponent(pathObject.node);
+                    '&node=' + encodeURIComponent(getParentPath(path)) +
+                    '&selection=' + encodeURIComponent(path);
                 value = $('<div>' +
                     '<a class="glyphicon glyphicon-link" href="' + link + '"  target="_blank" tooltip="Open"></a>' +
                     '<span><code style="word-wrap: break-word; white-space: normal">' + text + '</code></span>' +

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -316,6 +316,23 @@ define(['common/util/canon',
             return filteredKeys;
         }
 
+        function arrayDiff(source, target) {
+            var i,
+                diff = {};
+            for (i = 0; i < source.length; i += 1) {
+                if (target.indexOf(source[i]) === -1) {
+                    diff[source[i]] = CONSTANTS.TO_DELETE_STRING;
+                }
+            }
+
+            for (i = 0; i < target.length; i += 1) {
+                if (source.indexOf(target[i])) {
+                    diff[target[i]] = true;
+                }
+            }
+            return diff;
+        }
+
         function diffObjects(source, target) {
             var diff = {},
                 sKeys = Object.keys(source),
@@ -330,10 +347,14 @@ define(['common/util/canon',
                 if (sKeys.indexOf(tKeys[i]) === -1) {
                     diff[tKeys[i]] = target[tKeys[i]];
                 } else {
-                    if (typeof target[tKeys[i]] === typeof source[tKeys[i]] &&
-                        typeof target[tKeys[i]] === 'object' &&
-                        (target[tKeys[i]] !== null && source[tKeys[i]] !== null)) {
-                        tDiff = diffObjects(source[tKeys[i]], target[tKeys[i]]);
+                    if (typeof target[tKeys[i]] === typeof source[tKeys[i]]) {
+                        tDiff = {};
+                        if (source[tKeys[i]] instanceof Array && target[tKeys[i]] instanceof Array) {
+                            tDiff = arrayDiff(source[tKeys[i]], target[tKeys[i]]);
+                        } else if (typeof target[tKeys[i]] === 'object' &&
+                            target[tKeys[i]] !== null && source[tKeys[i]] !== null) {
+                            tDiff = diffObjects(source[tKeys[i]], target[tKeys[i]]);
+                        }
                         if (Object.keys(tDiff).length > 0) {
                             diff[tKeys[i]] = tDiff;
                         }

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -532,7 +532,7 @@ define(['common/util/canon',
             return TASYNC.call(function () {
                 return TASYNC.call(function (child, sChild) {
                     if (!child) {
-                        child === sChild;
+                        child = sChild;
                     }
                     diff.guid = self.getGuid(child);
                     diff.hash = self.getHash(child);
@@ -905,7 +905,7 @@ define(['common/util/canon',
             if (REGEXP.GUID.test(guid) !== true) {
                 return null;
             }
-            return _getPathOfGuidR(diff, guid, '')
+            return _getPathOfGuidR(diff, guid, '');
         }
 
         function getRelidFromPath(path) {

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -2600,8 +2600,14 @@ define(['common/util/canon',
             for (i = 0; i < conflictObject.items.length; i++) {
                 if (conflictObject.items[i].selected !== 'mine') {
                     removePathFromDiff(conflictObject.merge, conflictObject.items[i].mine.path);
-                    insertAtPath(conflictObject.merge,
-                        conflictObject.items[i].theirs.path, conflictObject.items[i].theirs.value);
+                    if (conflictObject.items[i].selected === 'theirs') {
+                        insertAtPath(conflictObject.merge,
+                            conflictObject.items[i].theirs.path, conflictObject.items[i].theirs.value);
+                    } else {
+                        insertAtPath(conflictObject.merge,
+                            conflictObject.items[i].other.path, conflictObject.items[i].other.value);
+                    }
+
                 }
             }
 

--- a/src/common/util/diff.js
+++ b/src/common/util/diff.js
@@ -20,11 +20,27 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
         childrenListChanged: true,
         oGuids: true,
         ooGuids: true,
+        oBaseGuids: true,
+        ooBaseGuids: true,
         min: true,
         max: true
     };
 
-    function diffPathStringToObject(path) {
+    /**
+     *
+     * @param {string} path - arbitrary string where the legs of the path are separated with '/' character.
+     * @return {object} The function returns an object with processed information about the path.
+     *
+     * @example
+     * {
+     *  full: "/a/b/set/mySet//a/c//reg/position",
+     *  node: "/a/b",
+     *  embededdNode: "/a/c",
+     *  pathArray:["a","b","set","mySet","/a/c","reg","position"]
+     *  }
+     *
+     */
+    function pathToObject(path) {
         var object = {
                 full: path,
                 node: null,
@@ -111,9 +127,17 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
         return undefined;
     }
 
-    // this function is intended to get simple values of the base state of the project knowing the place of conflict
+    /**
+     *
+     * @param {object} core - the core object that allows access to the Core API
+     * @param (module:Core~Node) node - the node whose value we are interested in
+     * @param {string} subNodePath - a string that has the path structure and represents the sub-node location
+     * of the value we are interested in.
+     * @returns {undefined|*} - if the value is undefined, that means there is no such value, otherwise the value will
+     * be returned back.
+     */
     function getValueFromNode(core, node, subNodePath) {
-        var pathObject = diffPathStringToObject(subNodePath);
+        var pathObject = pathToObject(subNodePath);
 
         ASSERT(pathObject.node === '');
         ASSERT(FORBIDDEN_WORDS[pathObject.pathArray[0]] === true);
@@ -136,6 +160,12 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
         }
     }
 
+    /**
+     *
+     * @param {object} completeDiff - a diff object, that we would like to process and gather information from.
+     * @returns {string[]} An array of string of the paths of the affected nodes are returned. No partial update nodes
+     * are returned as we cannot gather that intel completely.
+     */
     function getChangedNodePaths(completeDiff) {
         var changedNodes = {},
             recGetNodePath = function (path, diff) {
@@ -155,7 +185,7 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
     }
 
     return {
-        pathToObject: diffPathStringToObject,
+        pathToObject: pathToObject,
         getValueFromNode: getValueFromNode,
         getChangedNodePaths: getChangedNodePaths,
         FORBIDDEN_WORDS: FORBIDDEN_WORDS

--- a/src/common/util/diff.js
+++ b/src/common/util/diff.js
@@ -1,0 +1,117 @@
+/*globals define*/
+/*jshint node: true, browser: true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CONSTANTS) {
+    'use strict';
+
+    var FORBIDDEN_WORDS = {
+        guid: true,
+        hash: true,
+        attr: true,
+        reg: true,
+        pointer: true,
+        set: true,
+        meta: true,
+        removed: true,
+        movedFrom: true,
+        childrenListChanged: true,
+        oGuids: true,
+        ooGuids: true,
+        min: true,
+        max: true
+    };
+
+    function diffPathStringToObject(path) {
+        var object = {
+                full: path,
+                node: null,
+                embeddedNode: null,
+                pathArray: []
+            },
+            firstRun = path.split(CONSTANTS.PATH_SEP + CONSTANTS.PATH_SEP),
+            i;
+
+        ASSERT(firstRun.length === 1 || firstRun.length === 3);
+
+        if (firstRun.length === 3) {
+            object.embeddedNode = firstRun[1].length === 0 ? '' : CONSTANTS.PATH_SEP + firstRun[1];
+            object.pathArray = firstRun[2].split(CONSTANTS.PATH_SEP);
+            object.pathArray.unshift(object.embeddedNode);
+            object.pathArray = firstRun[0].split(CONSTANTS.PATH_SEP).concat(object.pathArray);
+        } else {
+            object.pathArray = path.split(CONSTANTS.PATH_SEP);
+        }
+        object.pathArray.shift();
+
+        object.node = '';
+        for (i = 0; i < object.pathArray.length; i += 1) {
+            if (FORBIDDEN_WORDS[object.pathArray[i]] !== true && object.pathArray[i].length > 0) {
+                object.node += CONSTANTS.PATH_SEP + object.pathArray[i];
+            } else {
+                break;
+            }
+        }
+
+        return object;
+    }
+
+    function getSetValueFromNode(core, node, memberPath, pathArray) {
+        var setName = pathArray[0];
+
+        console.log(pathArray, memberPath);
+        if (typeof memberPath === 'string') {
+            switch (pathArray[2]) {
+                case 'attr':
+                    return core.getMemberOwnAttribute(node, setName, memberPath, pathArray[3]);
+                case 'reg':
+                    return core.getMemberOwnRegistry(node, setName, memberPath, pathArray[3]);
+            }
+        } else {
+            switch (pathArray[1]) {
+                case 'attr':
+                    return core.getOwnSetAttribute(node, setName, pathArray[2]);
+                case 'reg':
+                    return core.getOwnSetRegistry(node, setName, pathArray[2]);
+            }
+        }
+
+        return undefined;
+    }
+
+    function getMetaValueFromNode(core, node, pathArray) {
+        return undefined;
+    }
+
+    function getValueFromNode(core, node, subNodePath) {
+        var pathObject = diffPathStringToObject(subNodePath);
+
+        ASSERT(pathObject.node === '');
+        ASSERT(FORBIDDEN_WORDS[pathObject.pathArray[0]] === true);
+
+        switch (pathObject.pathArray[0]) {
+            case 'guid':
+                return core.getGuid(node);
+            case 'attr':
+                return core.getOwnAttribute(node, pathObject.pathArray[1]);
+            case 'reg':
+                return core.getOwnRegistry(node, pathObject.pathArray[1]);
+            case 'pointer':
+                return core.getOwnPointerPath(node, pathObject.pathArray[1]);
+            case 'set':
+                return getSetValueFromNode(core, node, pathObject.embeddedNode, pathObject.pathArray.slice(1));
+            case 'meta':
+                return getMetaValueFromNode(core, node, pathObject.pathArray.slice(1));
+            default:
+                return undefined;
+        }
+    }
+
+    return {
+        pathToObject: diffPathStringToObject,
+        getValueFromNode: getValueFromNode,
+        FORBIDDEN_WORDS: FORBIDDEN_WORDS
+    };
+});

--- a/src/common/util/diff.js
+++ b/src/common/util/diff.js
@@ -23,7 +23,8 @@ define(['common/core/CoreAssert', 'common/core/constants'], function (ASSERT, CO
         oBaseGuids: true,
         ooBaseGuids: true,
         min: true,
-        max: true
+        max: true,
+        collidingRelid: true
     };
 
     /**

--- a/test/common/core/corediff.merge.spec.js
+++ b/test/common/core/corediff.merge.spec.js
@@ -7,7 +7,6 @@
 
 var testFixture = require('../../_globals.js');
 
-
 describe('corediff-merge', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
@@ -40,7 +39,6 @@ describe('corediff-merge', function () {
                 .nodeify(next);
         };
 
-
     before(function (done) {
         testFixture.clearDBAndGetGMEAuth(gmeConfig/*, projectName*/)
             .then(function (gmeAuth_) {
@@ -55,12 +53,11 @@ describe('corediff-merge', function () {
 
     after(function (done) {
         Q.allSettled([
-                gmeAuth.unload(),
-                storage.closeDatabase()
-            ])
+            gmeAuth.unload(),
+            storage.closeDatabase()
+        ])
             .nodeify(done);
     });
-
 
     describe('basic', function () {
         var projectName = 'corediffMergeTesting',
@@ -106,10 +103,10 @@ describe('corediff-merge', function () {
 
             it('initial value check', function (done) {
                 Q.allDone([
-                        core.loadByPath(rootNode, '/579542227/651215756'),
-                        core.loadByPath(rootNode, '/579542227/2088994530')
+                    core.loadByPath(rootNode, '/579542227/651215756'),
+                    core.loadByPath(rootNode, '/579542227/2088994530')
 
-                    ])
+                ])
                     .then(function (nodes) {
                         core.getAttribute(nodes[0], 'priority').should.be.equal(100);
                         core.getAttribute(nodes[1], 'priority').should.be.equal(100);
@@ -477,9 +474,9 @@ describe('corediff-merge', function () {
         describe('registry', function () {
             it('initial value check', function (done) {
                 Q.allDone([
-                        core.loadByPath(rootNode, '/579542227/651215756'),
-                        core.loadByPath(rootNode, '/579542227/2088994530')
-                    ])
+                    core.loadByPath(rootNode, '/579542227/651215756'),
+                    core.loadByPath(rootNode, '/579542227/2088994530')
+                ])
                     .then(function (nodes) {
                         expect(core.getRegistry(nodes[0], 'position')).to.eql({x: 69, y: 276});
                         expect(core.getRegistry(nodes[1], 'position')).to.eql({x: 243, y: 184});
@@ -944,12 +941,12 @@ describe('corediff-merge', function () {
 
         before(function (done) {
             testFixture.importProject(storage, {
-                    projectSeed: 'test/common/core/corediff/base003.webgmex',
-                    projectName: projectName,
-                    branchName: 'master',
-                    gmeConfig: gmeConfig,
-                    logger: logger
-                })
+                projectSeed: 'test/common/core/corediff/base003.webgmex',
+                projectName: projectName,
+                branchName: 'master',
+                gmeConfig: gmeConfig,
+                logger: logger
+            })
                 .then(function (result) {
                     project = result.project;
                     core = result.core;
@@ -1148,8 +1145,8 @@ describe('corediff-merge', function () {
 
                     change.diff = change.conflict.merge;
 
-                    expect(Object.keys(change.diff.K)).to.have.length(5);
-                    expect(change.diff.K).to.include.keys('oGuids', 'guid', 'S', 'childrenListChanged');
+                    expect(Object.keys(change.diff.K)).to.have.length(6);
+                    expect(change.diff.K).to.include.keys('oGuids', 'guid', 'S', 'childrenListChanged', 'oBaseGuids');
 
                     applyParams.changeObject = change;
                     return Q.nfcall(applyChange, applyParams);
@@ -1345,8 +1342,8 @@ describe('corediff-merge', function () {
                     change.conflict = core.tryToConcatChanges(changeA.computedDiff, changeB.computedDiff);
                     expect(change.conflict.items).to.have.length(2);
 
-                    expect(change.conflict.items[0].theirs.path).to.equal('/K/S/removed');
-                    expect(change.conflict.items[1].theirs.path).to.equal('/K/S/removed');
+                    expect(change.conflict.items[0].theirs.path).to.equal('/Y/S/removed');
+                    expect(change.conflict.items[1].theirs.path).to.equal('/Y/S/removed');
                     change.diff = core.applyResolution(change.conflict);
 
                     applyParams.changeObject = change;

--- a/test/common/core/corediff.spec.js
+++ b/test/common/core/corediff.spec.js
@@ -79,7 +79,19 @@ describe('core diff', function () {
             var patch = {
                 1303043463: {
                     guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
-                    removed: true
+                    removed: true,
+                    oBaseGuids: {
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                    },
+                    oGuids: {
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
+                        'd926b4e8-676d-709b-e10e-a6fe730e71f5': true
+                    }
                 },
                 childrenListChanged: true,
                 guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
@@ -1630,6 +1642,71 @@ describe('core diff', function () {
             expect(result1.items).to.have.length(result2.items.length);
             expect(result1.items).to.have.length(0);
             expect(result1.merge).to.eql(result2.merge);
+        });
+
+        it('should present original colliding path when there were collision resolution', function () {
+            var diff1 = {
+                    childrenListChanged: true,
+                    D: {
+                        guid: 'ef812549-4970-2312-5e3a-7eb9b96b2ae7',
+                        removed: false,
+                        hash: '#e341ba304b75ad76642dcf11dd920ca4a403be60',
+                        pointer: {
+                            base: '/2'
+                        },
+                        oGuids: {
+                            'ef812549-4970-2312-5e3a-7eb9b96b2ae7': true,
+                            '03d36072-9e09-7866-cb4e-d0a36ff825f6': true,
+                            'cd891e7b-1111-e929-f6cd-9faf4f1fc045': true
+                        }
+                    },
+                    1: {
+                        guid: 'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045',
+                        removed: true,
+                        oGuids: {
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                        }
+                    },
+                    guid: '03d36072-9e09-7866-cb4e-d0a36ff825f6',
+                    oGuids: {
+                        '03d36072-9e09-7866-cb4e-d0a36ff825f6': true
+                    }
+                },
+                diff2 = {
+                    childrenListChanged: true,
+                    D: {
+                        guid: 'ef812549-4970-1111-5e3a-7eb9b96b2ae7',
+                        removed: false,
+                        movedFrom: '/E/F',
+                        pointer: {
+                            base: '/1'
+                        },
+                        oGuids: {
+                            'ef812549-4970-1111-5e3a-7eb9b96b2ae7': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                        },
+                        ooGuids: {
+                            'ef812549-4970-1111-5e3a-7eb9b96b2ae7': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                        }
+                    },
+                    E: {
+                        childrenListChanged: true,
+                        guid: 'ef812549-4970-1111-1111-7eb9b96b2ae7',
+                        oGuids: {
+                            'ef812549-4970-1111-1111-7eb9b96b2ae7': true
+                        }
+                    },
+                    guid: '03d36072-9e09-7866-cb4e-d0a36ff825f6',
+                    oGuids: {
+                        '03d36072-9e09-7866-cb4e-d0a36ff825f6': true
+                    }
+                },
+                result1 = core.tryToConcatChanges(diff1, diff2),
+                result2 = core.tryToConcatChanges(diff2, diff1);
+
+            expect(result1.items[0].theirs.originalNodePath).to.eql('/D');
+            expect(result2.items[0].mine.originalNodePath).to.eql('/D');
         });
     });
 

--- a/test/common/core/corediff.spec.js
+++ b/test/common/core/corediff.spec.js
@@ -77,63 +77,13 @@ describe('core diff', function () {
 
         it('should generate diff if an object is deleted', function (done) {
             var patch = {
-                175547009: {
-                    471466181: {
-                        guid: 'be36b1a1-8d82-8aba-9eda-03d655a8bf3e',
-                        oGuids: {
-                            'be36b1a1-8d82-8aba-9eda-03d655a8bf3e': true,
-                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                        }
-                    },
-                    871430202: {
-                        guid: '18eb3c1d-c951-b757-c8c4-0ea8736c2470',
-                        oGuids: {
-                            '18eb3c1d-c951-b757-c8c4-0ea8736c2470': true,
-                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                        }
-                    },
-                    1104061497: {
-                        guid: 'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb',
-                        oGuids: {
-                            'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true,
-                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                        }
-                    },
-                    1817665259: {
-                        guid: '5f73946c-68aa-9de1-7979-736d884171af',
-                        oGuids: {
-                            '5f73946c-68aa-9de1-7979-736d884171af': true,
-                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                        }
-                    },
-                    guid: 'd926b4e8-676d-709b-e10e-a6fe730e71f5',
-                    oGuids: {
-                        'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                        '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                    }
-                },
                 1303043463: {
                     guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
-                    removed: true,
-                    oGuids: {
-                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
-                        '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
-                        '5f73946c-68aa-9de1-7979-736d884171af': true,
-                        'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
-                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
-                    }
+                    removed: true
                 },
                 childrenListChanged: true,
                 guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
+                oBaseGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true},
                 oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
             };
 
@@ -231,6 +181,29 @@ describe('core diff', function () {
             });
         });
 
+        it('should generate the correct diff if the base of a node is changed', function (done) {
+            var node,
+                base;
+
+            Q.ninvoke(core, 'loadByPath', rootNode, '/1303043463/902088723')
+                .then(function (node_) {
+                    node = node_;
+                    return Q.ninvoke(core, 'loadByPath', rootNode, '/175547009/1104061497');
+                })
+                .then(function (base_) {
+                    base = base_;
+                    core.setBase(node, base);
+
+                    core.persist(rootNode);
+
+                    return Q.ninvoke(core, 'generateTreeDiff', originalRootNode, rootNode);
+                })
+                .then(function (diff) {
+                    expect(diff['1303043463']['902088723'].pointer.base).to.eql('/175547009/1104061497');
+                })
+                .nodeify(done);
+        });
+
         //TODO check if the light function can be removed as currently it has no real users
         it.skip('should generate light tree diff', function (done) {
             core.generateLightTreeDiff(originalRootNode, originalRootNode, function (err, diff) {
@@ -264,6 +237,11 @@ describe('core diff', function () {
                             'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
                             'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
                             'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
+                        },
+                        oBaseGuids: {
+                            '45657d4d-f82d-13ce-1acb-0aadebb5c8b5': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
+                            'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
                         }
                     },
                     guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
@@ -273,10 +251,16 @@ describe('core diff', function () {
                         '5f73946c-68aa-9de1-7979-736d884171af': true,
                         'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
                         'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                    },
+                    oBaseGuids: {
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
                     }
                 },
                 guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
-                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true},
+                oBaseGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
             };
 
             core.applyTreeDiff(rootNode, patch, function (err) {
@@ -326,6 +310,11 @@ describe('core diff', function () {
                             'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
                             'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
                             'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
+                        },
+                        oBaseGuids: {
+                            '45657d4d-f82d-13ce-1acb-0aadebb5c8b5': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true,
+                            'f05865fa-6f8b-0bc8-dea0-6bfdd1f552fb': true
                         }
                     },
                     guid: 'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42',
@@ -335,10 +324,16 @@ describe('core diff', function () {
                         '5f73946c-68aa-9de1-7979-736d884171af': true,
                         'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
                         'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                    },
+                    oBaseGuids: {
+                        '5f73946c-68aa-9de1-7979-736d884171af': true,
+                        'ae1b4f8e-32ea-f26f-93b3-ab9c8daa8a42': true,
+                        'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
                     }
                 },
                 guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
-                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+                oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true},
+                oBaseGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
             };
 
             core.applyTreeDiff(rootNode, patch, function (err) {

--- a/test/common/core/corediff.spec.js
+++ b/test/common/core/corediff.spec.js
@@ -2045,6 +2045,65 @@ describe('core diff', function () {
             expect(resultPatch['1303043463']['2119137141'].set.setPtr.attr.one).to.equal('four');
             expect(resultPatch['1303043463']['2119137141'].set.setPtr.reg.three).to.equal('*to*delete*');
         });
+
+        it('should combine and resolve: rename and move + rename', function () {
+            var resultPatch,
+                resultConflict,
+                diff1 = {
+                    175547009: {
+                        471466181: {
+                            attr: {name: 'one'},
+                            guid: 'be36b1a1-8d82-8aba-9eda-03d655a8bf3e',
+                            oGuids: {
+                                'be36b1a1-8d82-8aba-9eda-03d655a8bf3e': true,
+                                'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                                '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                                'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                            }
+                        },
+                        guid: 'd926b4e8-676d-709b-e10e-a6fe730e71f5',
+                        oGuids: {
+                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                        }
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
+                    oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+                },
+                diff2 = {
+                    175547009: {
+                        471466181: {
+                            attr: {name: 'two'},
+                            guid: 'be36b1a1-8d82-8aba-9eda-03d655a8bf3e',
+                            oGuids: {
+                                'be36b1a1-8d82-8aba-9eda-03d655a8bf3e': true,
+                                'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                                '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                                'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                            }
+                        },
+                        guid: 'd926b4e8-676d-709b-e10e-a6fe730e71f5',
+                        oGuids: {
+                            'd926b4e8-676d-709b-e10e-a6fe730e71f5': true,
+                            '86236510-f1c7-694f-1c76-9bad3a2aa4e0': true,
+                            'cd891e7b-e2ea-e929-f6cd-9faf4f1fc045': true
+                        }
+                    },
+                    guid: '86236510-f1c7-694f-1c76-9bad3a2aa4e0',
+                    oGuids: {'86236510-f1c7-694f-1c76-9bad3a2aa4e0': true}
+                };
+
+            resultConflict = core.tryToConcatChanges(diff1, diff2);
+            expect(resultConflict.items).to.have.length(1);
+            resultConflict.items[0].other = JSON.parse(JSON.stringify(resultConflict.items[0].theirs));
+            resultConflict.items[0].other.value = 'three';
+
+            resultConflict.items[0].selected = 'other';
+            resultPatch = core.applyResolution(resultConflict);
+
+            expect(resultPatch['175547009']['471466181'].attr.name).to.eql('three');
+        });
     });
 
     describe('patch', function () {

--- a/test/common/util/diff.spec.js
+++ b/test/common/util/diff.spec.js
@@ -61,10 +61,11 @@ describe('DIFF', function () {
             childrenListChanged: true,
             oGuids: true,
             ooGuids: true,
-            oBaseGuids:true,
-            ooBaseGuids:true,
+            oBaseGuids: true,
+            ooBaseGuids: true,
             min: true,
-            max: true
+            max: true,
+            collidingRelid: true
         });
     });
 

--- a/test/common/util/diff.spec.js
+++ b/test/common/util/diff.spec.js
@@ -1,0 +1,229 @@
+/*jshint node:true, mocha:true, expr:true*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+var testFixture = require('../../_globals.js');
+
+describe('DIFF', function () {
+    'use strict';
+    var DIFF = testFixture.requirejs('common/util/diff'),
+        Q = testFixture.Q,
+        gmeConfig = testFixture.getGmeConfig(),
+        logger = testFixture.logger.fork('diff.spec'),
+        projectName = 'DIFF_testing',
+        expect = testFixture.expect,
+        gmeAuth,
+        storage,
+        project,
+        Core = testFixture.requirejs('common/core/core'),
+        core;
+
+    before(function (done) {
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                return storage.createProject({
+                    projectName: projectName,
+                    username: gmeConfig.authentication.guestAccount
+                });
+            })
+            .then(function (project_) {
+                project = project_;
+                core = new Core(project, {globConf: gmeConfig, logger: logger});
+            })
+            .nodeify(done);
+    });
+
+    after(function (done) {
+        Q.allDone([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ]).nodeify(done);
+    });
+
+    it('should have the correct forbidden words list', function () {
+        expect(DIFF.FORBIDDEN_WORDS).to.eql({
+            guid: true,
+            hash: true,
+            attr: true,
+            reg: true,
+            pointer: true,
+            set: true,
+            meta: true,
+            removed: true,
+            movedFrom: true,
+            childrenListChanged: true,
+            oGuids: true,
+            ooGuids: true,
+            min: true,
+            max: true
+        });
+    });
+
+    it('should reply with the proper attribute value', function () {
+        var node = core.createNode();
+
+        core.setAttribute(node, 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/attr/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/attr/unknown')).to.eql(undefined);
+    });
+
+    it('should reply with the proper registry value', function () {
+        var node = core.createNode();
+
+        core.setRegistry(node, 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/reg/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/reg/unknown')).to.eql(undefined);
+    });
+
+    it('should reply with the proper pointer value', function () {
+        var node = core.createNode();
+
+        core.setPointer(node, 'null', null);
+        core.setPointer(node, 'self', node);
+
+        expect(DIFF.getValueFromNode(core, node, '/pointer/null')).to.eql(null);
+        expect(DIFF.getValueFromNode(core, node, '/pointer/self')).to.eql('');
+        expect(DIFF.getValueFromNode(core, node, '/pointer/unknown')).to.eql(undefined);
+    });
+
+    it('should reply with the proper guid', function () {
+        var node = core.createNode({guid: '233a98c5-89b7-d489-7f9a-945dda808522'});
+
+        expect(DIFF.getValueFromNode(core, node, '/guid')).to.eql('233a98c5-89b7-d489-7f9a-945dda808522');
+    });
+
+    it('should reply with undefined by default', function () {
+        expect(DIFF.getValueFromNode(core, null, '/removed')).to.eql(undefined);
+    });
+
+    it('should throw an error for invalid subNodePaths', function (done) {
+        try {
+            DIFF.getValueFromNode(core, null, '/whatever');
+            done(new Error('should throw CoreInternalError'));
+        } catch (e) {
+            expect(e.name).to.eql('CoreInternalError');
+            done();
+        }
+    });
+
+    it('should get correct set attribute value', function () {
+        var node = core.createNode();
+
+        core.createSet(node, 'set');
+        core.setSetAttribute(node, 'set', 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/set/set/attr/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/set/set/attr/unknown')).to.eql(undefined);
+    });
+
+    it('should get correct set registry value', function () {
+        var node = core.createNode();
+
+        core.createSet(node, 'set');
+        core.setSetRegistry(node, 'set', 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/set/set/reg/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/set/set/reg/unknown')).to.eql(undefined);
+    });
+
+    it('should get correct set-member attribute value', function () {
+        var node = core.createNode();
+
+        core.createSet(node, 'set');
+        core.addMember(node, 'set', node);
+        core.setMemberAttribute(node, 'set', '', 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/set/set////attr/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/set/set////attr/unknown')).to.eql(undefined);
+    });
+
+    it('should get correct set-member registry value', function () {
+        var node = core.createNode();
+
+        core.createSet(node, 'set');
+        core.addMember(node, 'set', node);
+        core.setMemberRegistry(node, 'set', '', 'something', 'one');
+
+        expect(DIFF.getValueFromNode(core, node, '/set/set////reg/something')).to.eql('one');
+        expect(DIFF.getValueFromNode(core, node, '/set/set////reg/unknown')).to.eql(undefined);
+    });
+
+    it('should get correct meta children values', function () {
+        var node = core.createNode();
+        core.setChildrenMetaLimits(node, 10, 20);
+        core.setChildMeta(node, node, 5, 6);
+
+        expect(DIFF.getValueFromNode(core, node, '/meta/children/min')).to.eql(10);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children/max')).to.eql(20);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children/unknown')).to.eql(undefined);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children////min')).to.eql(5);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children////max')).to.eql(6);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children////unknown')).to.eql(undefined);
+        expect(DIFF.getValueFromNode(core, node, '/meta/children//unknown/path//min')).to.eql(undefined);
+    });
+
+    it('should get correct meta pointer values', function () {
+        var node = core.createNode();
+        core.setPointerMetaLimits(node, 'ptr', 10, 20);
+        core.setPointerMetaTarget(node, 'ptr', node, 5, 6);
+
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr/min')).to.eql(10);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr/max')).to.eql(20);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr/unknown')).to.eql(undefined);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr////min')).to.eql(5);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr////max')).to.eql(6);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr////unknown')).to.eql(undefined);
+        expect(DIFF.getValueFromNode(core, node, '/meta/pointers/ptr//unknown/path//min')).to.eql(undefined);
+    });
+
+    it('should get correct meta attribute values', function () {
+        var node = core.createNode();
+        core.setAttributeMeta(node, 'something', {type: 'string', enum: ['one', 'two', 'three']});
+
+        expect(DIFF.getValueFromNode(core, node, '/meta/attributes/something/type')).to.eql('string');
+        expect(DIFF.getValueFromNode(core, node, '/meta/attributes/something/enum'))
+            .to.have.members(['one', 'two', 'three']);
+        expect(DIFF.getValueFromNode(core, node, '/meta/attributes/unknown/type')).to.eql(undefined);
+    });
+
+    it('should get correct meta constraint values', function () {
+        var node = core.createNode();
+        core.setConstraint(node, 'c', {priority: 'p', script: 's', info: 'i'});
+
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c'))
+            .to.eql({priority: 'p', script: 's', info: 'i'});
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c/priority')).to.eql('p');
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c/script')).to.eql('s');
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c/info')).to.eql('i');
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c/unknown')).to.eql(undefined);
+        expect(DIFF.getValueFromNode(core, node, '/meta/constraints/unknown')).to.eql(null);
+    });
+
+    it('should get the correct constraint value', function (done) {
+        var source = core.createNode(),
+            child = core.createNode({parent: source}),
+            target = core.createNode({guid: core.getGuid(source)});
+
+        // core.setConstraint(source, 'c', {script: 'a', priority: 'b', info: 'c'});
+        // core.setConstraint(target, 'c', {script: 'a', priority: 'b', info: 'd'});
+        // core.setAspectMetaTarget(source, 'a', source);
+        core.setAspectMetaTarget(source, 'a', child);
+        core.setAspectMetaTarget(target, 'a', target);
+        console.log(JSON.stringify(core.getOwnJsonMeta(source)));
+        core.generateTreeDiff(source, target, function (err, diff) {
+            console.log(JSON.stringify(diff, null, 2));
+            done();
+        });
+    });
+
+});
+

--- a/test/common/util/diff.spec.js
+++ b/test/common/util/diff.spec.js
@@ -61,6 +61,8 @@ describe('DIFF', function () {
             childrenListChanged: true,
             oGuids: true,
             ooGuids: true,
+            oBaseGuids:true,
+            ooBaseGuids:true,
             min: true,
             max: true
         });
@@ -207,23 +209,5 @@ describe('DIFF', function () {
         expect(DIFF.getValueFromNode(core, node, '/meta/constraints/c/unknown')).to.eql(undefined);
         expect(DIFF.getValueFromNode(core, node, '/meta/constraints/unknown')).to.eql(null);
     });
-
-    it('should get the correct constraint value', function (done) {
-        var source = core.createNode(),
-            child = core.createNode({parent: source}),
-            target = core.createNode({guid: core.getGuid(source)});
-
-        // core.setConstraint(source, 'c', {script: 'a', priority: 'b', info: 'c'});
-        // core.setConstraint(target, 'c', {script: 'a', priority: 'b', info: 'd'});
-        // core.setAspectMetaTarget(source, 'a', source);
-        core.setAspectMetaTarget(source, 'a', child);
-        core.setAspectMetaTarget(target, 'a', target);
-        console.log(JSON.stringify(core.getOwnJsonMeta(source)));
-        core.generateTreeDiff(source, target, function (err, diff) {
-            console.log(JSON.stringify(diff, null, 2));
-            done();
-        });
-    });
-
 });
 


### PR DESCRIPTION
With this change we provide a third option for 'simple' value conflicts during merge.
By default the third option's value if the original value, but the user can manually edit and put anything there.
The change also contains a few fixes regarding the merge procedure and some utility functions to deal with paths of conflicts.