### PR TITLE
Closes #1360 navigate to parent is now owned by tree-browser.

### DIFF
--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -112,11 +112,11 @@ define(['js/logger',
 
             this._graphVizWidget.setTitle(desc.name.toUpperCase());
 
-            if (desc.parentId || desc.parentId === CONSTANTS.PROJECT_ROOT_ID) {
-                this.$btnModelHierarchyUp.show();
-            } else {
-                this.$btnModelHierarchyUp.hide();
-            }
+            // if (desc.parentId || desc.parentId === CONSTANTS.PROJECT_ROOT_ID) {
+            //     this.$btnModelHierarchyUp.show();
+            // } else {
+            //     this.$btnModelHierarchyUp.hide();
+            // }
 
             this._currentNodeParentId = desc.parentId;
 
@@ -304,15 +304,15 @@ define(['js/logger',
         this._toolbarItems.push(toolBar.addSeparator());
 
         /************** GOTO PARENT IN HIERARCHY BUTTON ****************/
-        this.$btnModelHierarchyUp = toolBar.addButton({
-            title: 'Go to parent',
-            icon: 'glyphicon glyphicon-circle-arrow-up',
-            clickFn: function (/*data*/) {
-                WebGMEGlobal.State.registerActiveObject(self._currentNodeParentId);
-            }
-        });
-        this._toolbarItems.push(this.$btnModelHierarchyUp);
-        this.$btnModelHierarchyUp.hide();
+        // this.$btnModelHierarchyUp = toolBar.addButton({
+        //     title: 'Go to parent',
+        //     icon: 'glyphicon glyphicon-circle-arrow-up',
+        //     clickFn: function (/*data*/) {
+        //         WebGMEGlobal.State.registerActiveObject(self._currentNodeParentId);
+        //     }
+        // });
+        // this._toolbarItems.push(this.$btnModelHierarchyUp);
+        // this.$btnModelHierarchyUp.hide();
         /************** END OF - GOTO PARENT IN HIERARCHY BUTTON ****************/
 
         /************** MODEL / CONNECTION filter *******************/

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -862,7 +862,6 @@ define(['js/logger',
             validConnectionTypes,
             j,
             parentID = this.currentNodeInfo.id,
-            client = this._client,
             aspect = this._selectedAspect,
             targetNode,
             p;

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.js
@@ -82,7 +82,7 @@ define(['js/logger',
         //attach all the event handlers for event's coming from DesignerCanvas
         this.attachDiagramDesignerWidgetEventHandlers();
 
-        this._updateTopNode();
+        //this._updateTopNode();
         this.logger.debug('ModelEditorControl ctor finished');
     };
 
@@ -127,7 +127,6 @@ define(['js/logger',
                 this.currentNodeInfo.parentId = desc.parentId;
             }
 
-            this._refreshBtnModelHierarchyUp();
             node = this._client.getNode(nodeId);
 
             if (this._selectedAspect !== CONSTANTS.ASPECT_ALL) {
@@ -869,15 +868,6 @@ define(['js/logger',
         this._client.removeUI(this._territoryId);
     };
 
-    ModelEditorControl.prototype._onModelHierarchyUp = function () {
-        var myId = this.currentNodeInfo.id;
-        if (this.currentNodeInfo.parentId ||
-            this.currentNodeInfo.parentId === CONSTANTS.PROJECT_ROOT_ID) {
-            WebGMEGlobal.State.registerActiveObject(this.currentNodeInfo.parentId);
-            WebGMEGlobal.State.registerActiveSelection([myId]);
-        }
-    };
-
     ModelEditorControl.prototype._removeConnectionSegmentPoints = function () {
         var idList = this.designerCanvas.selectionManager.getSelectedElements(),
             len = idList.length,
@@ -1038,7 +1028,7 @@ define(['js/logger',
     };
 
     ModelEditorControl.prototype._activeProjectChanged = function (/*model, activeProjectId*/) {
-        this._updateTopNode();
+        //this._updateTopNode();
     };
 
     ModelEditorControl.prototype._updateTopNode = function () {
@@ -1099,8 +1089,6 @@ define(['js/logger',
                 this._toolbarItems[i].show();
             }
         }
-
-        this._refreshBtnModelHierarchyUp();
     };
 
     ModelEditorControl.prototype._hideToolbarItems = function () {
@@ -1139,18 +1127,6 @@ define(['js/logger',
         this._toolbarItems.push(this.$btnConnectionRemoveSegmentPoints);
         this.$btnConnectionRemoveSegmentPoints.enabled(false);
 
-        /************** GOTO PARENT IN HIERARCHY BUTTON ****************/
-        this.$btnModelHierarchyUp = toolBar.addButton({
-            title: 'Go to parent',
-            icon: 'glyphicon glyphicon-circle-arrow-up',
-            clickFn: function (/*data*/) {
-                self._onModelHierarchyUp();
-            }
-        });
-        this._toolbarItems.push(this.$btnModelHierarchyUp);
-
-        this.$btnModelHierarchyUp.enabled(false);
-
         this._toolbarInitialized = true;
     };
 
@@ -1158,13 +1134,6 @@ define(['js/logger',
         return this.currentNodeInfo.id;
     };
 
-    ModelEditorControl.prototype._refreshBtnModelHierarchyUp = function () {
-        if (this.currentNodeInfo.id && this.currentNodeInfo.id !== this._topNode) {
-            this.$btnModelHierarchyUp.enabled(true);
-        } else {
-            this.$btnModelHierarchyUp.enabled(false);
-        }
-    };
 
     ModelEditorControl.prototype._updateAspects = function () {
         var nodeId = this.currentNodeInfo.id,

--- a/src/client/js/Toolbar/ToolbarTextBox.js
+++ b/src/client/js/Toolbar/ToolbarTextBox.js
@@ -21,21 +21,23 @@ define(['./ToolbarItemBase'], function (ToolbarItemBase) {
             textBox = TEXTBOX_BASE.clone(),
             oldVal;
 
+        params = params || {};
+
         this.el = EL_BASE.clone();
 
         this._textBox = textBox;
 
-        if (params && params.label) {
+        if (params.label) {
             label = LABEL_BASE.clone();
             label.text(params.label + ': ');
         }
 
-        if (params && params.prependContent) {
+        if (params.prependContent) {
             label = LABEL_BASE.clone();
             label.html(params.prependContent);
         }
 
-        if (params && params.collapse) {
+        if (params.collapse) {
             textBox.addClass('no-focus-collapse');
         }
 
@@ -43,13 +45,17 @@ define(['./ToolbarItemBase'], function (ToolbarItemBase) {
             txtGroup.append(label);
         }
 
-        if (params && params.placeholder) {
+        if (params.placeholder) {
             textBox.attr('placeholder', params.placeholder);
+        }
+
+        if (params.extraCss) {
+            textBox.addClass(params.extraCss);
         }
 
         txtGroup.append(textBox);
 
-        if (params && params.textChangedFn) {
+        if (params.textChangedFn) {
             textBox.on('keyup', function (/*e*/) {
                 var val = $(this).val();
 

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Toolbar.js
@@ -27,25 +27,36 @@ define([
 
         this.toolbarItems = {};
 
-        //if and external toolbar exist for the component
+        //if an external toolbar exist for the component
         if (toolbar) {
             this.toolbarItems.beginSeparator = toolbar.addSeparator();
 
-            this.toolbarItems.btnGridLayout = toolbar.addButton({
-                title: 'Compact Grid Layout',
+            this.toolbarItems.btnGridLayouts = toolbar.addDropDownButton({
+                title: 'Arrange items',
                 icon: 'glyphicon glyphicon-th',
-                data: {mode: 'grid'},
-                clickFn: function (data) {
-                    self.itemAutoLayout(data.mode);
-                }
-            });
+                //menuClass: 'split-panel-dropdown-list',
+                clickFn: function () {
+                    self.toolbarItems.btnGridLayouts.clear();
 
-            this.toolbarItems.btnCozyGridLayout = toolbar.addButton({
-                title: 'Sparse Grid Layout',
-                icon: 'glyphicon glyphicon-th-large',
-                data: {mode: 'cozygrid'},
-                clickFn: function (data) {
-                    self.itemAutoLayout(data.mode);
+                    self.toolbarItems.btnGridLayouts.addButton({
+                        text: 'Arrange items on canvas compactly',
+                        title: 'Compact Grid Layout',
+                        //icon: 'glyphicon glyphicon-th',
+                        data: {mode: 'grid'},
+                        clickFn: function (data) {
+                            self.itemAutoLayout(data.mode);
+                        }
+                    });
+
+                    self.toolbarItems.btnGridLayouts.addButton({
+                        text: 'Arrange items on canvas sparsely',
+                        title: 'Sparse Grid Layout',
+                        //icon: 'glyphicon glyphicon-th-large',
+                        data: {mode: 'cozygrid'},
+                        clickFn: function (data) {
+                            self.itemAutoLayout(data.mode);
+                        }
+                    });
                 }
             });
 

--- a/src/client/js/Widgets/Notification/NotificationWidget.js
+++ b/src/client/js/Widgets/Notification/NotificationWidget.js
@@ -105,7 +105,7 @@ define([
             if (eventData.severity.toLowerCase() === 'error') {
                 self._popoverBox.show(eventData.message, alertLevel, 3000);
             } else {
-                self._popoverBox.show(eventData.message, alertLevel, 500);
+                self._popoverBox.show(eventData.message, alertLevel, 1000);
             }
         }
         //self._ddNotification.addItem({


### PR DESCRIPTION
This way visualizers do not need to create their own toolbar button for navigating to the parent. 