### PR TITLE
Copy nodes

### DIFF
--- a/src/client/js/client/gmeNodeSetter.js
+++ b/src/client/js/client/gmeNodeSetter.js
@@ -44,7 +44,7 @@ define([], function () {
 
         function _copyMultipleNodes(paths, parentNode, resultAsArray) {
             var copiedNodes, result = {},
-                resultAsArray = [],
+                resultArray = [],
                 i, originalNodes = [],
                 checkPaths = function () {
                     var i,
@@ -71,11 +71,11 @@ define([], function () {
 
                 for (i = 0; i < paths.length; i += 1) {
                     result[paths[i]] = copiedNodes[i];
-                    resultAsArray.push(storeNode(copiedNodes[i]));
+                    resultArray.push(storeNode(copiedNodes[i]));
                 }
 
-                if (resultAsArray) {
-                    return resultAsArray;
+                if (resultAsArray === true) {
+                    return resultArray;
                 }
             }
 

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -76,6 +76,6 @@ define([], function () {
         MAX_MUTATE: 30000,
         MAXIMUM_STARTING_RELID_LENGTH: 5,
 
-        OVERLAY_SHARD_INDICATOR : 'sharded'
+        OVERLAY_SHARD_INDICATOR: 'sharded'
     };
 });

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -843,7 +843,8 @@ define([
          * @param {module:Core~Node[]} nodes - the nodes to be copied.
          * @param {module:Core~Node} parent - the parent node of the copy.
          *
-         * @return {module:Core~Node[]} The function returns an array of the copied nodes.
+         * @return {module:Core~Node[]} The function returns an array of the copied nodes. The order follows
+         * the order of originals.
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.

--- a/src/common/core/coreQ.js
+++ b/src/common/core/coreQ.js
@@ -203,13 +203,15 @@ define(['common/core/core', 'q'], function (Core, Q) {
         var updateLibraryOrg = this.updateLibrary;
         this.updateLibrary = function (node, name, updatedLibraryRootHash, libraryInfo, updateInstructions, callback) {
             var deferred = Q.defer();
-            updateLibraryOrg(node, name, updatedLibraryRootHash, libraryInfo, updateInstructions, function (err, result) {
-                if (err) {
-                    deferred.reject(err);
-                } else {
-                    deferred.resolve(result);
+            updateLibraryOrg(node, name, updatedLibraryRootHash, libraryInfo, updateInstructions,
+                function (err, result) {
+                    if (err) {
+                        deferred.reject(err);
+                    } else {
+                        deferred.resolve(result);
+                    }
                 }
-            });
+            );
 
             return deferred.promise.nodeify(callback);
         };

--- a/src/common/core/corerel.js
+++ b/src/common/core/corerel.js
@@ -109,7 +109,7 @@ define([
                     break;
                 }
 
-                source = '/' + innerCore.getRelid(node) + source;
+                source = CONSTANTS.PATH_SEP + innerCore.getRelid(node) + source;
                 node = innerCore.getParent(node);
 
             } while (node);
@@ -385,10 +385,6 @@ define([
             if (shouldUpdateSmallest) {
                 updateSmallestOverlayShardIndex(node);
             }
-        }
-
-        function isPathInSubTree(path, subTreeRoot) {
-            return path === subTreeRoot | path.indexOf(subTreeRoot + CONSTANTS.PATH_SEP) === 0;
         }
 
         //</editor-fold>
@@ -821,7 +817,7 @@ define([
          * @param {string} relid - Relid of the child to be removed.
          */
         this.deleteChild = function (parent, relid) {
-            var prefix = '/' + relid;
+            var prefix = CONSTANTS.PATH_SEP + relid;
             innerCore.deleteProperty(parent, relid);
             innerCore.removeChildFromCache(parent, relid);
             if (parent.childrenRelids) {
@@ -884,7 +880,7 @@ define([
                 ancestorNewPath = innerCore.getPath(newNode, ancestor);
 
                 base = innerCore.getParent(node);
-                baseOldPath = '/' + innerCore.getRelid(node);
+                baseOldPath = CONSTANTS.PATH_SEP + innerCore.getRelid(node);
                 aboveAncestor = 1;
 
                 while (base) {
@@ -901,7 +897,7 @@ define([
 
                         if (entry.p) {
                             ASSERT(entry.s.substr(0, baseOldPath.length) === baseOldPath);
-                            ASSERT(entry.s === baseOldPath || entry.s.charAt(baseOldPath.length) === '/');
+                            ASSERT(entry.s === baseOldPath || entry.s.charAt(baseOldPath.length) === CONSTANTS.PATH_SEP);
 
                             if (aboveAncestor < 0) {
                                 //below ancestor node - further from root
@@ -932,7 +928,7 @@ define([
                         }
                     }
 
-                    baseOldPath = '/' + innerCore.getRelid(base) + baseOldPath;
+                    baseOldPath = CONSTANTS.PATH_SEP + innerCore.getRelid(base) + baseOldPath;
                     base = innerCore.getParent(base);
                 }
             } else {
@@ -974,7 +970,7 @@ define([
 
             overlaysToCheck = self.overlayQuery(commonParent, commonPathInformation.first);
             for (i = 0; i < overlaysToCheck.length; i += 1) {
-                if (isPathInSubTree(overlaysToCheck[i].t, commonPathInformation.second)) {
+                if (self.isPathInSubTree(overlaysToCheck[i].t, commonPathInformation.second)) {
                     relationInformation.push({
                         source: innerCore.joinPaths(commonPathInformation.common, overlaysToCheck[i].s),
                         sourceBase: innerCore.joinPaths(commonPathInformation.common,
@@ -997,7 +993,7 @@ define([
 
             overlaysToCheck = self.overlayQuery(root, sourceRelPath);
             for (i = 0; i < overlaysToCheck.length; i += 1) {
-                if (isPathInSubTree(overlaysToCheck[i].t, targetRelPath)) {
+                if (self.isPathInSubTree(overlaysToCheck[i].t, targetRelPath)) {
                     relationInformation.push({
                         source: innerCore.joinPaths(rootPath, overlaysToCheck[i].s),
                         sourceBase: innerCore.joinPaths(rootPath, sourceRelPath),
@@ -1160,7 +1156,7 @@ define([
             }
 
             base = innerCore.getParent(node);
-            baseOldPath = '/' + innerCore.getRelid(node);
+            baseOldPath = CONSTANTS.PATH_SEP + innerCore.getRelid(node);
             aboveAncestor = 1;
 
             var oldNode = node;
@@ -1207,7 +1203,7 @@ define([
                     }
 
                     ASSERT(entry.s.substr(0, baseOldPath.length) === baseOldPath);
-                    ASSERT(entry.s === baseOldPath || entry.s.charAt(baseOldPath.length) === '/');
+                    ASSERT(entry.s === baseOldPath || entry.s.charAt(baseOldPath.length) === CONSTANTS.PATH_SEP);
 
                     if (aboveAncestor < 0) {
                         //below ancestor node
@@ -1248,7 +1244,7 @@ define([
                     self.overlayInsert(nodeToModifyOverlays, source, entry.n, target);
                 }
 
-                baseOldPath = '/' + innerCore.getRelid(base) + baseOldPath;
+                baseOldPath = CONSTANTS.PATH_SEP + innerCore.getRelid(base) + baseOldPath;
                 base = innerCore.getParent(base);
             }
 
@@ -1277,7 +1273,7 @@ define([
                 i;
 
             for (i = 0; i < relids.length; i += 1) {
-                result.push(path + '/' + relids[i]);
+                result.push(path + CONSTANTS.PATH_SEP + relids[i]);
             }
 
             return result;
@@ -1316,7 +1312,7 @@ define([
                         }
                     }
                 }
-                source = '/' + innerCore.getRelid(node) + source;
+                source = CONSTANTS.PATH_SEP + innerCore.getRelid(node) + source;
                 node = innerCore.getParent(node);
             } while (node);
 
@@ -1473,8 +1469,8 @@ define([
         this.isValidRelid = RANDOM.isValidRelid;
 
         this.isContainerPath = function (path, parentPath) {
-            var pathArray = (path || '').split('/'),
-                parentArray = (parentPath || '').split('/'),
+            var pathArray = (path || '').split(CONSTANTS.PATH_SEP),
+                parentArray = (parentPath || '').split(CONSTANTS.PATH_SEP),
                 i;
 
             for (i = 0; i < parentArray.length; i += 1) {
@@ -1486,6 +1482,9 @@ define([
             return true;
         };
 
+        this.isPathInSubTree = function (path, subTreeRoot) {
+            return path === subTreeRoot | path.indexOf(subTreeRoot + CONSTANTS.PATH_SEP) === 0;
+        }
         // by default the function removes any 'sub-node' relations
         this.getRawOverlayInformation = function (node) {
             var completeOverlayInfo = {},

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -111,6 +111,10 @@ define([
             return null;
         }
 
+        function __getEmptyData() {
+            return {};
+        }
+
         function __getChildData(data, relid) {
             ASSERT(typeof relid === 'string');
 
@@ -134,10 +138,6 @@ define([
             } else {
                 return false;
             }
-        }
-
-        function __getEmptyData() {
-            return {};
         }
 
         function __areEquivalent(data1, data2) {
@@ -181,7 +181,7 @@ define([
                 key = keys[i];
                 child = data[key];
                 if (__isMutableData(child)) {
-                    sub = __saveData(child, root, path + '/' + key, stackedObjects);
+                    sub = __saveData(child, root, path + CONSTANTS.PATH_SEP + key, stackedObjects);
                     if (JSON.stringify(sub) === JSON.stringify(__getEmptyData())) {
                         delete data[key];
                     } else {
@@ -377,14 +377,14 @@ define([
 
             var path = '';
             while (node.relid !== null && node !== base) {
-                path = '/' + node.relid + path;
+                path = CONSTANTS.PATH_SEP + node.relid + path;
                 node = node.parent;
             }
             return path;
         };
 
         this.isValidPath = function (path) {
-            return typeof path === 'string' && (path === '' || path.charAt(0) === '/');
+            return typeof path === 'string' && (path === '' || path.charAt(0) === CONSTANTS.PATH_SEP);
         };
 
         this.splitPath = function (path) {
@@ -405,7 +405,7 @@ define([
         this.buildPath = function (path) {
             ASSERT(path instanceof Array);
 
-            return path.length === 0 ? '' : '/' + path.join('/');
+            return path.length === 0 ? '' : CONSTANTS.PATH_SEP + path.join(CONSTANTS.PATH_SEP);
         };
 
         this.joinPaths = function (first, second) {
@@ -432,6 +432,10 @@ define([
                 second: self.buildPath(second.slice(i)),
                 secondLength: second.length - i
             };
+        };
+
+        this.isPathInSubTree = function (path, subTreeRoot) {
+            return path === subTreeRoot || path.indexOf(subTreeRoot + CONSTANTS.PATH_SEP) === 0;
         };
 
         this.normalize = function (node) {
@@ -902,9 +906,9 @@ define([
 
         this.loadByPath = function (node, path) {
             ASSERT(self.isValidNode(node));
-            ASSERT(path === '' || path.charAt(0) === '/');
+            ASSERT(path === '' || path.charAt(0) === CONSTANTS.PATH_SEP);
 
-            path = path.split('/');
+            path = path.split(CONSTANTS.PATH_SEP);
             return __loadDescendantByPath2(node, path, 1);
         };
 

--- a/src/common/core/coretree.js
+++ b/src/common/core/coretree.js
@@ -390,10 +390,16 @@ define([
         this.splitPath = function (path) {
             ASSERT(self.isValidPath(path));
 
-            path = path.split('/');
+            path = path.split(CONSTANTS.PATH_SEP);
             path.splice(0, 1);
 
             return path;
+        };
+
+        this.getParentPath = function (path) {
+            path = path.split(CONSTANTS.PATH_SEP);
+            path.splice(-1, 1);
+            return path.join(CONSTANTS.PATH_SEP);
         };
 
         this.buildPath = function (path) {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -878,6 +878,8 @@ define([
                 }
             }
 
+            self.processRelidReservation(parent, longestNewRelid);
+
             // Setting the preserved relations
             // create the relations, that have to be preserved
             for (i = 0; i < relationsToPreserve.length; i += 1) {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -908,6 +908,9 @@ define([
                         continue;
                     }
 
+                    node = nodes[i];
+                    basePath = self.getPath(node);
+
                     while (node) {
                         relations = innerCore.gatherRelationsAmongSubtrees(node, nodes[j]);
                         nodePath = self.getPath(node);

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -775,68 +775,68 @@ define([
             return newnode;
         };
 
-        this.copyNodes = function (nodes, parent, relidLength) {
-            var copiedNodes,
-                i, j, index, base,
-                relations = [],
-                names, pointer,
-                longestNewRelid = '',
-                paths = [];
-
-            //here we also have to copy the inherited relations which points inside the copy area
-            for (i = 0; i < nodes.length; i++) {
-                paths.push(self.getPath(nodes[i]));
-            }
-
-            for (i = 0; i < nodes.length; i++) {
-                names = inheritedPointerNames(nodes[i]);
-                pointer = {};
-                for (j = 0; j < names.length; j++) {
-                    index = paths.indexOf(self.getPointerPath(nodes[i], names[j]));
-                    if (index !== -1) {
-                        pointer[names[j]] = index;
-                    }
-                }
-                relations.push(pointer);
-            }
-
-            relidLength = relidLength || innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
-            //making the actual copy
-            copiedNodes = innerCore.copyNodes(nodes, parent, self.getChildrenRelids(parent, true), relidLength);
-
-            //setting internal-inherited relations
-            for (i = 0; i < nodes.length; i++) {
-                names = Object.keys(relations[i]);
-                for (j = 0; j < names.length; j++) {
-                    self.setPointer(copiedNodes[i], names[j], copiedNodes[relations[i][names[j]]]);
-                }
-            }
-
-            //setting base relation
-            for (i = 0; i < nodes.length; i++) {
-                base = nodes[i].base;
-                copiedNodes[i].base = base;
-                innerCore.setPointer(copiedNodes[i], CONSTANTS.BASE_POINTER, base);
-                innerCore.deleteProperty(copiedNodes[i], CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
-            }
-
-            //searching for the longest new relid and then process it towards the bases of the parent
-            for (i = 0; i < copiedNodes.length; i += 1) {
-                j = this.getRelid(copiedNodes[i]);
-                if (j.length > longestNewRelid) {
-                    longestNewRelid = j;
-                }
-            }
-
-            this.processRelidReservation(parent, longestNewRelid);
-
-            // Addition to #1232
-            if (isInheritedChild(parent)) {
-                self.processRelidReservation(self.getParent(parent), self.getRelid(parent));
-            }
-
-            return copiedNodes;
-        };
+        // this.copyNodes = function (nodes, parent, relidLength) {
+        //     var copiedNodes,
+        //         i, j, index, base,
+        //         relations = [],
+        //         names, pointer,
+        //         longestNewRelid = '',
+        //         paths = [];
+        //
+        //     //here we also have to copy the inherited relations which points inside the copy area
+        //     for (i = 0; i < nodes.length; i++) {
+        //         paths.push(self.getPath(nodes[i]));
+        //     }
+        //
+        //     for (i = 0; i < nodes.length; i++) {
+        //         names = inheritedPointerNames(nodes[i]);
+        //         pointer = {};
+        //         for (j = 0; j < names.length; j++) {
+        //             index = paths.indexOf(self.getPointerPath(nodes[i], names[j]));
+        //             if (index !== -1) {
+        //                 pointer[names[j]] = index;
+        //             }
+        //         }
+        //         relations.push(pointer);
+        //     }
+        //
+        //     relidLength = relidLength || innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
+        //     //making the actual copy
+        //     copiedNodes = innerCore.copyNodes(nodes, parent, self.getChildrenRelids(parent, true), relidLength);
+        //
+        //     //setting internal-inherited relations
+        //     for (i = 0; i < nodes.length; i++) {
+        //         names = Object.keys(relations[i]);
+        //         for (j = 0; j < names.length; j++) {
+        //             self.setPointer(copiedNodes[i], names[j], copiedNodes[relations[i][names[j]]]);
+        //         }
+        //     }
+        //
+        //     //setting base relation
+        //     for (i = 0; i < nodes.length; i++) {
+        //         base = nodes[i].base;
+        //         copiedNodes[i].base = base;
+        //         innerCore.setPointer(copiedNodes[i], CONSTANTS.BASE_POINTER, base);
+        //         innerCore.deleteProperty(copiedNodes[i], CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
+        //     }
+        //
+        //     //searching for the longest new relid and then process it towards the bases of the parent
+        //     for (i = 0; i < copiedNodes.length; i += 1) {
+        //         j = this.getRelid(copiedNodes[i]);
+        //         if (j.length > longestNewRelid) {
+        //             longestNewRelid = j;
+        //         }
+        //     }
+        //
+        //     this.processRelidReservation(parent, longestNewRelid);
+        //
+        //     // Addition to #1232
+        //     if (isInheritedChild(parent)) {
+        //         self.processRelidReservation(self.getParent(parent), self.getRelid(parent));
+        //     }
+        //
+        //     return copiedNodes;
+        // };
 
         this.deleteNode = function (node, technical) {
             //currently we only check if the node is inherited from its parents children

--- a/src/common/core/librarycore.js
+++ b/src/common/core/librarycore.js
@@ -1122,7 +1122,7 @@ define([
                         bases: {},
                         relations: {preserved: {}, lost: {}}
                     },
-                    infoLosses = {},
+                    // infoLosses = {},
                     allMetaNodes,
                     path,
                     node,

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -213,7 +213,7 @@ define([
             return innerCore.getOwnValidPointerNames(node).concat(innerCore.getOwnValidSetNames(node));
         }
 
-        function containmentGetter(node) {
+        function containmentGetter(/*node*/) {
             return ['containment'];
         }
 
@@ -370,10 +370,8 @@ define([
         this.getJsonMeta = function (node) {
             var meta = {children: {}, attributes: {}, pointers: {}, aspects: {}, constraints: {}},
                 nullRule = {items: [], minItems: [], maxItems: []},
-                tempNode,
                 names,
-                pointer,
-                i, j;
+                i;
 
             meta.children = self.getChildrenMeta(node);
             if (meta.children) {
@@ -642,8 +640,8 @@ define([
                                     targetNode: targetNode,
                                     collisionPaths: [definitions[keys[k]].path, path],
                                     collisionNodes: [mixinNodes[definitions[keys[k]].index], mixinNodes[j]],
-                                    message: '[' + ownName + ']: inherits pointer (' + names[i]
-                                    + ') target definition of ' + targetInfoTxt +
+                                    message: '[' + ownName + ']: inherits pointer (' + names[i] +
+                                    ') target definition of ' + targetInfoTxt +
                                     ' from [' + definitions[keys[k]].name + '] and [' + name + ']',
                                     hint: 'Remove one of the mixin relations'
                                 });
@@ -688,8 +686,8 @@ define([
                                     targetNode: targetNode,
                                     collisionPaths: [definitions[keys[k]].path, path],
                                     collisionNodes: [mixinNodes[definitions[keys[k]].index], mixinNodes[j]],
-                                    message: '[' + ownName + ']: inherits set (' + names[i]
-                                    + ') member definition of ' + targetInfoTxt +
+                                    message: '[' + ownName + ']: inherits set (' + names[i] +
+                                    ') member definition of ' + targetInfoTxt +
                                     ' from [' + definitions[keys[k]].name + '] and [' + name + ']',
                                     hint: 'Remove one of the mixin relations'
                                 });
@@ -782,7 +780,7 @@ define([
         };
 
         this.delMixin = function (node, mixinPath) {
-            var metaNodes = innerCore.getAllMetaNodes(node);
+            // var metaNodes = innerCore.getAllMetaNodes(node);
 
             innerCore.delMember(node, CONSTANTS.MIXINS_SET, mixinPath);
         };

--- a/src/common/core/users/getroot.js
+++ b/src/common/core/users/getroot.js
@@ -10,6 +10,7 @@ define(['common/regexp', 'q'], function (REGEXP, Q) {
 
     function getRoot(parameters, callback) {
         var deferred = Q.defer(),
+            result = {},
             loadRoot = function (hash) {
                 parameters.core.loadRoot(hash, function (err, root) {
                     if (err) {
@@ -32,8 +33,7 @@ define(['common/regexp', 'q'], function (REGEXP, Q) {
                     result.rootHash = commitObj.root;
                     loadRoot(commitObj.root);
                 });
-            },
-            result = {};
+            };
 
         if (REGEXP.HASH.test(parameters.id)) {
             loadCommit(parameters.id);

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -26,7 +26,7 @@ define([
 
         if (persisted.hasOwnProperty('objects') === false || Object.keys(persisted.objects).length === 0) {
             parameters.logger.warn('empty patch was inserted - not making commit');
-            return new Q({
+            return Q({
                 hash: parameters.parents[0], //if there is no change, we return the first parent!!!
                 branchName: parameters.branchName
             })

--- a/src/common/core/users/merge.js
+++ b/src/common/core/users/merge.js
@@ -26,7 +26,7 @@ define([
 
         if (persisted.hasOwnProperty('objects') === false || Object.keys(persisted.objects).length === 0) {
             parameters.logger.warn('empty patch was inserted - not making commit');
-            return Q({
+            return new Q({
                 hash: parameters.parents[0], //if there is no change, we return the first parent!!!
                 branchName: parameters.branchName
             })

--- a/src/common/core/users/metarules.js
+++ b/src/common/core/users/metarules.js
@@ -405,6 +405,17 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
             };
         }
 
+        function getMixinError(mixinError) {
+            return {
+                severity: mixinError.severity,
+                message: mixinError.message,
+                description: 'Mixin violations makes it hard to see which definition is used.',
+                hint: mixinError.hint,
+                path: path,
+                relatedPaths: mixinError.collisionPaths || []
+            };
+        }
+
         for (path in metaNodes) {
             metaNode = metaNodes[path];
             metaName = core.getFullyQualifiedName(metaNode);
@@ -436,16 +447,7 @@ define(['q', 'common/core/constants'], function (Q, CONSTANTS) {
             }
 
             // Get the mixin errors.
-            result = result.concat(core.getMixinErrors(metaNode).map(function (mixinError) {
-                return {
-                    severity: mixinError.severity,
-                    message: mixinError.message,
-                    description: 'Mixin violations makes it hard to see which definition is used.',
-                    hint: mixinError.hint,
-                    path: path,
-                    relatedPaths: mixinError.collisionPaths || []
-                };
-            }));
+            result = result.concat(core.getMixinErrors(metaNode).map(getMixinError));
 
             if (ownMetaJson.children.items) {
                 for (i = 0; i < ownMetaJson.children.items.length; i += 1) {

--- a/test/client/js/client/gmeNodeSetter.spec.js
+++ b/test/client/js/client/gmeNodeSetter.spec.js
@@ -155,7 +155,8 @@ describe('gmeNodeSetter', function () {
     it('should copy more node at once', function () {
         var parameters = {
             parentId: ''
-        };
+        },
+        oldNodeCount;
 
         parameters['/1303043463/2119137141'] = {
             attributes: {
@@ -168,11 +169,9 @@ describe('gmeNodeSetter', function () {
             }
         };
 
-        expect(basicState.nodes['/2119137141']).to.eql(undefined);
-        expect(basicState.nodes['/1044885565']).to.eql(undefined);
+        oldNodeCount = Object.keys(basicState.nodes).length;
         setNode.copyMoreNodes(parameters);
-        expect(basicState.nodes['/2119137141']).not.to.eql(undefined);
-        expect(basicState.nodes['/1044885565']).not.to.eql(undefined);
+        expect(Object.keys(basicState.nodes)).to.have.length(oldNodeCount+2);
     });
 
     it('should move a node', function () {

--- a/test/client/js/client/gmeNodeSetter.spec.js
+++ b/test/client/js/client/gmeNodeSetter.spec.js
@@ -154,9 +154,9 @@ describe('gmeNodeSetter', function () {
 
     it('should copy more node at once', function () {
         var parameters = {
-            parentId: ''
-        },
-        oldNodeCount;
+                parentId: ''
+            },
+            oldNodeCount;
 
         parameters['/1303043463/2119137141'] = {
             attributes: {
@@ -171,7 +171,7 @@ describe('gmeNodeSetter', function () {
 
         oldNodeCount = Object.keys(basicState.nodes).length;
         setNode.copyMoreNodes(parameters);
-        expect(Object.keys(basicState.nodes)).to.have.length(oldNodeCount+2);
+        expect(Object.keys(basicState.nodes)).to.have.length(oldNodeCount + 2);
     });
 
     it('should move a node', function () {
@@ -400,4 +400,18 @@ describe('gmeNodeSetter', function () {
         expect(context.core.getBase(basicState.nodes[newId].node)).to.eql(null);
     });
 
+    it('should copy more node at once with copyNodes', function () {
+        var oldNodeCount;
+
+        oldNodeCount = Object.keys(basicState.nodes).length;
+        setNode.copyNodes(['/1303043463/2119137141', '/1303043463/1044885565'], '');
+        expect(Object.keys(basicState.nodes)).to.have.length(oldNodeCount + 2);
+    });
+
+    it('should copy more node at once with copyNodes and return back the new ids', function () {
+        var newPaths;
+
+        newPaths = setNode.copyNodes(['/1303043463/2119137141', '/1303043463/1044885565'], '');
+        expect(newPaths).to.have.length(2);
+    });
 });

--- a/test/common/core/corerel.spec.js
+++ b/test/common/core/corerel.spec.js
@@ -118,6 +118,17 @@ describe('corerel', function () {
         }, core.loadChildren(root));
     });
 
+    it('should preserve relation among nodes that being copied', function () {
+        var root = core.createNode(),
+            source = core.createNode({parent: root}),
+            target = core.createNode({parent: root}),
+            copies;
+
+        core.setPointer(source, 'follow', target);
+        copies = core.copyNodes([source, target], root);
+        expect(core.getPointerPath(copies[0], 'follow')).to.eql(core.getPath(copies[1]));
+    });
+
     it('loading collection and pointer', function (done) {
         TASYNC.call(function (children) {
             expect(children).to.have.length(1);

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -233,6 +233,7 @@ describe('coretype', function () {
             }, core.loadChildren(instance));
         }, core.loadChildren(root));
     });
+
     it('copying nodes around', function (done) {
         TASYNC.call(function (children) {
             var base, instance, i, bCopy, copies;
@@ -263,6 +264,7 @@ describe('coretype', function () {
             done();
         }, core.loadChildren(root));
     });
+
     it('removing base', function (done) {
         TASYNC.call(function (children) {
             var base, instance, i;

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -575,6 +575,43 @@ describe('coretype', function () {
         }, core.loadByPath(root, '/v/d/c'));
     });
 
+    // FIXME: according to the theoretical view of inheritance, these test cases should run
+    // but the current implementation cannot discover the whole chain of inheritance shyncronously
+    it.skip('should provide the info of instance-internal collections (second instance)', function (done) {
+        var root = core.createNode(),
+            A = core.createNode({parent: root, base: null, relid: 'A'}),
+            B = core.createNode({parent: A, base: null, relid: 'B'}),
+            C = core.createNode({parent: A, base: null, relid: 'C'}),
+            aP = core.createNode({parent: root, base: A, relid: 'a'}),
+            bP, bPP, cP;
+
+        core.setPointer(B, 'ref', C);
+
+        TASYNC.call(function (bP_, cP_) {
+            bP = bP_;
+            cP = cP_;
+            bPP = core.createNode({parent: aP, base: bP, relid: 'b'});
+            console.log(core.getPointerPath(bPP, 'ref'));
+            expect(core.getCollectionPaths(cP, 'ref')).to.have.length(2);
+            done();
+        }, core.loadByPath(aP, '/B'), core.loadByPath(aP, '/B'));
+    });
+
+    it.skip('should provide the info of collections throughout instances', function (done) {
+        var root = core.createNode(),
+            C = core.createNode({parent: root, base: null, relid: 'C'}),
+            C1 = core.createNode({parent: C, base: null, relid: 'C1'}),
+            C2 = core.createNode({parent: C, base: null, relid: 'C2'}),
+            CC1 = core.createNode({parent: C1, base: null, relid: '1'}),
+            CC1P = core.createNode({parent: C1, base: CC1, relid: '1P'}),
+            CC1PP = core.createNode({parent: C1, base: CC1P, relid: '1PP'});
+
+        core.setPointer(CC1, 'ref', C2);
+
+        expect(core.getCollectionPaths(C2, 'ref')).to.have.members(['/C/C1/1', '/C/C1/1P', '/C/C1/1PP']);
+        done();
+    });
+
     it('isValidNewParent should return true when new-parent is root', function () {
         var node = core.createNode({parent: root});
 
@@ -1458,7 +1495,7 @@ describe('coretype', function () {
             }
             expect(core.getPointerPath(cFrom, 'ref')).to.eql(core.getPath(cTo));
 
-            instanceChild = core.createNode({parent: instanceOne, base: cFrom, relid:'ic1'});
+            instanceChild = core.createNode({parent: instanceOne, base: cFrom, relid: 'ic1'});
 
             expect(core.getPointerPath(instanceChild, 'ref')).to.eql(core.getPath(cTo));
 


### PR DESCRIPTION
The copyNodes function have been reimplemented and corrected.
Now, it is able to follow the chain if inheritance correctly when preserving 'copy-internal' relationships.
Also it is provided on the client in its 'purest' form to hopefully replace the copyMoreNodes at some point in the futue.