### PR TITLE
Crosscut fixes

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -517,7 +517,7 @@ define(['js/logger',
         return undefined;
     };
 
-    DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype.getMemberListSetsRegistry = function (nodeId) {
+    DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype.getMemberListSetsRegistry = function (/*nodeId*/) {
         this.logger.warn('DiagramDesignerWidgetMultiTabMemberListControllerBase.getMemberListSetsRegistry is not ' +
             'overridden, returning default value...');
         return undefined;
@@ -1600,7 +1600,6 @@ define(['js/logger',
             memberListSetsRegistryKey = this.getMemberListSetsRegistryKey(),
             memberListSetsRegistry,
             i,
-            base,
             len,
             setID;
 
@@ -1640,7 +1639,6 @@ define(['js/logger',
             memberListSetsRegistry,
             i,
             j,
-            base,
             oldIDList = this._tabIDMemberListID,
             urlTab = WebGMEGlobal.State.getActiveTab(),
             setID;
@@ -1743,7 +1741,6 @@ define(['js/logger',
             memberListSetsRegistryKey = this.getMemberListSetsRegistryKey(),
             memberListSetsRegistry,
             i,
-            base,
             newSetID,
             newSetNamePrefixDesc,
             newSetDesc;

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -517,6 +517,12 @@ define(['js/logger',
         return undefined;
     };
 
+    DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype.getMemberListSetsRegistry = function (nodeId) {
+        this.logger.warn('DiagramDesignerWidgetMultiTabMemberListControllerBase.getMemberListSetsRegistry is not ' +
+            'overridden, returning default value...');
+        return undefined;
+    };
+
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._onSelectedTabChanged = function (tabID) {
         if (this._tabIDMemberListID[tabID] && this._selectedMemberListID !== this._tabIDMemberListID[tabID]) {
             this._selectedMemberListID = this._tabIDMemberListID[tabID];

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -1604,15 +1604,14 @@ define(['js/logger',
             len,
             setID;
 
-        if (memberListContainerID &&
-            memberListSetsRegistryKey &&
-            memberListSetsRegistryKey !== '') {
-            memberListContainer = this._client.getNode(memberListContainerID);
-            memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
-            base = this._client.getNode(memberListContainer.getBaseId());
+        if (typeof memberListContainerID === 'string') {
+            memberListSetsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
+
             if (memberListSetsRegistry === undefined &&
-                (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
-                memberListSetsRegistry = [];
+                memberListSetsRegistryKey &&
+                memberListSetsRegistryKey !== '') {
+                memberListContainer = this._client.getNode(memberListContainerID);
+                memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
             }
 
             if (this._tabIDMemberListID[tabID] && memberListSetsRegistry) {
@@ -1646,46 +1645,87 @@ define(['js/logger',
             urlTab = WebGMEGlobal.State.getActiveTab(),
             setID;
 
-        if (typeof memberListContainerID === 'string' &&
-            memberListSetsRegistryKey &&
-            memberListSetsRegistryKey !== '') {
-            memberListContainer = this._client.getNode(memberListContainerID);
-            memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
-            base = this._client.getNode(memberListContainer.getBaseId());
-            if (memberListSetsRegistry === undefined &&
-                (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
-                memberListSetsRegistry = [];
+        if (typeof memberListContainerID === 'string') {
+            memberListSetsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
+
+            if(memberListSetsRegistry === undefined &&
+                memberListSetsRegistryKey &&
+                memberListSetsRegistryKey !== ''){
+                memberListContainer = this._client.getNode(memberListContainerID);
+                memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
             }
 
-            if (memberListSetsRegistry) {
-                this._tabIDMemberListID = {};
-                for (i = 0; i < newTabIDOrder.length; i += 1) {
-                    //i is the new order number
-                    //newTabIDOrder[i] is the tab identifier
-                    if (urlTab === newTabIDOrder[i]) {
-                        WebGMEGlobal.State.registerActiveTab(i);
-                    }
-                    setID = oldIDList[newTabIDOrder[i]];
-                    this._tabIDMemberListID[i] = setID;
-                    for (j = 0; j < memberListSetsRegistry.length; j += 1) {
-                        if (memberListSetsRegistry[j].SetID === setID) {
-                            memberListSetsRegistry[j].order = i;
-                            break;
-                        }
+        }
+
+        if (memberListSetsRegistry) {
+            this._tabIDMemberListID = {};
+            for (i = 0; i < newTabIDOrder.length; i += 1) {
+                //i is the new order number
+                //newTabIDOrder[i] is the tab identifier
+                if (urlTab === newTabIDOrder[i]) {
+                    WebGMEGlobal.State.registerActiveTab(i);
+                }
+                setID = oldIDList[newTabIDOrder[i]];
+                this._tabIDMemberListID[i] = setID;
+                for (j = 0; j < memberListSetsRegistry.length; j += 1) {
+                    if (memberListSetsRegistry[j].SetID === setID) {
+                        memberListSetsRegistry[j].order = i;
+                        break;
                     }
                 }
-
-                memberListSetsRegistry.sort(function (a, b) {
-                    if (a.order < b.order) {
-                        return -1;
-                    } else {
-                        return 1;
-                    }
-                });
-
-                this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
             }
+
+            memberListSetsRegistry.sort(function (a, b) {
+                if (a.order < b.order) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            });
+
+            this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
         }
+
+        // if (typeof memberListContainerID === 'string' &&
+        //     memberListSetsRegistryKey &&
+        //     memberListSetsRegistryKey !== '') {
+        //     memberListContainer = this._client.getNode(memberListContainerID);
+        //     memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
+        //     base = this._client.getNode(memberListContainer.getBaseId());
+        //     if (memberListSetsRegistry === undefined &&
+        //         (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
+        //         memberListSetsRegistry = [];
+        //     }
+        //
+        //     if (memberListSetsRegistry) {
+        //         this._tabIDMemberListID = {};
+        //         for (i = 0; i < newTabIDOrder.length; i += 1) {
+        //             //i is the new order number
+        //             //newTabIDOrder[i] is the tab identifier
+        //             if (urlTab === newTabIDOrder[i]) {
+        //                 WebGMEGlobal.State.registerActiveTab(i);
+        //             }
+        //             setID = oldIDList[newTabIDOrder[i]];
+        //             this._tabIDMemberListID[i] = setID;
+        //             for (j = 0; j < memberListSetsRegistry.length; j += 1) {
+        //                 if (memberListSetsRegistry[j].SetID === setID) {
+        //                     memberListSetsRegistry[j].order = i;
+        //                     break;
+        //                 }
+        //             }
+        //         }
+        //
+        //         memberListSetsRegistry.sort(function (a, b) {
+        //             if (a.order < b.order) {
+        //                 return -1;
+        //             } else {
+        //                 return 1;
+        //             }
+        //         });
+        //
+        //         this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
+        //     }
+        // }
     };
 
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._onTabDeleteClicked = function (tabID) {

--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -1648,9 +1648,9 @@ define(['js/logger',
         if (typeof memberListContainerID === 'string') {
             memberListSetsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
 
-            if(memberListSetsRegistry === undefined &&
+            if (memberListSetsRegistry === undefined &&
                 memberListSetsRegistryKey &&
-                memberListSetsRegistryKey !== ''){
+                memberListSetsRegistryKey !== '') {
                 memberListContainer = this._client.getNode(memberListContainerID);
                 memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
             }
@@ -1685,47 +1685,6 @@ define(['js/logger',
 
             this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
         }
-
-        // if (typeof memberListContainerID === 'string' &&
-        //     memberListSetsRegistryKey &&
-        //     memberListSetsRegistryKey !== '') {
-        //     memberListContainer = this._client.getNode(memberListContainerID);
-        //     memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
-        //     base = this._client.getNode(memberListContainer.getBaseId());
-        //     if (memberListSetsRegistry === undefined &&
-        //         (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
-        //         memberListSetsRegistry = [];
-        //     }
-        //
-        //     if (memberListSetsRegistry) {
-        //         this._tabIDMemberListID = {};
-        //         for (i = 0; i < newTabIDOrder.length; i += 1) {
-        //             //i is the new order number
-        //             //newTabIDOrder[i] is the tab identifier
-        //             if (urlTab === newTabIDOrder[i]) {
-        //                 WebGMEGlobal.State.registerActiveTab(i);
-        //             }
-        //             setID = oldIDList[newTabIDOrder[i]];
-        //             this._tabIDMemberListID[i] = setID;
-        //             for (j = 0; j < memberListSetsRegistry.length; j += 1) {
-        //                 if (memberListSetsRegistry[j].SetID === setID) {
-        //                     memberListSetsRegistry[j].order = i;
-        //                     break;
-        //                 }
-        //             }
-        //         }
-        //
-        //         memberListSetsRegistry.sort(function (a, b) {
-        //             if (a.order < b.order) {
-        //                 return -1;
-        //             } else {
-        //                 return 1;
-        //             }
-        //         });
-        //
-        //         this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
-        //     }
-        // }
     };
 
     DiagramDesignerWidgetMultiTabMemberListControllerBase.prototype._onTabDeleteClicked = function (tabID) {
@@ -1734,7 +1693,6 @@ define(['js/logger',
             memberListSetsRegistryKey = this.getMemberListSetsRegistryKey(),
             memberListSetsRegistry,
             i,
-            base,
             setID;
 
         if (typeof memberListContainerID === 'string') {
@@ -1742,42 +1700,36 @@ define(['js/logger',
 
             this._client.startTransaction();
 
-            if (memberListSetsRegistryKey) {
+            memberListSetsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
+
+            if (memberListSetsRegistry === undefined && typeof memberListSetsRegistryKey === 'string') {
                 memberListContainer = this._client.getNode(memberListContainerID);
-                memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
-                base = this._client.getNode(memberListContainer.getBaseId());
-                if (memberListSetsRegistry === undefined &&
-                    (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
-                    memberListSetsRegistry = [];
-                }
+                memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey) || [];
+            }
 
-                if (memberListSetsRegistry) {
-                    i = memberListSetsRegistry.length;
-                    while (i--) {
-                        if (memberListSetsRegistry[i].SetID === setID) {
-                            memberListSetsRegistry.splice(i, 1);
-                            break;
-                        }
-                    }
-
-                    //order remaining and reset order number
-                    memberListSetsRegistry.sort(function (a, b) {
-                        if (a.order < b.order) {
-                            return -1;
-                        } else {
-                            return 1;
-                        }
-                    });
-
-                    i = memberListSetsRegistry.length;
-                    while (i--) {
-                        memberListSetsRegistry[i].order = i;
-                    }
-
-                    this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
+            i = memberListSetsRegistry.length;
+            while (i--) {
+                if (memberListSetsRegistry[i].SetID === setID) {
+                    memberListSetsRegistry.splice(i, 1);
+                    break;
                 }
             }
 
+            //order remaining and reset order number
+            memberListSetsRegistry.sort(function (a, b) {
+                if (a.order < b.order) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            });
+
+            i = memberListSetsRegistry.length;
+            while (i--) {
+                memberListSetsRegistry[i].order = i;
+            }
+
+            this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
             //finally delete the sheet's SET
             this._client.deleteSet(memberListContainerID, setID);
 
@@ -1796,62 +1748,57 @@ define(['js/logger',
             newSetNamePrefixDesc,
             newSetDesc;
 
-        if (this._canAddTab() &&
-            memberListSetsRegistryKey &&
-            memberListSetsRegistryKey !== '') {
-            memberListContainer = this._client.getNode(memberListContainerID);
-            memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey);
-            base = this._client.getNode(memberListContainer.getBaseId());
-            if (memberListSetsRegistry === undefined &&
-                (base === null || base.getRegistry(memberListSetsRegistryKey) === undefined)) {
-                memberListSetsRegistry = [];
+        if (this._canAddTab()) {
+            memberListSetsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
+            if(memberListSetsRegistry === undefined &&
+                memberListSetsRegistryKey &&
+                memberListSetsRegistryKey !== ''){
+                memberListContainer = this._client.getNode(memberListContainerID);
+                memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey) || [];
             }
 
-            if (memberListSetsRegistry) {
-                //reset set's order
-                memberListSetsRegistry.sort(function (a, b) {
-                    if (a.order < b.order) {
-                        return -1;
-                    } else {
-                        return 1;
-                    }
-                });
-
-                i = memberListSetsRegistry.length;
-                while (i--) {
-                    memberListSetsRegistry[i].order = i;
+            memberListSetsRegistry.sort(function (a, b) {
+                if (a.order < b.order) {
+                    return -1;
+                } else {
+                    return 1;
                 }
+            });
 
-                //create new Set's descriptor
-                //create new aspect set in  meta container node
-                newSetNamePrefixDesc = this.getNewSetNamePrefixDesc();
-
-                newSetID = newSetNamePrefixDesc.SetID + generateGuid();
-
-                newSetDesc = {
-                    SetID: newSetID,
-                    order: memberListSetsRegistry.length,
-                    title: newSetNamePrefixDesc.Title + memberListSetsRegistry.length
-                };
-
-                memberListSetsRegistry.push(newSetDesc);
-
-                //start transaction
-                this._client.startTransaction();
-
-                this._client.createSet(memberListContainerID, newSetID);
-
-                this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
-
-                //force switching to the new sheet if this is not the first sheet
-                //if this is the first, it will be activated by default
-                if (memberListSetsRegistry.length !== 1) {
-                    this._selectedMemberListID = newSetID;
-                }
-
-                //finish transaction
-                this._client.completeTransaction();
+            i = memberListSetsRegistry.length;
+            while (i--) {
+                memberListSetsRegistry[i].order = i;
             }
+
+            //create new Set's descriptor
+            //create new aspect set in  meta container node
+            newSetNamePrefixDesc = this.getNewSetNamePrefixDesc();
+
+            newSetID = newSetNamePrefixDesc.SetID + generateGuid();
+
+            newSetDesc = {
+                SetID: newSetID,
+                order: memberListSetsRegistry.length,
+                title: newSetNamePrefixDesc.Title + memberListSetsRegistry.length
+            };
+
+            memberListSetsRegistry.push(newSetDesc);
+
+            //start transaction
+            this._client.startTransaction();
+
+            this._client.createSet(memberListContainerID, newSetID);
+
+            this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
+
+            //force switching to the new sheet if this is not the first sheet
+            //if this is the first, it will be activated by default
+            if (memberListSetsRegistry.length !== 1) {
+                this._selectedMemberListID = newSetID;
+            }
+
+            //finish transaction
+            this._client.completeTransaction();
         }
     };
 

--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -266,54 +266,8 @@ define(['js/logger',
     CrosscutController.prototype.getMemberListSetsRegistryKey = function () {
         return REGISTRY_KEYS.CROSSCUTS;
     };
-
-    CrosscutController.prototype._getObjectifiedSetsRegistry = function (nodeId) {
-        var node = this._client.getNode(nodeId),
-            setNames,
-            baseObjectifiedSetsRegistry,
-            selfObjectifiedSetsRegistry = {},
-            registry,
-            i;
-
-        if (node) {
-            baseObjectifiedSetsRegistry = this._getObjectifiedSetsRegistry(node.getBaseId());
-            registry = node.getOwnEditableRegistry(REGISTRY_KEYS.CROSSCUTS) || [];
-            setNames = node.getSetNames();
-            for (i = 0; i < registry.length; i += 1) {
-                if (setNames.indexOf(registry[i].SetID) !== -1) {
-                    selfObjectifiedSetsRegistry[registry[i].SetID] = registry[i];
-                }
-            }
-
-            for (i in selfObjectifiedSetsRegistry) {
-                baseObjectifiedSetsRegistry[i] = selfObjectifiedSetsRegistry[i];
-            }
-
-            selfObjectifiedSetsRegistry = baseObjectifiedSetsRegistry;
-        }
-
-        return selfObjectifiedSetsRegistry;
-    };
-
-    CrosscutController.prototype.getMemberListSetsRegistry = function (nodeId) {
-        var objectifiedSetsRegistry = this._getObjectifiedSetsRegistry(nodeId),
-            id,
-            preIndex = 0,
-            registry = [];
-
-        while (Object.keys(objectifiedSetsRegistry).length > 0) {
-            for (id in objectifiedSetsRegistry) {
-                if (objectifiedSetsRegistry[id].order === preIndex) {
-                    objectifiedSetsRegistry[id].order = registry.length;
-                    registry.push(objectifiedSetsRegistry[id]);
-                    delete objectifiedSetsRegistry[id];
-                }
-            }
-            preIndex += 1;
-        }
-
-        return registry;
-    };
+    
+    CrosscutController.prototype.getMemberListSetsRegistry = GMEConcepts.getCrosscuts;
 
     CrosscutController.prototype.getNewSetNamePrefixDesc = function () {
         return {

--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -30,7 +30,7 @@ define(['js/logger',
     var CrosscutController,
         DEFAULT_DECORATOR = 'ModelDecorator',
         WIDGET_NAME = 'DiagramDesigner';
-        //CONNECTION_DECORATOR = 'CircleDecorator';
+    //CONNECTION_DECORATOR = 'CircleDecorator';
 
     CrosscutController = function (options) {
         options = options || {};
@@ -961,6 +961,25 @@ define(['js/logger',
             NON_DELETABLE_POINTERS = [CONSTANTS.POINTER_SOURCE, CONSTANTS.POINTER_TARGET, CONSTANTS.POINTER_BASE],
             lineDesc,
             canDeletePointer,
+            exclusiveMemberOfCrosscut = function (gmeObject) {
+                var setsInfo = gmeObject.isMemberOf(),
+                    setOwnerId,
+                    crosscutMemberships = [],
+                    i;
+
+                for (setOwnerId in setsInfo) {
+                    for (i = 0; i < setsInfo[setOwnerId].length; i += 1) {
+                        if (setsInfo[setOwnerId][i].indexOf(CrosscutConstants.CROSSCUT_NAME_PREFIX) === 0) {
+                            crosscutMemberships.push(setsInfo[setOwnerId][i]);
+                        }
+                    }
+                }
+
+                if (crosscutMemberships.length === 1 && crosscutMemberships[0] === memberListToRemoveFrom) {
+                    return true;
+                }
+                return false;
+            },
             logger = this.logger;
 
         client.startTransaction();
@@ -971,7 +990,8 @@ define(['js/logger',
             gmeID = this._ComponentID2GMEID[componentId];
 
             //#1: deleting an item --> deleting a member
-            //  #1/a: if deleting a connection whose hierarchical parent is the membershipContainer,
+            //  #1/a: if deleting a connection whose hierarchical parent is the membershipContainer and only occurs in
+            //          this crosscut (#896 issue resolution),
             //          delete the connection from the hierarchy too
             //#2:  deleting a line --> deleting a pointer
             //  #2/a: do not let the user delete an src/dst pointer??
@@ -982,9 +1002,12 @@ define(['js/logger',
                     ', memberListToRemoveFrom: ' + memberListToRemoveFrom);
                 //_client.removeMember(memberListContainerID, gmeID, memberListToRemoveFrom);
 
-                //check if this GME object is a connection and whether it's parent is the crosscut container
+                // check if this GME object is a connection and whether it's parent is the crosscut container and it is
+                // and exclusive member of this crosscut
                 gmeObj = client.getNode(gmeID);
-                if (GMEConcepts.isConnection(gmeID) && gmeObj.getParentId() === memberListContainerID) {
+                if (GMEConcepts.isConnection(gmeID) &&
+                    gmeObj.getParentId() === memberListContainerID &&
+                    exclusiveMemberOfCrosscut(gmeObj)) {
                     if (GMEConcepts.canDeleteNode(gmeID)) {
                         logger.debug('deleting connection from crosscut hierarchy too gmeID: ' + gmeID);
                         client.deleteNodes([gmeID]);

--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -230,13 +230,13 @@ define(['js/logger',
     CrosscutController.prototype.getOrderedMemberListInfo = function (/* memberListContainerObject */) {
         var result = [],
             memberListContainerID = this._memberListContainerID,
-            crosscutsRegistry = GMEConcepts.getCrosscuts(memberListContainerID),
+            crosscutsRegistry = this.getMemberListSetsRegistry(memberListContainerID),
             len = crosscutsRegistry.length;
 
         if (this._autoCreateCrosscut === true && len === 0 && this._tabsHasBeenRequested === false) {
             this._onTabAddClicked();
             memberListContainerID = this._memberListContainerID;
-            crosscutsRegistry = GMEConcepts.getCrosscuts(memberListContainerID);
+            crosscutsRegistry = this.getMemberListSetsRegistry(memberListContainerID);
             len = crosscutsRegistry.length;
         }
 

--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -267,6 +267,53 @@ define(['js/logger',
         return REGISTRY_KEYS.CROSSCUTS;
     };
 
+    CrosscutController.prototype._getObjectifiedSetsRegistry = function (nodeId) {
+        var node = this._client.getNode(nodeId),
+            setNames,
+            baseObjectifiedSetsRegistry,
+            selfObjectifiedSetsRegistry = {},
+            registry,
+            i;
+
+        if (node) {
+            baseObjectifiedSetsRegistry = this._getObjectifiedSetsRegistry(node.getBaseId());
+            registry = node.getRegistry(REGISTRY_KEYS.CROSSCUTS) || [];
+            setNames = node.getSetNames();
+            for (i = 0; i < registry.length; i += 1) {
+                if (setNames.indexOf(registry[i].SetID)) {
+                    selfObjectifiedSetsRegistry[registry[i].SetID] = registry[i];
+                }
+            }
+
+            for (i in selfObjectifiedSetsRegistry) {
+                baseObjectifiedSetsRegistry[i] = selfObjectifiedSetsRegistry[i];
+            }
+
+            selfObjectifiedSetsRegistry = baseObjectifiedSetsRegistry;
+        }
+
+        return selfObjectifiedSetsRegistry;
+    };
+
+    CrosscutController.prototype.getMemberListSetsRegistry = function (nodeId) {
+        var objectifiedSetsRegistry = this._getObjectifiedSetsRegistry(nodeId),
+            id,
+            preIndex = 0,
+            registry = [];
+
+        while (Object.keys(objectifiedSetsRegistry).length > 0) {
+            for (id in objectifiedSetsRegistry) {
+                if (objectifiedSetsRegistry[id].order === preIndex) {
+                    objectifiedSetsRegistry[id].order = registry.length;
+                    registry.push(objectifiedSetsRegistry[id]);
+                    delete objectifiedSetsRegistry[id];
+                }
+            }
+        }
+
+        return registry;
+    };
+
     CrosscutController.prototype.getNewSetNamePrefixDesc = function () {
         return {
             SetID: CrosscutConstants.CROSSCUT_NAME_PREFIX,

--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -277,10 +277,10 @@ define(['js/logger',
 
         if (node) {
             baseObjectifiedSetsRegistry = this._getObjectifiedSetsRegistry(node.getBaseId());
-            registry = node.getRegistry(REGISTRY_KEYS.CROSSCUTS) || [];
+            registry = node.getOwnEditableRegistry(REGISTRY_KEYS.CROSSCUTS) || [];
             setNames = node.getSetNames();
             for (i = 0; i < registry.length; i += 1) {
-                if (setNames.indexOf(registry[i].SetID)) {
+                if (setNames.indexOf(registry[i].SetID) !== -1) {
                     selfObjectifiedSetsRegistry[registry[i].SetID] = registry[i];
                 }
             }
@@ -309,6 +309,7 @@ define(['js/logger',
                     delete objectifiedSetsRegistry[id];
                 }
             }
+            preIndex += 1;
         }
 
         return registry;
@@ -1572,15 +1573,15 @@ define(['js/logger',
 
     CrosscutController.prototype._updateCrosscutRegistry = function () {
         var containerNode = this._client.getNode(this._memberListContainerID),
-            regItem = containerNode.getOwnEditableRegistry(REGISTRY_KEYS.CROSSCUTS),
+            regItem = this.getMemberListSetsRegistry(this._memberListContainerID) || [],
             i, crosscutId = Number(this._activeCrosscutId),
             base;
 
-        base = this._client.getNode(containerNode.getBaseId());
-        if (regItem === undefined &&
-            (base === null || base.getRegistry(REGISTRY_KEYS.CROSSCUTS) === undefined)) {
-            regItem = [];
-        }
+        // base = this._client.getNode(containerNode.getBaseId());
+        // if (regItem === undefined &&
+        //     (base === null || base.getRegistry(REGISTRY_KEYS.CROSSCUTS) === undefined)) {
+        //     regItem = [];
+        // }
 
         if (regItem) {
             for (i = 0; i < regItem.length; i += 1) {
@@ -1601,8 +1602,7 @@ define(['js/logger',
         this._activeCrosscutId = tabId;
         this._initActiveTab = true;
 
-        var containerNode = this._client.getNode(this._memberListContainerID),
-            regItem = containerNode ? containerNode.getEditableRegistry(REGISTRY_KEYS.CROSSCUTS) : [],
+        var regItem = this.getMemberListSetsRegistry(this._memberListContainerID) || [],
             i, crosscutId = Number(this._activeCrosscutId),
             filter = [];
 

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -196,6 +196,10 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         return this._state.core.getSetNames(this._state.nodes[this._id].node);
     };
 
+    GMENode.prototype.isMemberOf = function () {
+        return this._state.core.isMemberOf(this._state.nodes[this._id].node);
+    };
+
     GMENode.prototype.getMemberAttributeNames = function (setName, memberId) {
         return this._state.core.getMemberAttributeNames(this._state.nodes[this._id].node, setName, memberId);
     };

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -211,6 +211,7 @@ describe('coretype', function () {
             }, core.loadCollection(childrenDictionary['B'], 'ref'));
         }, core.loadChildren(instance));
     });
+
     it('check pointer', function (done) {
         TASYNC.call(function (children) {
             var base, instance, i;
@@ -1353,8 +1354,9 @@ describe('coretype', function () {
         var root = core.createNode({}),
             base = core.createNode({parent: root, relid: 'base'}),
             container = core.createNode({parent: root, base: base, relid: 'template'}),
-            child = core.createNode({parent: container, base: base, relid: 'child'}),
-            instance = core.createNode({parent: root, base: container, relid: 'instance'});
+            child = core.createNode({parent: container, base: base, relid: 'child'});
+
+        core.createNode({parent: root, base: container, relid: 'instance'}); //instance
 
         expect(core.getInstancePaths(root)).to.have.length(0);
         expect(core.getInstancePaths(base)).to.have.members(['/template', '/template/child']);
@@ -1367,9 +1369,11 @@ describe('coretype', function () {
         var root = core.createNode({}),
             base = core.createNode({parent: root, relid: 'base'}),
             container = core.createNode({parent: root, base: base, relid: 'template'}),
-            child = core.createNode({parent: container, base: base, relid: 'child'}),
-            instance = core.createNode({parent: root, base: container, relid: 'instance'}),
             neededChecks = 2;
+
+
+        core.createNode({parent: container, base: base, relid: 'child'}); // child
+        core.createNode({parent: root, base: container, relid: 'instance'}), // instance
 
         core.persist(root);
         TASYNC.call(function (newRoot) {
@@ -1397,8 +1401,9 @@ describe('coretype', function () {
     });
 
     it('should remove atr and reg field of an instance during persist', function (done) {
-        var ancestor = core.createNode({parent: root, relid: 'theAncestor'}),
-            node = core.createNode({parent: root, base: ancestor, relid: 'theNode'});
+        var ancestor = core.createNode({parent: root, relid: 'theAncestor'});
+
+        core.createNode({parent: root, base: ancestor, relid: 'theNode'}); // node
 
         core.persist(root);
         TASYNC.call(function (newRoot) {
@@ -1449,11 +1454,12 @@ describe('coretype', function () {
             baseB = core.createNode({parent: root, relid: 'B'}),
             containerOne = core.createNode({parent: root, base: baseA, relid: 'C1'}),
             childOne = core.createNode({parent: containerOne, base: baseB, relid: '1'}),
-            childTwo = core.createNode({parent: containerOne, base: baseB, relid: '2'}),
             instanceOne = core.createNode({parent: root, base: containerOne, relid: 'I1'}),
             containerTwo = core.createNode({parent: root, base: baseA, relid: 'C2'}),
             instanceTwo = core.createNode({parent: root, base: containerTwo, relid: 'I2'}),
             copiedNodes;
+
+        core.createNode({parent: containerOne, base: baseB, relid: '2'}); // childTwo
 
         core.setPointer(childOne, 'ref', instanceTwo);
         copiedNodes = core.copyNodes([instanceOne, instanceTwo], root);

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -7,7 +7,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe.only('set core', function () {
+describe('set core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         Q = testFixture.Q,

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -7,7 +7,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe('set core', function () {
+describe.only('set core', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         Q = testFixture.Q,
@@ -983,5 +983,65 @@ describe('set core', function () {
             done();
         });
 
+    });
+
+    it('should inherit relative members as relative even if direct is available at base', function (done) {
+        var setType = core.createNode({parent: root, relid: 'S'}),
+            setInstance = core.createNode({parent: root, base: setType, relid: 'I'}),
+            member1 = core.createNode({parent: setType, relid: 'C1'}),
+            member2 = core.createNode({parent: setType, relid: 'C2'});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', member1);
+        core.setMemberAttribute(setType, 'set', core.getPath(member1), 'attri', 1);
+        core.addMember(setType, 'set', member2);
+        core.setMemberAttribute(setType, 'set', core.getPath(member2), 'attri', 2);
+        core.loadChildren(setInstance, function (err, children) {
+            var i;
+            expect(err).to.eql(null);
+
+            for (i = 0; i < children.length; i += 1) {
+                core.addMember(setType, 'set', children[i]);
+                core.setMemberAttribute(setType, 'set', core.getPath(children[i]), 'attri', 10 + i);
+            }
+
+            expect(core.getMemberPaths(setType, 'set')).to.have.members(['/S/C1', '/S/C2', '/I/C1', '/I/C2']);
+            expect(core.getMemberPaths(setInstance, 'set')).to.have.members(['/I/C1', '/I/C2']);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C1', 'attri')).to.eql(1);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C2', 'attri')).to.eql(2);
+
+            core.setMemberAttribute(setInstance, 'set', '/I/C1', 'attri', 100);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C1', 'attri')).to.eql(100);
+            done();
+        });
+    });
+
+    it('should inherit relative members as well as static member if inheritance is clear', function (done) {
+        var setType = core.createNode({parent: root, relid: 'S'}),
+            setInstance = core.createNode({parent: root, base: setType, relid: 'I'}),
+            member1 = core.createNode({parent: setType, relid: 'C1'}),
+            member2 = core.createNode({parent: setType, relid: 'C2'});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', member1);
+        core.setMemberAttribute(setType, 'set', core.getPath(member1), 'attri', 1);
+        core.loadChildren(setInstance, function (err, children) {
+            var i;
+            expect(err).to.eql(null);
+
+            for (i = 0; i < children.length; i += 1) {
+                core.addMember(setType, 'set', children[i]);
+                core.setMemberAttribute(setType, 'set', core.getPath(children[i]), 'attri', 10 + i);
+            }
+
+            expect(core.getMemberPaths(setType, 'set')).to.have.members(['/S/C1', '/I/C1', '/I/C2']);
+            expect(core.getMemberPaths(setInstance, 'set')).to.have.members(['/I/C1', '/I/C2']);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C1', 'attri')).to.eql(1);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C2', 'attri')).to.be.at.least(10);
+
+            core.setMemberAttribute(setInstance, 'set', '/I/C2', 'attri', 100);
+            expect(core.getMemberAttribute(setInstance, 'set', '/I/C2', 'attri')).to.eql(100);
+            done();
+        });
     });
 });

--- a/test/common/core/setcore.spec.js
+++ b/test/common/core/setcore.spec.js
@@ -104,8 +104,9 @@ describe('set core', function () {
         function (done) {
             var proto = core.createNode({parent: root, relid: 'p'}),
                 derived = core.createNode({parent: root, base: proto, relid: 'd'}),
-                child = core.createNode({parent: proto, relid: 'c'}),
                 member = core.createNode({parent: root});
+
+            core.createNode({parent: proto, relid: 'c'}); // child
 
             core.loadChildren(derived, function (err, children) {
                 var newChild;
@@ -1019,8 +1020,9 @@ describe('set core', function () {
     it('should inherit relative members as well as static member if inheritance is clear', function (done) {
         var setType = core.createNode({parent: root, relid: 'S'}),
             setInstance = core.createNode({parent: root, base: setType, relid: 'I'}),
-            member1 = core.createNode({parent: setType, relid: 'C1'}),
-            member2 = core.createNode({parent: setType, relid: 'C2'});
+            member1 = core.createNode({parent: setType, relid: 'C1'});
+
+        core.createNode({parent: setType, relid: 'C2'});
 
         core.createSet(setType, 'set');
         core.addMember(setType, 'set', member1);
@@ -1041,6 +1043,35 @@ describe('set core', function () {
 
             core.setMemberAttribute(setInstance, 'set', '/I/C2', 'attri', 100);
             expect(core.getMemberAttribute(setInstance, 'set', '/I/C2', 'attri')).to.eql(100);
+            done();
+        });
+    });
+
+    it('should recursively inherit relative or static members', function (done) {
+        var setType = core.createNode({parent: root, relid: 'S'}),
+            setInstance = core.createNode({parent: root, base: setType, relid: 'I'}),
+            secondInstance = core.createNode({parent: root, base: setInstance, relid: 'II'}),
+            member1 = core.createNode({parent: setType, relid: 'C1'});
+
+        core.createNode({parent: setType, relid: 'C2'});
+
+        core.createSet(setType, 'set');
+        core.addMember(setType, 'set', member1);
+        core.setMemberAttribute(setType, 'set', core.getPath(member1), 'attri', 1);
+        core.loadChildren(setInstance, function (err, children) {
+            var i;
+            expect(err).to.eql(null);
+
+            for (i = 0; i < children.length; i += 1) {
+                if (core.getRelid(children[i]) === 'C2') {
+                    core.addMember(setType, 'set', children[i]);
+                    core.setMemberAttribute(setType, 'set', core.getPath(children[i]), 'attri', 2);
+                    core.setMemberAttribute(setInstance, 'set', core.getPath(children[i]), 'attrib', 20);
+                }
+
+            }
+
+            expect(core.getMemberPaths(secondInstance, 'set')).to.have.members(['/II/C1', '/II/C2']);
             done();
         });
     });


### PR DESCRIPTION
Fixes #896 - removing a connection from a crosscut will only result in the node's deletion, if the given crosscut is the only one it appears and the parent of the connection node is the owner of the crosscut
Fixes #1266 - inheritance among crosscut owners are done via special lookup of the crosscut registry of the owner and merging it along inheritance chain.

The enhancement also contains fixes and improvements on pointer and set member inheritance handling.
A set member is considered relative if it is inside the containment subtree of the root of the instantiation. A relative member inherits relatively meaning it will be 'replaced' by its instance. Otherwise the member considered static and kept as is in the instances. 