### PR TITLE
Authentication enhancements for integrating/embedding webgme in other app.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -51,10 +51,14 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
  - If true certain parts will require that users are authenticated.
 - `config.authentication.allowGuests = true`
  - Generate a guest account for non-authenticated connections.
-- `config.authentication.allowUserRegistration = true`
- - Allow clients to create new users via the REST api.
 - `config.authentication.guestAccount = 'guest'`
  - User account which non-authenticated connections will access the storage.
+- `config.authentication.allowUserRegistration = true`
+ - Allows user-creation via the REST api without being an authenticated site admin.
+- `config.authentication.registeredUsersCanCreate = true`
+ - Set this option to `false` if user registration is `true` and registered users should not be able to create projects (site-admins can edit the `canCreate` property post-hoc for existing users).
+- `config.authentication.inferredUsersCanCreate = false`
+ - Users authenticated by externally generated tokens are automatically put in the database at their first login. By default these users cannot create new projects unless this option is set to `true`.
 - `config.authentication.logInUrl = '/profile/login'`
  - Where clients are redirected if not authenticated.
 - `config.authentication.logOutUrl = '/profile/login'`
@@ -76,7 +80,7 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
 - `config.authentication.jwt.publicKey = './src/server/middleware/auth/EXAMPLE_PRIVATE_KEY'`
  - Public RSA256 key used when evaluating tokens.
 - `config.authentication.jwt.algorithm = 'RS256'`
- - The algorithm used for encryption (should not be edited w/o chaning keys appropriately).
+ - The algorithm used for encryption (should not be edited w/o changing keys appropriately).
 - `config.authentication.jwt.tokenGenerator = './src/server/middleware/auth/localtokengenerator.js'`
  - Replaceable module for generating tokens in case webgme should not generated new tokens by itself.
 

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -21,6 +21,8 @@ var path = require('path'),
 
             allowGuests: true,
             allowUserRegistration: true,
+            registeredUsersCanCreate: true,
+            inferredUsersCanCreate: false,
             guestAccount: 'guest',
             logOutUrl: '/profile/login',
             logInUrl: '/profile/login',

--- a/src/bin/usermanager.js
+++ b/src/bin/usermanager.js
@@ -82,14 +82,22 @@ main = function (argv) {
 
     program
         .command('userlist [username]')
+        .option('-t, --generateToken', 'Generates a token for given username', false)
         .description('lists all users or the specified user')
         .action(function (username, options) {
             setupGMEAuth(options.parent.db, function (/*err*/) {
                 if (username) {
                     auth.getUser(username)
                         .then(function (userObject) {
-                            // TODO: pretty print users
-                            console.log(userObject);
+                            if (options.generateToken) {
+                                return auth.generateJWTokenForAuthenticatedUser(username);
+                            } else {
+                                // TODO: pretty print users
+                                return userObject;
+                            }
+                        })
+                        .then(function (output) {
+                            console.log(output);
                             mainDeferred.resolve();
                         })
                         .catch(mainDeferred.reject)

--- a/src/client/js/Widgets/UserProfile/UserProfileWidget.js
+++ b/src/client/js/Widgets/UserProfile/UserProfileWidget.js
@@ -10,7 +10,7 @@ define(['js/logger'], function (Logger) {
 
     var UserProfileWidget,
         USER_PROFILE_WIDGET_TEMPLATE_LOGGEDIN = '<i class="glyphicon glyphicon-user icon-white" title="Logged in as">' +
-            '</i> <a href="/profile/" target="_top" class="navbar-link" title="View profile">__USERNAME__</a> ' +
+            '</i> <a href="/profile/" target="_self" class="navbar-link" title="View profile">__USERNAME__</a> ' +
             '<a href="/logout" target="_top" class="navbar-link">' +
             '<i class="glyphicon glyphicon-eject icon-white" title="Log out"></i></a>',
         USER_PROFILE_WIDGET_TEMPLATE_NOTLOGGEDIN = '<i class="glyphicon glyphicon-user" title="Not logged in"></i>';

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -97,7 +97,7 @@ function createAPI(app, mountPath, middlewareOpts) {
         gmeAuth.addUser(receivedData.userId,
             receivedData.email,
             receivedData.password,
-            true,
+            gmeConfig.authentication.registeredUsersCanCreate,
             {overwrite: false},
             function (err/*, updateData*/) {
                 if (err) {
@@ -211,7 +211,7 @@ function createAPI(app, mountPath, middlewareOpts) {
             .catch(function (err) {
                 if (err.message.indexOf('no such user') === 0) {
                     logger.info('Authenticated user did not exist in db, adding:', userId);
-                    gmeAuth.addUser(userId, 'em@il', GUID(), false, {overwrite: false})
+                    gmeAuth.addUser(userId, 'em@il', GUID(), gmeConfig.authentication.inferredUsersCanCreate, {overwrite: false})
                         .then(function (/*userData*/) {
                             return gmeAuth.getUser(userId);
                         })


### PR DESCRIPTION
This PR deals with the following:
- The user profile page link does not target the top frame, instead just _self. So when webgme is embedded in an iframe it no longer redirects the embedder. N.B. The logout url still does but the target should be configured in `config.authentication.logOutUrl`.
- Added options for enabling/disabling registered or inferred users to create new projects.
- Added option in usermanager.js to generate and print a token to the console. `$usermanager.js userlist guest -t`

Closes #1352 