### PR TITLE
Fixes #1349 Uncaught exception in GraphViz

### DIFF
--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -105,7 +105,7 @@ define(['js/logger',
 
         this._nodes = {};
 
-        if (this._currentNodeId || this._currentNodeId === CONSTANTS.PROJECT_ROOT_ID) {
+        if ((this._currentNodeId || this._currentNodeId === CONSTANTS.PROJECT_ROOT_ID) && desc) {
             //put new node's info into territory rules
             this._selfPatterns = {};
             this._selfPatterns[nodeId] = {children: 0};


### PR DESCRIPTION
Fix missing error handling when loading happens at the time when the given node is not present.