### PR TITLE
Index appcache manifest and try to avoid browser from caching index.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta4",
+  "version": "2.13.0-beta5",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta2",
+  "version": "2.13.0-beta3",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta5",
+  "version": "2.13.0-beta6",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.12.1",
+  "version": "2.13.0-beta1",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta3",
+  "version": "2.13.0-beta4",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta6",
+  "version": "2.13.0-beta1",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.13.0-beta1",
+  "version": "2.13.0-beta2",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html manifest="webgme.dist.appcache">
+<html manifest="webgme.dist.<%=webgmeVersion%>.appcache">
 <head>
     <title>WebGME</title>
     <!-- Load main.js with RequireJS and launch the app from there -->

--- a/src/client/js/mainDEBUG.js
+++ b/src/client/js/mainDEBUG.js
@@ -11,7 +11,7 @@
 var DEBUG = false,
     WebGMEGlobal = WebGMEGlobal || {};
 
-WebGMEGlobal.version = 'x';
+WebGMEGlobal.version = 'DEBUG';
 WebGMEGlobal.SUPPORTS_TOUCH = 'ontouchstart' in window || navigator.msMaxTouchPoints;
 
 

--- a/src/client/js/start.js
+++ b/src/client/js/start.js
@@ -44,6 +44,10 @@ require(
         }
 
         WebGMEGlobal.gmeConfig = gmeConfig;
+        if (WebGMEGlobal.version !== 'DEBUG' && WebGMEGlobal.version !== npmJSON.version) {
+            // If the index.html was cached from a previous version force a reload of the page.
+            window.location.reload();
+        }
 
         WebGMEGlobal.version = npmJSON.version;
         WebGMEGlobal.NpmVersion = npmJSON.dist ? npmJSON.version : '';

--- a/src/common/util/random.js
+++ b/src/common/util/random.js
@@ -62,6 +62,13 @@ define(['chance', 'common/Constants'], function (ChanceJs, CONSTANTS) {
         return relid;
     }
 
+    function generateRandomString(length) {
+        return chance.string({
+            pool: relidPool,
+            length: length
+        });
+    }
+
     function isValidRelid(relid) {
 
         if (typeof relid !== 'string') {
@@ -130,7 +137,8 @@ define(['chance', 'common/Constants'], function (ChanceJs, CONSTANTS) {
             generateRelid: generateRelid,
             isValidRelid: isValidRelid,
             isValidPath: isValidPath,
-            relidToInteger: relidToInteger
+            relidToInteger: relidToInteger,
+            generateRandomString: generateRandomString
         };
 
     return random;

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -670,7 +670,7 @@ function StandAloneServer(gmeConfig) {
                 res.send(404);
             } else {
                 res.contentType('text/html');
-                res.setHeader('Cache-Control', 'no-cache');
+                res.setHeader('Cache-Control', 'no-store');
                 res.send(ejs.render(indexTemp, {
                     webgmeVersion: nmpPackageJson.version,
                     url: url,

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -852,7 +852,7 @@ function StandAloneServer(gmeConfig) {
         '/dist/webgme.' + nmpPackageJson.version + '.dist.build.js\n' +
         'NETWORK:\n*';
 
-    __app.get('/webgme.dist.appcache', function (req, res) {
+    __app.get('/webgme.dist.' + nmpPackageJson.version + '.appcache', function (req, res) {
         res.set('Content-Type', 'text/cache-manifest');
         res.send(cacheManifest);
     });

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -670,6 +670,7 @@ function StandAloneServer(gmeConfig) {
                 res.send(404);
             } else {
                 res.contentType('text/html');
+                res.setHeader('Cache-Control', 'no-cache');
                 res.send(ejs.render(indexTemp, {
                     webgmeVersion: nmpPackageJson.version,
                     url: url,

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -20,6 +20,7 @@ var path = require('path'),
     multipart = require('connect-multiparty'),
     Http = require('http'),
     ejs = requireJS('common/util/ejs'),
+    RANDOM = requireJS('common/util/random'),
 
     MongoAdapter = require('./storage/mongo'),
     RedisAdapter = require('./storage/datastores/redisadapter'),
@@ -674,6 +675,9 @@ function StandAloneServer(gmeConfig) {
                 res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate'); // HTTP 1.1.
                 res.setHeader('Pragma', 'no-cache'); // HTTP 1.0.
                 res.setHeader('Expires', '0'); // Proxies.
+
+                // Override the ETag with random string (26 is the length of default express tag).
+                res.setHeader('ETag', RANDOM.generateRandomString(26));
                 res.send(ejs.render(indexTemp, {
                     webgmeVersion: nmpPackageJson.version,
                     url: url,

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -20,7 +20,6 @@ var path = require('path'),
     multipart = require('connect-multiparty'),
     Http = require('http'),
     ejs = requireJS('common/util/ejs'),
-    RANDOM = requireJS('common/util/random'),
 
     MongoAdapter = require('./storage/mongo'),
     RedisAdapter = require('./storage/datastores/redisadapter'),

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -670,7 +670,10 @@ function StandAloneServer(gmeConfig) {
                 res.send(404);
             } else {
                 res.contentType('text/html');
-                res.setHeader('Cache-Control', 'no-store');
+                //http://stackoverflow.com/questions/49547/how-to-control-web-page-caching-across-all-browsers
+                res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate'); // HTTP 1.1.
+                res.setHeader('Pragma', 'no-cache'); // HTTP 1.0.
+                res.setHeader('Expires', '0'); // Proxies.
                 res.send(ejs.render(indexTemp, {
                     webgmeVersion: nmpPackageJson.version,
                     url: url,

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -676,8 +676,6 @@ function StandAloneServer(gmeConfig) {
                 res.setHeader('Pragma', 'no-cache'); // HTTP 1.0.
                 res.setHeader('Expires', '0'); // Proxies.
 
-                // Override the ETag with random string (26 is the length of default express tag).
-                res.setHeader('ETag', RANDOM.generateRandomString(26));
                 res.send(ejs.render(indexTemp, {
                     webgmeVersion: nmpPackageJson.version,
                     url: url,


### PR DESCRIPTION
In case index.html is cached - fallback to reload page in start.js if version from index.html doesn't match the actual version.

N.B. Controlling browsers cache mechanism is more or less impossible - therefor the fallback is introduced.