### PR TITLE
FIX #1348 svgs paths failed with relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.12.0",
+  "version": "2.12.1-beta1",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,8 @@ function getSVGMap(gmeConfig, logger, callback) {
                             fname, ']. Will proceed and use the latter...');
                     }
 
-                    svgMap[p] = path.join(process.cwd(), fname);
+                    fname = path.isAbsolute(fname) ? fname : path.join(process.cwd(), fname);
+                    svgMap[p] = fname;
                 });
             });
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,7 @@ function getSVGMap(gmeConfig, logger, callback) {
                             fname, ']. Will proceed and use the latter...');
                     }
 
-                    svgMap[p] = fname;
+                    svgMap[p] = path.join(process.cwd(), fname);
                 });
             });
     }

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -459,4 +459,34 @@ describe('standalone server', function () {
             });
         });
     });
+
+    describe('http server svgs with relative paths', function () {
+        var server;
+
+        before(function (done) {
+            // we have to set the config here
+            var gmeConfig = testFixture.getGmeConfig();
+            gmeConfig.visualization.svgDirs.push(testFixture.path.join('./test', 'server', 'extra-svgs'));
+            // Make sure we clear standalone and utlis from the cache so we get a new svgMap.
+            delete require.cache[require.resolve('../../src/server/standalone')];
+            delete require.cache[require.resolve('../../src/utils')];
+            server = WebGME.standaloneServer(gmeConfig);
+            serverBaseUrl = server.getUrl();
+            server.start(done);
+        });
+
+        after(function (done) {
+            server.stop(done);
+        });
+
+        it('should return svg file if exists and relative path given /assets/DecoratorSVG/extra-svgs/level1.svg',
+            function (done) {
+                agent.get(serverBaseUrl + '/assets/DecoratorSVG/extra-svgs/level1.svg').end(function (err, res) {
+                    expect(res.status).to.equal(200);
+                    expect(res.body.toString('utf8')).to.contain('</svg>');
+                    done();
+                });
+            }
+        );
+    });
 });


### PR DESCRIPTION
A workaround till this is out is to make the config.visualization.svgDirs all absolute, e.g.
`config.visualization.svgDirs.push('./myIcons');` becomes `config.visualization.svgDirs.push(path.join(__dirname, '..', './myIcons'));`
