### PR TITLE
Panels can be split arbitrarily many times

### DIFF
--- a/src/client/js/PanelManager/PanelManager.js
+++ b/src/client/js/PanelManager/PanelManager.js
@@ -1,4 +1,4 @@
-/*globals define, _, WebGMEGlobal*/
+/*globals define, WebGMEGlobal*/
 /*jshint browser: true*/
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
@@ -15,13 +15,8 @@ define(['js/logger', 'js/Constants'], function (Logger, CONSTANTS) {
         this._activePanel = undefined;
     };
 
-
     PanelManager.prototype.setActivePanel = function (p) {
-        if (this._activePanel === p) {
-            // [lattmann] we need to call setActive in order to get the split panel working correctly
-            this._activePanel.setActive(true);
-
-        } else {
+        if (this._activePanel !== p) {
             if (this._activePanel) {
                 //deactivate currently active panel
                 this._activePanel.setActive(false);
@@ -29,12 +24,17 @@ define(['js/logger', 'js/Constants'], function (Logger, CONSTANTS) {
 
             this._activePanel = undefined;
 
-            if (p && _.isFunction(p.setActive)) {
+            if (p) {
                 this._activePanel = p;
-                this._activePanel.setActive(true);
-            }
 
-            WebGMEGlobal.State.registerActiveVisualizer(this._activePanel[CONSTANTS.VISUALIZER_PANEL_IDENTIFIER]);
+                if (typeof p.setActive === 'function') {
+                    this._activePanel.setActive(true);
+                }
+
+                WebGMEGlobal.State.registerActiveVisualizer(this._activePanel[CONSTANTS.VISUALIZER_PANEL_IDENTIFIER], {
+                    invoker: this
+                });
+            }
         }
 
         WebGMEGlobal.KeyboardManager.captureFocus();

--- a/src/client/js/Panels/Crosscut/CrosscutPanel.js
+++ b/src/client/js/Panels/Crosscut/CrosscutPanel.js
@@ -53,7 +53,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         };
 
         this.widget.onUIActivity = function () {
-            WebGMEGlobal.PanelManager.setActivePanel(self);
+            //WebGMEGlobal.PanelManager.setActivePanel(self);
             WebGMEGlobal.KeyboardManager.setListener(self.widget);
         };
 

--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -254,7 +254,7 @@ define(['js/logger',
 
         //setting the active object to the root of the graph
         if (typeof this._currentNodeId === 'string') {
-            WebGMEGlobal.State.registerActiveObject(this._currentNodeId);
+            WebGMEGlobal.State.registerActiveObject(this._currentNodeId, {suppressVisualizerFromNode: true});
         }
     };
 

--- a/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorPanel.js
@@ -53,7 +53,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         };
 
         this.widget.onUIActivity = function () {
-            WebGMEGlobal.PanelManager.setActivePanel(self);
+            //WebGMEGlobal.PanelManager.setActivePanel(self);
             WebGMEGlobal.KeyboardManager.setListener(self.widget);
         };
 

--- a/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
@@ -48,7 +48,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         };
 
         this.widget.onUIActivity = function () {
-            WebGMEGlobal.PanelManager.setActivePanel(self);
+            //WebGMEGlobal.PanelManager.setActivePanel(self);
             WebGMEGlobal.KeyboardManager.setListener(self.widget);
         };
 

--- a/src/client/js/Panels/SetEditor/SetEditorPanel.js
+++ b/src/client/js/Panels/SetEditor/SetEditorPanel.js
@@ -54,7 +54,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         };
 
         this.widget.onUIActivity = function () {
-            WebGMEGlobal.PanelManager.setActivePanel(self);
+            //WebGMEGlobal.PanelManager.setActivePanel(self);
             WebGMEGlobal.KeyboardManager.setListener(self.widget);
         };
 

--- a/src/client/js/Panels/SplitPanel/SplitPanel.js
+++ b/src/client/js/Panels/SplitPanel/SplitPanel.js
@@ -3,26 +3,31 @@
 
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
 
-define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (PanelBase) {
+define([
+    'common/util/assert',
+    'js/PanelBase/PanelBase',
+    'css!./styles/SplitPanel.css'
+], function (ASSERT, PanelBase) {
 
     'use strict';
 
-    var SplitPanel,
-        SPLIT_PANEL_CLASS = 'split-panel',
-        PANEL1_CLASS = 'p1',
-        PANEL2_CLASS = 'p2',
+    var SPLIT_PANEL_CLASS = 'split-panel',
+        PANEL_CONTAINER_CLASS = 'split-panel-panel-container',
+        PANEL_ID_DATA_KEY = 'SPLIT_PANEL_ID',
+        SPLITTER_ID_DATA_KEY = 'SPLIT_PANEL_SPILITTER_ID',
         SPLITTER_CLASS = 'splitter',
         SPLITTER_SIZE = 4,
-        VERTICAL_CLASS = 'vertical',
-        HORIZONTAL_CLASS = 'horizontal',
         SPLITTER_RESIZE_CLASS = 'resize',
         MINIMUM_PANEL_SIZE = 50,
-        SPLITTER_SNAP_FROM_DISTANCE = 25,
-        SPLITTER_RESIZE_PADDING = 2;
+        SPLITTER_SNAP_FROM_DISTANCE = 0,
+        SPLITTER_RESIZE_PADDING = 2,
+        MINIMUM_RESCALE_WIDTH = 400,
+        MINIMUM_RESCALE_HEIGHT = 400;
 
-    SplitPanel = function (/*layoutManager, params*/) {
+    function SplitPanel(/*layoutManager, params*/) {
         var options = {};
         //set properties from options
         options[PanelBase.OPTIONS.LOGGER_INSTANCE_NAME] = 'SplitPanel';
@@ -30,60 +35,113 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
         //call parent's constructor
         PanelBase.apply(this, [options]);
 
-        this._panel1 = undefined;
-        this._panel2 = undefined;
+        this._panelIdCounter = 1;
+        this._activePanelId = null;
+
+        /**
+         *
+         * @example
+         * {
+         *   1: {
+         *     instance: ModelEditor instance,
+         *     panelContainer: <div class=PANEL_CLASS_CONTAINER, data=.. 0>,
+         *     splitters: {
+         *          top: null,
+         *          right: 1_2,
+         *          bottom: null,
+         *          left: null
+         *     },
+         *     currentSplitter: 1_2
+         *   },
+         *   2: {
+         *     instance: MetaEditor instance,
+         *     panelContainer: <div class=PANEL_CLASS_CONTAINER, data=.. 1>,
+         *     splitters: {
+         *          top: null,
+         *          right: null,
+         *          bottom: null,
+         *          left: 1_2
+         *     },
+         *     currentSplitter: 1_2
+         *   }
+         * }
+         * @private
+         */
+        this._panels = {};
 
         this._readOnly = false;
 
         this._splitterPos = 0.5;
 
+        /**
+         *
+         * @example
+         * {
+         *   1_2: {
+         *      vertical: true,
+         *      el: $splitter,
+         *      relPos: 0.5, // Range between 0 and 1
+         *      x1: 50,
+         *      y1: 0,
+         *      x2: 50,
+         *      y2, 100
+         *   }
+         * }
+         * @private
+         */
+        this._splitters = {};
+
         //initialize UI
         this._initialize();
 
         this.logger.debug('SplitPanel ctor finished');
-    };
+    }
 
     //inherit from PanelBaseWithHeader
     _.extend(SplitPanel.prototype, PanelBase.prototype);
 
-    SplitPanel.prototype.onResize = function (width, height) {
-        this.logger.debug('onResize --> width: ' + width + ', height: ' + height);
-
-        this._width = width;
-        this._height = height;
-
-        this.$el.width(this._width);
-        this.$el.height(this._height);
-
-        this._updateUI();
-    };
-
     SplitPanel.prototype._initialize = function () {
-        var self = this;
+        var self = this,
+            panelContainer = $('<div/>', {class: PANEL_CONTAINER_CLASS});
 
         this.$el.addClass(SPLIT_PANEL_CLASS);
 
-        this._panel1Container = $('<div/>', {class: PANEL1_CLASS});
-        this.$el.append(this._panel1Container);
+        // Add this first panel container ..
+        this._activePanelId = '' + this._panelIdCounter;
+        panelContainer.data(PANEL_ID_DATA_KEY, this._activePanelId);
+        this.$el.append(panelContainer);
+        this._panels[this._activePanelId] = {
+            panelContainer: panelContainer,
+            instance: null,
+            splitters: {
+                top: null,
+                right: null,
+                bottom: null,
+                left: null
+            },
+            currentSplitter: null
+        };
 
-        this._splitter = $('<div/>', {class: SPLITTER_CLASS});
-        this.$el.append(this._splitter);
+        // the panel instance is still null at this point.
+        WebGMEGlobal.PanelManager.setActivePanel(null);
 
-        this._panel2Container = $('<div/>', {class: PANEL2_CLASS});
-        this.$el.append(this._panel2Container);
+        // We register one all three mouse events in case ui elements in the visualizer
+        // prevents bubbling of any of these.
+        // (Setting the same panel as active will only trigger one setActive in the PanelManager)
+        this.$el.on('mousedown click mouseup', '.' + PANEL_CONTAINER_CLASS, function (/*event*/) {
+            var el = $(this),
+                panelId = el.data(PANEL_ID_DATA_KEY);
 
-        this._panel1Container.on('mousedown', function (event) {
-            self._setActivePanel(0);
+            self.setActivePanel(panelId);
+
             //#1151 event.stopPropagation();
         });
 
-        this._panel2Container.on('mousedown', function (event) {
-            self._setActivePanel(1);
-            //#1151 event.stopPropagation();
-        });
+        this.$el.on('mousedown', '.' + SPLITTER_CLASS, function (event) {
+            var el = $(this),
+                splitterId = el.data(SPLITTER_ID_DATA_KEY);
 
-        this._splitter.on('mousedown', function (event) {
-            self._startPanelResize(event);
+            self._startPanelResize(splitterId, event);
             event.stopPropagation();
             event.preventDefault();
         });
@@ -91,189 +149,600 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
         this._updateUI();
     };
 
-    SplitPanel.prototype._updateUI = function () {
-        var verticalSplit = this._width > this._height,
-            w1 = this._width,
-            h1 = this._height,
-            w2 = this._width,
-            h2 = this._height,
-            sw = SPLITTER_SIZE,
-            sh = SPLITTER_SIZE,
-            p1Top = 0,
-            p1Left = 0,
-            splitterTop = 0,
-            splitterLeft = 0,
-            p2Top = 0,
-            p2Left = 0,
-            has2Panels = this._panel2 !== undefined;
+    SplitPanel.prototype.setActivePanel = function (panelId) {
+        var panel;
 
-        if (has2Panels) {
-            this._splitter.show();
-            this._panel2Container.show();
-            this._splitter.removeClass([VERTICAL_CLASS, HORIZONTAL_CLASS].join(' '));
+        if (typeof panelId === 'string') {
+            panel = this._panels[panelId].instance;
+            this._activePanelId = panelId;
+            WebGMEGlobal.PanelManager.setActivePanel(panel);
         } else {
-            this._splitter.hide();
-            this._panel2Container.hide();
-        }
-
-        if (has2Panels) {
-            if (verticalSplit) {
-                sh = this._height;
-                w1 = Math.floor((this._width - sw) * this._splitterPos);
-                w2 = this._width - w1 - sw;
-                this._splitter.addClass(VERTICAL_CLASS);
-                p1Left = 0;
-                splitterLeft = w1;
-                p2Left = w1 + sw;
-            } else {
-                sw = this._width;
-                h1 = Math.floor((this._height - sh) * this._splitterPos);
-                h2 = this._height - h1 - sh;
-                this._splitter.addClass(HORIZONTAL_CLASS);
-                p1Top = 0;
-                splitterTop = h1;
-                p2Top = h1 + sh;
-            }
-
-            this._splitter.css({
-                width: sw,
-                height: sh,
-                top: splitterTop,
-                left: splitterLeft
-            });
-
-            this._panel1Container.css({
-                width: w1,
-                height: h1,
-                top: p1Top,
-                left: p1Left
-            });
-
-            this._panel2Container.css({
-                width: w2,
-                height: h2,
-                top: p2Top,
-                left: p2Left
-            });
-
-            if (this._panel1) {
-                this._panel1.setSize(w1, h1);
-            }
-
-            if (this._panel2) {
-                this._panel2.setSize(w2, h2);
-            }
-        } else {
-            this._panel1Container.css({
-                width: w1,
-                height: h1,
-                top: p1Top,
-                left: p1Left
-            });
-
-            if (this._panel1) {
-                this._panel1.setSize(w1, h1);
-            }
-
-            this._splitterPos = 0.5;
+            this.logger.error('panel el did not have "', PANEL_ID_DATA_KEY, '" data.');
         }
     };
 
-    SplitPanel.prototype.setPanel = function (panel, container) {
-        if (container === 'p1') {
-            this._panel1Container.empty();
-            this._panel1 = panel;
-            this._panel1Container.append(this._panel1.$pEl);
-            this._panel1.afterAppend();
-            this._setActivePanel(0);
-        } else {
-            this._panel2Container.empty();
-            this._panel2 = panel;
-            this._panel2Container.append(this._panel2.$pEl);
-            this._panel2.afterAppend();
-            this._setActivePanel(1);
-        }
+    SplitPanel.prototype.updateActivePanel = function (panel) {
+        var activePanel = this._panels[this._activePanelId];
 
+        activePanel.panelContainer.empty();
+        activePanel.instance = panel;
+        activePanel.panelContainer.append(panel.$pEl);
+        panel.afterAppend();
+
+        WebGMEGlobal.PanelManager.setActivePanel(panel);
         //make sure that read-only info is passed down to the actual panels
         this.onReadOnlyChanged(this._readOnly);
 
         this._updateUI();
     };
 
-    SplitPanel.prototype.deletePanel = function (container) {
-        if (container === 'p1') {
-            this._panel1Container.empty();
-            this._panel1 = undefined;
-            this._setActivePanel(1);
+    SplitPanel.prototype.addPanel = function (vertical) {
+        var panelContainer = $('<div/>', {class: PANEL_CONTAINER_CLASS}),
+            activePanelPos,
+            newPanelId,
+            splitterId,
+            splitterEl;
+
+        this._panelIdCounter += 1;
+
+        newPanelId = '' + this._panelIdCounter;
+        panelContainer.data(PANEL_ID_DATA_KEY, newPanelId);
+        this.$el.append(panelContainer);
+        this._panels[newPanelId] = {
+            panelContainer: panelContainer,
+            instance: null,
+            splitters: {
+                // Initially set splitters to same as panel splitting from.
+                top: this._panels[this._activePanelId].splitters.top,
+                right: this._panels[this._activePanelId].splitters.right,
+                bottom: this._panels[this._activePanelId].splitters.bottom,
+                left: this._panels[this._activePanelId].splitters.left
+            },
+            currentSplitter: null
+        };
+
+        splitterId = this._activePanelId + '_' + newPanelId;
+        splitterEl = $('<div/>', {class: SPLITTER_CLASS});
+        splitterEl.data(SPLITTER_ID_DATA_KEY, splitterId);
+        this.$el.append(splitterEl);
+
+        this._splitters[splitterId] = {
+            vertical: !!vertical,
+            el: splitterEl,
+            relPos: 0.5,
+            x1: 0,
+            y1: 0,
+            x2: 0,
+            y2: 0
+        };
+
+        this._panels[newPanelId].currentSplitter = splitterId;
+        this._panels[this._activePanelId].currentSplitter = splitterId;
+
+        // top: 0
+        // left: 0
+        // width: 0
+        // height: 0
+        activePanelPos = this._panels[this._activePanelId].panelContainer.position();
+        activePanelPos.width = this._panels[this._activePanelId].panelContainer.width();
+        activePanelPos.heigth = this._panels[this._activePanelId].panelContainer.height();
+
+        // Based on the splitting direction - update the splitters for the new and the active panel.
+        if (vertical) {
+            splitterEl.addClass('vertical');
+            this._panels[newPanelId].splitters.left = splitterId;
+            this._panels[this._activePanelId].splitters.right = splitterId;
+
+            this._splitters[splitterId].x1 = this._splitters[splitterId].x2 = activePanelPos.left +
+                activePanelPos.width * 0.5;
+
+            this._splitters[splitterId].y1 = activePanelPos.top;
+            this._splitters[splitterId].y2 = activePanelPos.top + activePanelPos.heigth;
+
+            splitterEl.css({
+                width: SPLITTER_SIZE,
+                height: this._splitters[splitterId].y2 - this._splitters[splitterId].y1,
+                top: this._splitters[splitterId].y1,
+                left: this._splitters[splitterId].x1
+            });
         } else {
-            this._panel2Container.empty();
-            this._panel2 = undefined;
-            this._setActivePanel(0);
+            splitterEl.addClass('horizontal');
+            this._panels[newPanelId].splitters.top = splitterId;
+            this._panels[this._activePanelId].splitters.bottom = splitterId;
+
+            this._splitters[splitterId].y1 = this._splitters[splitterId].y2 = activePanelPos.top +
+                activePanelPos.heigth * 0.5;
+
+            this._splitters[splitterId].x1 = activePanelPos.left;
+            this._splitters[splitterId].x2 = activePanelPos.left + activePanelPos.width;
+
+            splitterEl.css({
+                width: this._splitters[splitterId].x2 - this._splitters[splitterId].x1,
+                height: SPLITTER_SIZE,
+                top: this._splitters[splitterId].y1,
+                left: this._splitters[splitterId].x1
+            });
+        }
+
+
+        this._activePanelId = newPanelId;
+        WebGMEGlobal.PanelManager.setActivePanel(null);
+        // Awaiting a call to updateActivePanel
+    };
+
+    SplitPanel.prototype.deletePanel = function () {
+        var activePanel = this._panels[this._activePanelId],
+            removedSplitterId = activePanel.currentSplitter,
+            newActivePanelId,
+            shiftSplitterType,
+            panelIds,
+            splitter,
+            i;
+
+        ASSERT(removedSplitterId, 'Panel did not have a currentSplitter');
+
+        splitter = this._splitters[removedSplitterId];
+        activePanel.panelContainer.remove();
+        delete this._panels[this._activePanelId];
+
+        splitter.el.remove();
+        delete this._splitters[removedSplitterId];
+
+        if (splitter.vertical) {
+            if (activePanel.splitters.left === removedSplitterId) {
+                shiftSplitterType = 'right';
+            } else if (activePanel.splitters.right === removedSplitterId) {
+                shiftSplitterType = 'left';
+            } else {
+                throw new Error('Mismatch in vertical splitters during remove!');
+            }
+        } else {
+            if (activePanel.splitters.top === removedSplitterId) {
+                shiftSplitterType = 'bottom';
+            } else if (activePanel.splitters.bottom === removedSplitterId) {
+                shiftSplitterType = 'top';
+            } else {
+                throw new Error('Mismatch in horizontal splitters during remove!');
+            }
+        }
+
+        // The shift has been determined - go through all panels and shift their splitters.
+        panelIds = Object.keys(this._panels);
+
+        for (i = 0; i < panelIds.length; i += 1) {
+            if (this._panels[panelIds[i]].splitters[shiftSplitterType] === removedSplitterId) {
+                this._panels[panelIds[i]].splitters[shiftSplitterType] = activePanel.splitters[shiftSplitterType];
+
+                // If the panel lost its current splitter we need to assign a new one.
+                if (this._panels[panelIds[i]].currentSplitter === removedSplitterId) {
+                    this._panels[panelIds[i]].currentSplitter = this._getNewCurrentSplitter(this._panels[panelIds[i]]);
+                    newActivePanelId = panelIds[i];
+                }
+            }
+        }
+
+        // If no panel shared the current splitter - a random panel will become the active one.
+        this._activePanelId = newActivePanelId ? newActivePanelId : panelIds[0];
+
+        if (this._activePanelId) {
+            WebGMEGlobal.PanelManager.setActivePanel(this._panels[this._activePanelId].instance);
+        } else {
+            this.logger.error('Deleted last panel..');
         }
 
         this._updateUI();
     };
 
+    SplitPanel.prototype.deleteAllPanels = function () {
+        var panelIds = Object.keys(this._panels),
+            splitterIds = Object.keys(this._splitters),
+            i;
+
+        for (i = 0; i < splitterIds.length; i += 1) {
+            this._splitters[splitterIds[i]].el.remove();
+            delete this._splitters[splitterIds[i]];
+        }
+
+        for (i = 0; i < panelIds.length; i += 1) {
+            if (panelIds[i] === this._activePanelId) {
+                this._panels[panelIds[i]].splitters.top = null;
+                this._panels[panelIds[i]].splitters.left = null;
+                this._panels[panelIds[i]].splitters.bottom = null;
+                this._panels[panelIds[i]].splitters.right = null;
+                this._panels[panelIds[i]].currentSplitter = null;
+            } else {
+                this._panels[panelIds[i]].instance.destroy();
+                this._panels[panelIds[i]].panelContainer.remove();
+                delete this._panels[panelIds[i]];
+            }
+        }
+
+        this._updateUI();
+    };
+
+    SplitPanel.prototype.getNumberOfPanels = function () {
+        return Object.keys(this._panels).length;
+    };
+
+    SplitPanel.prototype.canSplitActivePanel = function (vertical) {
+        var splitters,
+            min,
+            max;
+
+        if (typeof this._activePanelId !== 'string') {
+            return false;
+        }
+
+        splitters = this._panels[this._activePanelId].splitters;
+
+        if (vertical) {
+            min = splitters.left ? this._splitters[splitters.left].x1 : 0;
+            max = splitters.right ? this._splitters[splitters.right].x1 : this._width;
+        } else {
+            min = splitters.top ? this._splitters[splitters.top].y1 : 0;
+            max = splitters.bottom ? this._splitters[splitters.bottom].y1 : this._height;
+        }
+
+        return (max - min) > (MINIMUM_PANEL_SIZE * 2 + SPLITTER_SIZE);
+    };
+
+    SplitPanel.prototype._getNewCurrentSplitter = function (p) {
+        var MARGIN = 2,
+            top = p.splitters.top && {
+                    x1: this._splitters[p.splitters.top].x1,
+                    x2: this._splitters[p.splitters.top].x2,
+                    y: this._splitters[p.splitters.top].y1,
+                    id: p.splitters.top
+                },
+            bottom = p.splitters.bottom && {
+                    x1: this._splitters[p.splitters.bottom].x1,
+                    x2: this._splitters[p.splitters.bottom].x2,
+                    y: this._splitters[p.splitters.bottom].y1,
+                    id: p.splitters.bottom
+                },
+            left = p.splitters.left && {
+                    y1: this._splitters[p.splitters.left].y1,
+                    y2: this._splitters[p.splitters.left].y2,
+                    x: this._splitters[p.splitters.left].x1,
+                    id: p.splitters.left
+                },
+            right = p.splitters.right && {
+                    y1: this._splitters[p.splitters.right].y1,
+                    y2: this._splitters[p.splitters.right].y2,
+                    x: this._splitters[p.splitters.right].x,
+                    id: p.splitters.right
+                },
+            candidate;
+
+        function eq(a, b) {
+            return (a >= b - MARGIN) && (a <= b + MARGIN);
+        }
+
+        // Find the first splitter that isn't intersected by any of the other splitters.
+
+        function verticalCheck(vertical) {
+            if (!vertical) {
+                return null;
+            }
+
+            if (top) {
+                if (bottom) {
+                    if (eq(top.y, vertical.y1) && eq(bottom.y, vertical.y2)) {
+                        //
+                        // ----------------- top y
+                        //   |         |y1
+                        //   |         |
+                        //   |         |y2
+                        //------------------ bottom y
+                        return vertical.id;
+                    }
+                } else if (eq(top.y, vertical.y1)){
+                    return vertical.id;
+                }
+            } else if (bottom) {
+                if (eq(bottom.y, vertical.y2)) {
+                    return vertical.id;
+                }
+            } else {
+                return vertical.id;
+            }
+
+            return null;
+        }
+
+        function horizontalCheck(horizontal) {
+            if (!horizontal) {
+                return null;
+            }
+
+            if (left) {
+                if (right) {
+                    if (eq(left.x, horizontal.x1) && eq(right.x, horizontal.x2)) {
+                        // left x      right x
+                        //   |          |
+                        //   |----------|
+                        //   |x1      x2|
+                        //   |          |
+                        //   |----------|
+                        //   |          |
+                        return horizontal.id;
+                    }
+                } else if (eq(left.x, horizontal.x1)){
+                    return horizontal.id;
+                }
+            } else if (right) {
+                if (eq(right.x, horizontal.x2)) {
+                    return horizontal.id;
+                }
+            } else {
+                return horizontal.id;
+            }
+
+            return null;
+        }
+
+        candidate = verticalCheck(left);
+        if (candidate) {
+            return candidate;
+        }
+
+        candidate = verticalCheck(right);
+        if (candidate) {
+            return candidate;
+        }
+
+        candidate = horizontalCheck(top);
+        if (candidate) {
+            return candidate;
+        }
+
+        candidate = horizontalCheck(bottom);
+        if (candidate) {
+            return candidate;
+        }
+
+        ASSERT(!(left || right || top || bottom), 'Should have found new currentSplitter');
+
+        return null;
+    };
+
+    SplitPanel.prototype._getSplitterBoundary = function (splitterId) {
+        var self = this,
+            maxVal = this._splitters[splitterId].vertical ? this._width : this._height,
+            minVal = 0;
+
+        Object.keys(this._panels).forEach(function (pId) {
+            var candidateVal;
+            if (self._splitters[splitterId].vertical) {
+                if (self._panels[pId].splitters.left === splitterId && self._panels[pId].splitters.right) {
+                    candidateVal = self._splitters[self._panels[pId].splitters.right].x1;
+
+                    maxVal = candidateVal < maxVal ? candidateVal : maxVal;
+                }
+
+                if (self._panels[pId].splitters.right === splitterId && self._panels[pId].splitters.left) {
+                    candidateVal = self._splitters[self._panels[pId].splitters.left].x1;
+
+                    minVal = candidateVal > minVal ? candidateVal : minVal;
+                }
+            } else {
+                // horizontal splitter
+                if (self._panels[pId].splitters.top === splitterId && self._panels[pId].splitters.bottom) {
+                    candidateVal = self._splitters[self._panels[pId].splitters.bottom].y1;
+
+                    maxVal = candidateVal < maxVal ? candidateVal : maxVal;
+                }
+
+                if (self._panels[pId].splitters.bottom === splitterId && self._panels[pId].splitters.top) {
+                    candidateVal = self._splitters[self._panels[pId].splitters.top].y1;
+
+                    minVal = candidateVal > minVal ? candidateVal : minVal;
+                }
+            }
+        });
+
+        return {
+            min: minVal,
+            max: maxVal
+        };
+    };
+
+    SplitPanel.prototype._harmonizeSplitters = function () {
+        // TODO: This should make sure that all splitters fill up the canvas exactly.
+        // TODO: When we support loading of stored configurations this needs to be implemented.
+    };
+
+    SplitPanel.prototype._updateUI = function () {
+        var self = this,
+            panelIds = Object.keys(this._panels),
+            splitterIds = Object.keys(this._splitters),
+            newVertPos = {},
+            newHorzPos = {},
+            panel,
+            panelPos,
+            splitter,
+            splitterBoundary,
+            x1,
+            y1,
+            x2,
+            y2,
+            i;
+
+        function updateVerticalPositions(splitterId, panelPos) {
+            newVertPos[splitterId] = newVertPos[splitterId] || {y1: self._height, y2: 0};
+            newVertPos[splitterId].y1 = panelPos.top < newVertPos[splitterId].y1 ?
+                panelPos.top : newVertPos[splitterId].y1;
+
+            newVertPos[splitterId].y2 = panelPos.top + panelPos.height > newVertPos[splitterId].y2 ?
+            panelPos.top + panelPos.height : newVertPos[splitterId].y2;
+        }
+
+        function updateHorizontalPositions(splitterId, panelPos) {
+            newHorzPos[splitterId] = newHorzPos[splitterId] || {x1: self._width, x2: 0};
+            newHorzPos[splitterId].x1 = panelPos.left < newHorzPos[splitterId].x1 ?
+                panelPos.left : newHorzPos[splitterId].x1;
+
+            newHorzPos[splitterId].x2 = panelPos.left + panelPos.width > newHorzPos[splitterId].x2 ?
+            panelPos.left + panelPos.width : newHorzPos[splitterId].x2;
+        }
+
+        // Update all panels sizes based on splitter positions.
+        for (i = 0; i < panelIds.length; i += 1) {
+            panel = this._panels[panelIds[i]];
+            x1 = panel.splitters.left ? this._splitters[panel.splitters.left].x1 : 0;
+            y1 = panel.splitters.top ? this._splitters[panel.splitters.top].y1 : 0;
+
+            x2 = panel.splitters.right ? this._splitters[panel.splitters.right].x1 : this._width;
+            y2 = panel.splitters.bottom ? this._splitters[panel.splitters.bottom].y1 : this._height;
+
+            panel.panelContainer.css({
+                width: x2 - x1,
+                height: y2 - y1,
+                top: y1,
+                left: x1
+            });
+
+            if (panel.instance) {
+                panel.instance.setSize(x2 - x1, y2 - y1);
+            }
+        }
+
+        // Determine lengths of splitters.
+        for (i = 0; i < panelIds.length; i += 1) {
+            panel = this._panels[panelIds[i]];
+            panelPos = panel.panelContainer.position();
+            panelPos.height = panel.panelContainer.height();
+            panelPos.width = panel.panelContainer.width();
+
+            if (panel.splitters.left) {
+                updateVerticalPositions(panel.splitters.left, panelPos);
+            }
+
+            if (panel.splitters.right) {
+                updateVerticalPositions(panel.splitters.right, panelPos);
+            }
+
+            if (panel.splitters.top) {
+                updateHorizontalPositions(panel.splitters.top, panelPos);
+            }
+
+            if (panel.splitters.bottom) {
+                updateHorizontalPositions(panel.splitters.bottom, panelPos);
+            }
+        }
+
+        // Update the length and relPos of the splitters.
+        for (i = 0; i < splitterIds.length; i += 1) {
+            splitter = this._splitters[splitterIds[i]];
+            splitterBoundary = this._getSplitterBoundary(splitterIds[i]);
+
+            if (splitter.vertical) {
+                splitter.relPos = (splitter.x1 - splitterBoundary.min) / (splitterBoundary.max - splitterBoundary.min);
+                splitter.y1 = newVertPos[splitterIds[i]].y1;
+                splitter.y2 = newVertPos[splitterIds[i]].y2;
+                splitter.el.css({
+                    top: splitter.y1,
+                    height: splitter.y2 - splitter.y1
+                });
+            } else {
+                splitter.relPos = (splitter.y1 - splitterBoundary.min) / (splitterBoundary.max - splitterBoundary.min);
+                splitter.x1 = newHorzPos[splitterIds[i]].x1;
+                splitter.x2 = newHorzPos[splitterIds[i]].x2;
+                splitter.el.css({
+                    left: splitter.x1,
+                    width: splitter.x2 - splitter.x1
+                });
+            }
+        }
+    };
+
     /* OVERRIDE FROM WIDGET-WITH-HEADER */
     /* METHOD CALLED WHEN THE WIDGET'S READ-ONLY PROPERTY CHANGES */
     SplitPanel.prototype.onReadOnlyChanged = function (isReadOnly) {
+        var self = this;
         //apply parent's onReadOnlyChanged
         PanelBase.prototype.onReadOnlyChanged.call(this, isReadOnly);
 
         this._readOnly = isReadOnly;
 
-        if (this._panel1) {
-            this._panel1.onReadOnlyChanged(isReadOnly);
-        }
-
-        if (this._panel2) {
-            this._panel2.onReadOnlyChanged(isReadOnly);
-        }
+        Object.keys(this._panels).forEach(function (panelId) {
+            self._panels[panelId].instance.onReadOnlyChanged(isReadOnly);
+        });
     };
 
-    SplitPanel.prototype._setActivePanel = function (p) {
-        if (p === 0) {
-            WebGMEGlobal.PanelManager.setActivePanel(this._panel1);
-        }
-
-        if (p === 1) {
-            WebGMEGlobal.PanelManager.setActivePanel(this._panel2);
-        }
-    };
-
-    SplitPanel.prototype._startPanelResize = function (event) {
+    SplitPanel.prototype.onResize = function (width, height) {
         var self = this,
-            verticalSplit = this._width > this._height;
+            widthMultiplier,
+            heightMultiplier;
 
-        this._splitterResize = this._splitter.clone().addClass(SPLITTER_RESIZE_CLASS);
+        this.logger.debug('onResize --> width: ' + width + ', height: ' + height);
+
+        width = width < MINIMUM_RESCALE_WIDTH ? MINIMUM_RESCALE_WIDTH : width;
+        height = height < MINIMUM_RESCALE_HEIGHT ? MINIMUM_RESCALE_HEIGHT : height;
+
+        widthMultiplier = width / this._width;
+        heightMultiplier = height / this._height;
+
+        this._width = width;
+        this._height = height;
+
+        this.$el.width(this._width);
+        this.$el.height(this._height);
+
+        // Update splitters sizes..
+        Object.keys(this._splitters).forEach(function (id) {
+            if (self._splitters[id].vertical) {
+                self._splitters[id].x1 = self._splitters[id].x2 = Math.floor(self._splitters[id].x1 * widthMultiplier);
+                self._splitters[id].el.css({
+                    left: self._splitters[id].x1
+                });
+            } else {
+                self._splitters[id].y1 = self._splitters[id].y2 = Math.floor(self._splitters[id].y1 * heightMultiplier);
+                self._splitters[id].el.css({
+                    top: self._splitters[id].y1
+                });
+            }
+        });
+
+        // We need to make sure that splitters sizes still apply after truncations...
+        this._harmonizeSplitters();
+
+        // .. which will update the panel size in _updateUI.
+        this._updateUI();
+    };
+
+    /*** SPLITTER POSITION UPDATES ***/
+    SplitPanel.prototype._startPanelResize = function (splitterId, event) {
+        var self = this;
+
+        this._splitterResize = this._splitters[splitterId].el.clone().addClass(SPLITTER_RESIZE_CLASS);
         this.$el.append(this._splitterResize);
 
-        this._splitterResizePos = this._splitterPos;
-        this._splitStartMousePos = verticalSplit ? event.pageX : event.pageY;
+        this._splitterResizePos = this._splitters[splitterId].relPos;
+        this._splitStartMousePos = this._splitters[splitterId].vertical ? event.pageX : event.pageY;
 
 
         $(document).on('mousemove.SplitPanel', function (event) {
-            self._onMouseMove(event);
+            self._onMouseMove(splitterId, event);
         });
         $(document).on('mouseup.SplitPanel', function (event) {
-            self._onMouseUp(event);
+            self._onMouseUp(splitterId, event);
         });
     };
 
-    SplitPanel.prototype._onMouseMove = function (event) {
-        var verticalSplit = this._width > this._height,
-            mousePos = verticalSplit ? event.pageX : event.pageY,
+    SplitPanel.prototype._onMouseMove = function (splitterId, event) {
+        var mousePos = this._splitters[splitterId].vertical ? event.pageX : event.pageY,
             mouseDelta = mousePos - this._splitStartMousePos,
-            maxVal = verticalSplit ? this._width : this._height,
-            resizeDelta = mouseDelta / maxVal,
-            snapDistance = SPLITTER_SNAP_FROM_DISTANCE / maxVal,
-            minPanelSize = MINIMUM_PANEL_SIZE / maxVal;
+            boundary = this._getSplitterBoundary(splitterId),
+            resizeDelta = mouseDelta / (boundary.max - boundary.min),
+            snapDistance = SPLITTER_SNAP_FROM_DISTANCE / (boundary.max - boundary.min),
+            minPanelSize = MINIMUM_PANEL_SIZE / (boundary.max - boundary.min);
 
-        this._splitterResizePos = this._splitterPos + resizeDelta;
+        this._splitterResizePos = this._splitters[splitterId].relPos + resizeDelta;
 
-        if (this._splitterResizePos >= 0.5 - snapDistance &&
-            this._splitterResizePos <= 0.5 + snapDistance) {
-            this._splitterResizePos = 0.5;
+        if (this._splitterResizePos >= this._splitters[splitterId].relPos - snapDistance &&
+            this._splitterResizePos <= this._splitters[splitterId].relPos + snapDistance) {
+            this._splitterResizePos = this._splitters[splitterId].relPos;
         }
 
         if (this._splitterResizePos < minPanelSize) {
@@ -284,22 +753,21 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
             this._splitterResizePos = 1 - minPanelSize;
         }
 
-        this._updateSplitterResize();
+        this._updateSplitterResize(splitterId, boundary.min, boundary.max);
     };
 
-    SplitPanel.prototype._updateSplitterResize = function () {
-        var verticalSplit = this._width > this._height,
-            sw = SPLITTER_SIZE + 2 * SPLITTER_RESIZE_PADDING,
+    SplitPanel.prototype._updateSplitterResize = function (splitterId, minVal, maxVal) {
+        var sw = SPLITTER_SIZE + 2 * SPLITTER_RESIZE_PADDING,
             sh = SPLITTER_SIZE + 2 * SPLITTER_RESIZE_PADDING,
             splitterLeft,
             splitterTop;
 
-        if (verticalSplit) {
-            sh = this._height;
-            splitterLeft = Math.floor((this._width - sw) * this._splitterResizePos);
+        if (this._splitters[splitterId].vertical) {
+            sh = this._splitters[splitterId].y2 - this._splitters[splitterId].y1;
+            splitterLeft = Math.floor(minVal + (maxVal - minVal - sw) * this._splitterResizePos);
         } else {
-            sw = this._width;
-            splitterTop = Math.floor((this._height - sh) * this._splitterResizePos);
+            sw = this._splitters[splitterId].x2 - this._splitters[splitterId].x1;
+            splitterTop = Math.floor(minVal + (maxVal - minVal - sh) * this._splitterResizePos);
         }
 
         this._splitterResize.css({
@@ -310,11 +778,25 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
         });
     };
 
-    SplitPanel.prototype._onMouseUp = function (event) {
+    SplitPanel.prototype._onMouseUp = function (splitterId /*, event*/) {
         $(document).off('mousemove.SplitPanel');
         $(document).off('mouseup.SplitPanel');
 
-        this._splitterPos = this._splitterResizePos;
+        var pos = this._splitterResize.position();
+
+        this._splitters[splitterId].relPos = this._splitterResizePos;
+
+        if (this._splitters[splitterId].vertical) {
+            this._splitters[splitterId].x1 = this._splitters[splitterId].x2 = pos.left;
+            this._splitters[splitterId].el.css({
+                left: pos.left
+            });
+        } else {
+            this._splitters[splitterId].y1 = this._splitters[splitterId].y2 = pos.top;
+            this._splitters[splitterId].el.css({
+                top: pos.top
+            });
+        }
 
         this._splitterResize.remove();
         this._splitterResize = undefined;
@@ -325,4 +807,3 @@ define(['js/PanelBase/PanelBase', 'css!./styles/SplitPanel.css'], function (Pane
 
     return SplitPanel;
 });
-

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
@@ -3,28 +3,32 @@
  * 
  * Author: Robert Kereskenyi
  */
+ul.split-panel-dropdown-list {
+  min-width: 205px; }
+  ul.split-panel-dropdown-list a.dropdown-list-button {
+    padding-left: 10px; }
+    ul.split-panel-dropdown-list a.dropdown-list-button .split-panel-dropdown-icon {
+      float: left;
+      margin-right: 8px;
+      margin-top: 2px; }
+
 .split-panel {
   position: absolute;
   top: 0;
   left: 0;
   margin: 0; }
-  .split-panel .p1,
-  .split-panel .p2 {
+  .split-panel .split-panel-panel-container {
     position: absolute;
     overflow: hidden; }
   .split-panel .splitter {
     z-index: 1000;
-    background: #DDD;
-    border: 0x solid #BBB;
     position: absolute;
     box-sizing: border-box; }
     .split-panel .splitter.vertical {
-      border-left-width: 1px;
-      border-right-width: 1px;
+      border-left: #DDD solid 2px;
       cursor: ew-resize; }
     .split-panel .splitter.horizontal {
-      border-top-width: 1px;
-      border-bottom-width: 1px;
+      border-top: #DDD solid 2px;
       cursor: ns-resize; }
     .split-panel .splitter.resize {
       background-color: #C4E1A4; }

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
@@ -3,6 +3,18 @@
  * 
  * Author: Robert Kereskenyi
  */
+ul.split-panel-dropdown-list {
+  min-width: 205px;
+  a.dropdown-list-button {
+    padding-left: 10px;
+    .split-panel-dropdown-icon {
+      float: left;
+      margin-right: 8px;
+      margin-top: 2px;
+    }
+  }
+}
+
 
 .split-panel {
   //background-color: #FF0000;
@@ -11,28 +23,25 @@
   left: 0;
   margin: 0;
 
-  .p1,
-  .p2 {
+  .split-panel-panel-container {
     position: absolute;
     overflow: hidden;
   }
 
   .splitter {
     z-index: 1000;
-    background: #DDD;
-    border: 0 solid #BBB;
+    //background: #DDD;
+    //border: 0 solid #BBB;
     position: absolute;
     box-sizing: border-box;
 
     &.vertical {
-      border-left-width: 1px;
-      border-right-width: 1px;
+      border-left: #DDD solid 2px;
       cursor: ew-resize;
     }
 
     &.horizontal {
-      border-top-width: 1px;
-      border-bottom-width: 1px;
+      border-top: #DDD solid 2px;
       cursor: ns-resize;
     }
 

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -4,6 +4,7 @@
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
  * @author nabana / https://github.com/nabana
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 define(['js/logger',
@@ -37,15 +38,52 @@ define(['js/logger',
         this._client = params.client;
         this._layoutManager = layoutManager;
 
-        //initialize UI
-        this._initialize();
-
-        this._activePanel = {};
-        this._activeVisualizer = {};
-        this._currentNodeID = null;
+        /**
+         *
+         * @example
+         * {
+         *  ModelEditor: {
+         *      id: "ModelEditor",
+         *      panel: ModelEditorPanel constructor
+         *  },
+         *  MetaEditor: {
+         *      id: "MetaEditor",
+         *      panel: MetaEditorPanel constructor
+         *  },
+         *  ...
+         * }
+         * @private
+         */
         this._visualizers = {};
-        this._validVisualizers = null;
-        this.defaultVisualizer = null;
+
+        /**
+         * @example
+         * "ModelEditor"
+         * @private
+         */
+        this.defaultVisualizerId = null;
+
+        /**
+         * @example
+         * "MetaEditor"
+         * @private
+         */
+        this._activeVisualizerId = null;
+
+        this._activeNodeID = null;
+
+        /**
+         *
+         * @example
+         * ["ModelEditor", "MetaEditor", ...]
+         * @private
+         */
+        this._validVisualizerIds = null;
+
+
+        //initialize UI
+
+        this._initialize();
 
         this._loadVisualizers();
 
@@ -54,6 +92,279 @@ define(['js/logger',
 
     //inherit from PanelBaseWithHeader
     _.extend(VisualizerPanel.prototype, PanelBaseWithHeader.prototype);
+
+    VisualizerPanel.prototype._initialize = function () {
+        var self = this,
+            toolbar = WebGMEGlobal.Toolbar;
+
+        //set Widget title
+        this.setTitle('Visualizer');
+
+        this.$el.addClass('visualizer-panel');
+
+        //add toolbar controls
+        toolbar.addSeparator();
+
+        this._toolbarBtn = toolbar.addDropDownButton({
+            title: 'Split Panels',
+            icon: 'gme icon-gme_split-panels',
+            menuClass: 'split-panel-dropdown-list',
+            clickFn: function () {
+                self._toolbarBtn.clear();
+
+                self._toolbarBtn.addButton({
+                    text: 'Split vertically',
+                    title: 'Splits the active panel vertically',
+                    icon: 'fa fa-columns split-panel-dropdown-icon',
+                    clickFn: function () {
+                        self._addNewPanel(true);
+                    }
+                });
+
+                self._toolbarBtn.addButton({
+                    text: 'Split horizontally',
+                    title: 'Splits the active panel horizontally',
+                    icon: 'fa fa-columns fa-rotate-270 split-panel-dropdown-icon',
+                    clickFn: function () {
+                        self._addNewPanel();
+                    }
+                });
+
+                self._toolbarBtn.addDivider();
+
+                self._toolbarBtn.addButton({
+                    text: 'Remove active panel',
+                    title: 'Removes the active panel',
+                    icon: 'fa fa-minus-circle split-panel-dropdown-icon',
+                    clickFn: function () {
+                        self._deletePanel();
+                    }
+                });
+
+                self._toolbarBtn.addButton({
+                    text: 'Exit split mode',
+                    title: 'Remove all but the active panel',
+                    icon: 'fa fa-times-circle split-panel-dropdown-icon',
+                    clickFn: function () {
+                        self._exitSplitMode();
+                    }
+                });
+            }
+        });
+
+        this._panelVisContainer = $('<div/>');
+        this._panelVisContainer.append($('<div class="pp">Visualizer Selector</div>'));
+        this._ul = $('<ul class="nav nav-pills nav-stacked">');
+
+        this._panelVisContainer.append(this._ul);
+
+        this.$el.append(this._panelVisContainer);
+
+        this.$el.on('click', 'ul > li:not(.active)', function (event) {
+            var vizId = $(this).attr('data-id');
+
+            self._setActiveVisualizer(vizId);
+            event.stopPropagation();
+            event.preventDefault();
+        });
+
+        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_OBJECT, function (model, activeObjectId, opts) {
+            if (opts.invoker !== self) {
+                self._onSelectedObjectChanged(activeObjectId, opts);
+            }
+        });
+
+        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_CLOSED, function (/* __project, nodeId */) {
+            self._validVisualizerIds = null;
+            self._exitSplitMode(true);
+        });
+
+        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_OPENED, function (/* __project, nodeId */) {
+            self._validVisualizerIds = null;
+            self._exitSplitMode(true);
+        });
+
+        this._client.addEventListener(CONSTANTS.CLIENT.BRANCH_CHANGED, function (/* __project, nodeId */) {
+            self._validVisualizerIds = null;
+            self._exitSplitMode(true);
+        });
+
+        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_VISUALIZER, function (model, activeVisualizer, opts) {
+            var keepPrevPanelInstance = opts.invoker === self || opts.invoker === WebGMEGlobal.PanelManager;
+            self._setActiveVisualizer(activeVisualizer, keepPrevPanelInstance);
+        });
+
+        this._splitPanel = new SplitPanel();
+        this._layoutManager.addPanel('visualizerSplitPanel', this._splitPanel, 'center');
+    };
+
+    VisualizerPanel.prototype._onSelectedObjectChanged = function (currentNodeId, opts) {
+        this._activeNodeID = currentNodeId;
+        this._updateValidVisualizers(currentNodeId);
+        this._updateListedVisualizers(!opts.suppressVisualizerFromNode);
+    };
+
+    VisualizerPanel.prototype._setActiveVisualizer = function (visualizerId, keepPrevPanelInstance) {
+        var PanelClass,
+            activePanel;
+
+        if (this._activeVisualizerId !== visualizerId && this._visualizers.hasOwnProperty(visualizerId)) {
+            this._activeVisualizerId = visualizerId;
+
+            this._ul.find('> li').removeClass('active');
+            this._ul.find('> li[data-id="' + visualizerId + '"]').addClass('active');
+
+            if (keepPrevPanelInstance) {
+                return;
+            }
+
+            // Destroy the previous visualizer.
+            activePanel = WebGMEGlobal.PanelManager.getActivePanel();
+
+            if (activePanel) {
+                activePanel.destroy();
+            }
+
+            if (this._visualizers[visualizerId]) {
+                PanelClass = this._visualizers[visualizerId].panel;
+                if (PanelClass) {
+                    activePanel = new PanelClass(this._layoutManager, {client: this._client});
+                    activePanel[CONSTANTS.VISUALIZER_PANEL_IDENTIFIER] = this._visualizers[visualizerId].id;
+                    this._splitPanel.updateActivePanel(activePanel);
+                    // The new panel is activated and should be listening to state events of interest..
+                }
+
+                if (typeof this._activeNodeID === 'string') {
+                    // ...so trigger an event about the active-object to get it started.
+
+                    // First set the state to null silently so even the same object will trigger an event.
+                    WebGMEGlobal.State.registerActiveObject(null, {silent: true});
+                    WebGMEGlobal.State.registerActiveObject(this._activeNodeID, {invoker: this});
+                }
+            }
+
+            WebGMEGlobal.State.registerActiveVisualizer(visualizerId, {invoker: this});
+        }
+    };
+
+    VisualizerPanel.prototype._updateValidVisualizers = function (currentNodeId) {
+        var node,
+            validVisuals;
+        // Update the validVisualizers
+        if (typeof currentNodeId === 'string') {
+            node = this._client.getNode(currentNodeId);
+            if (node) {
+                validVisuals = node.getRegistry(REGISTRY_KEYS.VALID_VISUALIZERS);
+                if (validVisuals) {
+                    this._validVisualizerIds = validVisuals.split(' ');
+
+                    return;
+                }
+            } else {
+                this.logger.error('could not load node in _updateValidVisualizers', currentNodeId);
+            }
+        } else {
+            this.logger.debug('nodePath not given');
+        }
+
+        // Fall back on null -> all visualizers displayed
+        this._validVisualizerIds = null;
+    };
+
+    VisualizerPanel.prototype._updateListedVisualizers = function (setActiveViz) {
+        var self = this,
+            currentNode = self._client.getNode(self._activeNodeID),
+            idToElem = {},
+            visualizerToSet,
+            i,
+            vizId,
+            libraryRoot = false;
+
+        function isAvailable(visualizerId) {
+            var i;
+
+            for (i = 0; i < VisualizersJSON.length; i += 1) {
+                if (visualizerId === VisualizersJSON[i].id) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (currentNode) {
+            libraryRoot = currentNode.isLibraryRoot();
+        }
+
+        // For the active panel hide/show listed visualizers
+        self._ul.children('li').each(function (index, _li) {
+            var li = $(_li),
+                id = li.attr('data-id');
+            if (self._validVisualizerIds === null) {
+                // By default fall back on showing all loaded visualizers.
+                if (libraryRoot && id === 'SetEditor') {
+                    li.hide();
+                } else {
+                    li.show();
+                }
+            } else {
+                if (self._validVisualizerIds.indexOf(id) > -1 && (!libraryRoot || (libraryRoot && id !== 'SetEditor'))) {
+                    li.show();
+                } else {
+                    li.hide();
+                }
+
+                idToElem[id] = li.detach();
+            }
+        });
+
+        if (self._validVisualizerIds !== null) {
+            // Reinsert the detached li-elements based on the specified order.
+            for (i = 0; i < self._validVisualizerIds.length; i += 1) {
+                vizId = self._validVisualizerIds[i];
+                if (idToElem.hasOwnProperty(vizId)) {
+                    self._ul.append(idToElem[vizId]);
+                    idToElem[vizId] = null;
+                }
+            }
+
+            // Finally append the hidden elements too.
+            for (vizId in idToElem) {
+                if (idToElem[vizId] !== null) {
+                    self._ul.append(idToElem[vizId]);
+                }
+            }
+        }
+
+        this.updateContainerSize();
+
+        if (self._validVisualizerIds) {
+            visualizerToSet = self._validVisualizerIds[0];
+            if (!isAvailable(visualizerToSet)) {
+                //fallback to the global default
+                visualizerToSet = self.defaultVisualizerId.id;
+            }
+        } else {
+            // Set this to the global default if it is valid for the project
+            visualizerToSet = self.defaultVisualizerId.id;
+        }
+
+        if (!isAvailable(visualizerToSet)) {
+            if (isAvailable(CONSTANTS.DEFAULT_VISUALIZER)) {
+                //fall back to model editor if nothing else works
+                visualizerToSet = CONSTANTS.DEFAULT_VISUALIZER;
+            } else {
+                visualizerToSet = null;
+            }
+        }
+
+        // Only set the visualizer only if we were able to select some valid one.
+        if (setActiveViz && visualizerToSet) {
+            setTimeout(function () {
+                self._setActiveVisualizer(visualizerToSet);
+            }, 0);
+        }
+    };
 
     VisualizerPanel.prototype._isAvailableVisualizer = function (visualizerId) {
         var i;
@@ -66,72 +377,6 @@ define(['js/logger',
         return false;
     };
 
-    VisualizerPanel.prototype._initialize = function () {
-        var self = this,
-            toolbar = WebGMEGlobal.Toolbar,
-            btnIconBase = $('<i/>');
-
-        //set Widget title
-        this.setTitle('Visualizer');
-
-        this.$el.addClass('visualizer-panel');
-
-        //add toolbar controls
-        toolbar.addSeparator();
-
-        toolbar.addToggleButton({
-            title: 'Split view ON/OFF',
-            icon: btnIconBase.clone().addClass('gme icon-gme_split-panels'),
-            clickFn: function (data, toggled) {
-                self._p2Editor(toggled);
-            }
-        });
-
-        this._panel1VisContainer = $('<div/>');
-        this._ul1 = $('<ul class="nav nav-pills nav-stacked">');
-        this._ul1.attr('data-id', 'p1');
-        this._panel1VisContainer.append($('<div class="pp">Panel 1:</div>'));
-        this._panel1VisContainer.append(this._ul1);
-
-        this.$el.append(this._panel1VisContainer);
-
-        this.$el.on('click', 'ul > li:not(.active)', function (event) {
-            var vis = $(this).attr('data-id'),
-                ul = $(this).parent();
-            self._setActiveVisualizer(vis, ul);
-            event.stopPropagation();
-            event.preventDefault();
-        });
-
-        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_OBJECT, function (model, activeObjectId, opts) {
-            self.selectedObjectChanged(activeObjectId, opts);
-        });
-
-        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_CLOSED, function (/* __project, nodeId */) {
-            self._p2Editor(false);
-            self._validVisualizers = null;
-        });
-
-        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_OPENED, function (/* __project, nodeId */) {
-            self._p2Editor(false);
-            self._validVisualizers = null;
-        });
-
-        this._client.addEventListener(CONSTANTS.CLIENT.BRANCH_CHANGED, function (/* __project, nodeId */) {
-            self._p2Editor(false);
-            self._validVisualizers = null;
-        });
-
-        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_VISUALIZER, function (model, activeVisualizer, opts) {
-            if (opts.invoker !== self) {
-                self.setActiveVisualizer(activeVisualizer);
-            }
-        });
-
-        this._splitPanel = new SplitPanel();
-        this._layoutManager.addPanel('visualizerSplitPanel', this._splitPanel, 'center');
-    };
-
     VisualizerPanel.prototype._loadVisualizers = function () {
         var self = this,
             defaultFromConst;
@@ -139,7 +384,7 @@ define(['js/logger',
         // Set the default visualizer
         for (var i = VisualizersJSON.length; i--;) {
             if (VisualizersJSON[i].default) {
-                self.defaultVisualizer = VisualizersJSON[i];
+                self.defaultVisualizerId = VisualizersJSON[i];
             }
 
             // If no default given - use the one from constants.
@@ -148,166 +393,11 @@ define(['js/logger',
             }
         }
 
-        self.defaultVisualizer  = self.defaultVisualizer || defaultFromConst;
+        self.defaultVisualizerId = self.defaultVisualizerId || defaultFromConst;
 
         this.addRange(VisualizersJSON, function () {
-            self._setActiveVisualizer(self.defaultVisualizer.id, self._ul1);
+            self._setActiveVisualizer(self.defaultVisualizerId.id);
         });
-    };
-
-    VisualizerPanel.prototype._setActiveVisualizer = function (visualizer, ul) {
-        var PanelClass,
-            panel = ul.attr('data-id');
-
-        if (this._activeVisualizer[panel] !== visualizer && this._visualizers.hasOwnProperty(visualizer)) {
-            //we should change the selected tab to 0 in case of visualizer change to get the 'default' behaviour
-            //WebGMEGlobal.State.registerActiveTab(0);
-            //WebGMEGlobal.State.set(CONSTANTS.STATE_ACTIVE_ASPECT, 'All');
-
-            //destroy current visualizer
-            if (this._activePanel[panel]) {
-                this._activePanel[panel].destroy();
-            }
-
-            this._activeVisualizer[panel] = visualizer;
-            ul.find('> li').removeClass('active');
-            ul.find('> li[data-id="' + visualizer + '"]').addClass('active');
-
-            this._activePanel[panel] = null;
-
-            if (this._visualizers[visualizer]) {
-                PanelClass = this._visualizers[visualizer].panel;
-                if (PanelClass) {
-                    this._activePanel[panel] = new PanelClass(this._layoutManager, {client: this._client});
-                    this._activePanel[panel][CONSTANTS.VISUALIZER_PANEL_IDENTIFIER] = this._visualizers[visualizer].id;
-                    this._splitPanel.setPanel(this._activePanel[panel], panel);
-                }
-
-                if (this._currentNodeID || this._currentNodeID === CONSTANTS.PROJECT_ROOT_ID) {
-                    if (this._activePanel[panel] && this._activePanel[panel].control &&
-                        _.isFunction(this._activePanel[panel].control.selectedObjectChanged)) {
-
-                        this._activePanel[panel].control.selectedObjectChanged(this._currentNodeID);
-                    }
-                }
-            }
-
-            WebGMEGlobal.State.registerActiveVisualizer(visualizer, {invoker: this});
-        }
-    };
-
-    VisualizerPanel.prototype._updateValidVisualizers = function (currentNodeId) {
-        var node,
-            validVisuals;
-        // Update the validVisualizers
-        if (currentNodeId || currentNodeId === CONSTANTS.PROJECT_ROOT_ID) {
-            node = this._client.getNode(currentNodeId);
-            if (node) {
-                validVisuals = node.getRegistry(REGISTRY_KEYS.VALID_VISUALIZERS);
-                if (validVisuals) {
-                    this._validVisualizers = validVisuals.split(' ');
-
-                    return;
-                }
-            } else {
-                this.logger.error('could not load node in _updateValidVisualizers', currentNodeId);
-            }
-        } else {
-            this.logger.debug('nodePath not given');
-        }
-        this._validVisualizers = null;
-    };
-
-    VisualizerPanel.prototype._getActivePanelElem = function () {
-        var panelListName = WebGMEGlobal.PanelManager.getActivePanel() === this._activePanel.p1 ? 'p1' : 'p2';
-        return panelListName === 'p1' ? this._ul1 : this._ul2;
-    };
-
-    VisualizerPanel.prototype._updateListedVisualizers = function (setActiveViz) {
-        var self = this,
-            ul = this._getActivePanelElem(),
-            currentNode = self._client.getNode(self._currentNodeID),
-            idToElem = {},
-            activeVisualizer,
-            i,
-            vizId,
-            libraryRoot = false;
-
-        if (currentNode) {
-            libraryRoot = currentNode.isLibraryRoot();
-        }
-        // For the active panel hide/show listed visualizers
-        ul.children('li').each(function (index, _li) {
-            var li = $(_li),
-                id = li.attr('data-id');
-            if (self._validVisualizers === null) {
-                // By default fall back on showing all loaded visualizers.
-                if (libraryRoot && id === 'SetEditor') {
-                    li.hide();
-                } else {
-                    li.show();
-                }
-            } else {
-                if (self._validVisualizers.indexOf(id) > -1 && (!libraryRoot || (libraryRoot && id !== 'SetEditor'))) {
-                    li.show();
-                } else {
-                    li.hide();
-                }
-
-                idToElem[id] = li.detach();
-            }
-        });
-
-        if (self._validVisualizers !== null) {
-            // Reinsert the detached li-elements based on the specified order.
-            for (i = 0; i < self._validVisualizers.length; i += 1) {
-                vizId = self._validVisualizers[i];
-                if (idToElem.hasOwnProperty(vizId)) {
-                    ul.append(idToElem[vizId]);
-                    idToElem[vizId] = null;
-                }
-            }
-
-            // Finally append the hidden elements too.
-            for (vizId in idToElem) {
-                if (idToElem[vizId] !== null) {
-                    ul.append(idToElem[vizId]);
-                }
-            }
-        }
-
-        this.updateContainerSize();
-
-        if (self._validVisualizers) {
-            activeVisualizer = self._validVisualizers[0];
-            if (!self._isAvailableVisualizer(activeVisualizer)) {
-                //fallback to the global default
-                activeVisualizer = self.defaultVisualizer.id;
-            }
-        } else {
-            // Set this to the global default if it is valid for the project
-            activeVisualizer = self.defaultVisualizer.id;
-        }
-
-        if (!self._isAvailableVisualizer(activeVisualizer)) {
-            if (self._isAvailableVisualizer(CONSTANTS.DEFAULT_VISUALIZER)) {
-                //fall back to model editor if nothing else works
-                activeVisualizer = CONSTANTS.DEFAULT_VISUALIZER;
-            } else {
-                activeVisualizer = null;
-            }
-        }
-
-        // Only set the visualizer only if we were able to select some valid one.
-        if (setActiveViz && activeVisualizer) {
-            setTimeout(function () {
-                self._setActiveVisualizer(activeVisualizer, ul);
-            }, 0);
-        }
-    };
-
-    VisualizerPanel.prototype.setActiveVisualizer = function (visualizer) {
-        this._setActiveVisualizer(visualizer, this._getActivePanelElem());
     };
 
     VisualizerPanel.prototype._removeLoader = function (li, loaderDiv) {
@@ -317,6 +407,64 @@ define(['js/logger',
             delete li.loader;
         }
         loaderDiv.remove();
+    };
+
+    VisualizerPanel.prototype._addNewPanel = function (vertical) {
+        //find the selected on
+        var activeLi = this._ul.find('li.active'),
+            visualizerId = activeLi.attr('data-id') || this.defaultVisualizerId;
+
+        if (this._splitPanel.canSplitActivePanel(vertical)) {
+            this._activeVisualizerId = null;
+
+            this._splitPanel.addPanel(vertical);
+
+            this._setActiveVisualizer(visualizerId);
+        } else {
+            this._client.notifyUser({
+                message: 'Active panel is too small to split ' + (vertical ? 'vertically' : 'horizontally') + '...',
+                severity: 'warn'
+            });
+        }
+    };
+
+    VisualizerPanel.prototype._deletePanel = function () {
+        var activePanel = WebGMEGlobal.PanelManager.getActivePanel();
+
+        if (this._splitPanel.getNumberOfPanels() > 1) {
+            if (activePanel) {
+                activePanel.destroy();
+            }
+
+            this._splitPanel.deletePanel();
+            // Split panel will register new active panel.
+        } else {
+            this._client.notifyUser({
+                message: 'You cannot remove last visualizer panel...',
+                severity: 'warn'
+            });
+        }
+    };
+
+    VisualizerPanel.prototype._exitSplitMode = function (force) {
+        var activePanel;
+
+        if (this._splitPanel.getNumberOfPanels() > 1) {
+
+            this._splitPanel.deleteAllPanels();
+
+            if (force) {
+                activePanel = WebGMEGlobal.PanelManager.getActivePanel();
+                WebGMEGlobal.PanelManager.setActivePanel(null);
+                WebGMEGlobal.PanelManager.setActivePanel(activePanel);
+                //WebGMEGlobal.State.registerActiveObject(this._activeNodeID);
+            }
+        } else if (!force) {
+            this._client.notifyUser({
+                message: 'There are no split panels..',
+                severity: 'info'
+            });
+        }
     };
 
     /**********************************************************************/
@@ -348,7 +496,7 @@ define(['js/logger',
             li.attr('data-id', menuDesc.id);
             a.text(menuDesc.title);
 
-            this._ul1.append(li);
+            this._ul.append(li);
 
             if (menuDesc.panel) {
 
@@ -402,55 +550,6 @@ define(['js/logger',
             queueLen += 1;
             this.add(menuDescList[i], callbackWrap);
         }
-    };
-
-    VisualizerPanel.prototype.selectedObjectChanged = function (currentNodeId, opts) {
-        this._currentNodeID = currentNodeId;
-        this._updateValidVisualizers(currentNodeId);
-        this._updateListedVisualizers(!opts.suppressVisualizerFromNode);
-    };
-
-    VisualizerPanel.prototype._p2Editor = function (enabled) {
-        var activeLi,
-            vis,
-            ul,
-            panel;
-
-        if (enabled) {
-            //show 2 panels
-            this._panel2VisContainer = this._panel1VisContainer.clone();
-            this._ul2 = this._panel2VisContainer.find('ul');
-            this._ul2.attr('data-id', 'p2');
-            this._panel2VisContainer.find('.pp').text('Panel 2:');
-            this.$el.append(this._panel2VisContainer);
-            //find the selected on
-            activeLi = this._panel2VisContainer.find('ul > li.active');
-            vis = activeLi.attr('data-id');
-            ul = activeLi.parent();
-            this._setActiveVisualizer(vis, ul);
-        } else {
-            //destroy current controller and visualizer
-            panel = 'p2';
-            if (this._activePanel[panel] && this._activePanel[panel].destroy) {
-                this._activePanel[panel].destroy();
-            }
-
-            this._activePanel[panel] = null;
-            this._activeVisualizer[panel] = null;
-
-            if (this._panel2VisContainer) {
-                this._panel2VisContainer.remove();
-                this._panel2VisContainer = undefined;
-                this._splitPanel.deletePanel('p2');
-                delete this._ul2;
-            }
-
-            if (typeof this._currentNodeID === 'string') {
-                WebGMEGlobal.State.registerActiveObject(this._currentNodeID);
-            }
-        }
-
-        this.updateContainerSize();
     };
 
     return VisualizerPanel;

--- a/src/common/util/assert.js
+++ b/src/common/util/assert.js
@@ -9,6 +9,11 @@
 define(function () {
     'use strict';
 
+    /**
+     * Checks given condition and throws new Error if "falsy".
+     * @param {boolean|*} cond
+     * @param {string} [msg='ASSERT failed']
+     */
     var assert = function (cond, msg) {
         if (!cond) {
             var error = new Error(msg || 'ASSERT failed');


### PR DESCRIPTION
This feature opens up possibilities to write smaller visualizers that end users can include without editing any code. Currently the state of the split panel isn't persisted - but if requested this can be added with option to store the layout for a specific project or project kind.

This PR also cleans the state handling by making sure that only the VisualizerPanel/SplitPanel registers the active panel. (The visualizers themselves should not have to deal with this.)

Closes #1361 
