### PR TITLE
Increase size of connectors at hover

### DIFF
--- a/src/client/decorators/DefaultDecorator/DiagramDesigner/DefaultDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/DefaultDecorator/DiagramDesigner/DefaultDecorator.DiagramDesignerWidget.css
@@ -32,6 +32,15 @@
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+    .default-decorator .connector:hover {
+      height: 24px;
+      width: 24px;
+      margin-left: -12px;
+      z-index: 12; }
+      .default-decorator .connector:hover.top {
+        top: -16px; }
+      .default-decorator .connector:hover.bottom {
+        bottom: -16px; }
     .default-decorator .connector.top {
       top: -10px; }
     .default-decorator .connector.bottom {

--- a/src/client/decorators/DefaultDecorator/DiagramDesigner/DefaultDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/DefaultDecorator/DiagramDesigner/DefaultDecorator.DiagramDesignerWidget.scss
@@ -34,6 +34,19 @@ $selected-border: 1px solid #52A8EC;
     margin-left: -8px;
     left: 50%;
 
+    &:hover {
+      height: 24px;
+      width: 24px;
+      margin-left: -12px;
+      z-index: 12;
+      &.top {
+        top: -16px;
+      }
+      &.bottom {
+        bottom: -16px;
+      }
+    }
+
     &.top {
       top: -10px;
     }

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.css
@@ -109,6 +109,15 @@
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+    .meta-decorator .connector:hover {
+      height: 24px;
+      width: 24px;
+      margin-left: -12px;
+      z-index: 12; }
+      .meta-decorator .connector:hover.top {
+        top: -16px; }
+      .meta-decorator .connector:hover.bottom {
+        bottom: -16px; }
     .meta-decorator .connector.top {
       top: -10px; }
     .meta-decorator .connector.bottom {

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/styles/MetaDecorator.DiagramDesignerWidget.scss
@@ -154,6 +154,19 @@ $abstract-class-name-color: #AAAAAA;
     margin-left: -8px;
     left: 50%;
 
+    &:hover {
+      height: 24px;
+      width: 24px;
+      margin-left: -12px;
+      z-index: 12;
+      &.top {
+        top: -16px;
+      }
+      &.bottom {
+        bottom: -16px;
+      }
+    }
+
     &.top {
       top: -10px;
     }

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -171,16 +171,32 @@
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+  .model-decorator .connector:hover {
+    height: 24px;
+    width: 24px;
+    margin-left: -12px;
+    z-index: 12; }
+    .model-decorator .connector:hover.top {
+      top: -16px; }
+    .model-decorator .connector:hover.bottom {
+      bottom: -16px; }
   .model-decorator .connector.top {
     top: -10px; }
   .model-decorator .connector.bottom {
     bottom: -9px; }
 .model-decorator .ports .port div.connector {
   top: 0.5px; }
+  .model-decorator .ports .port div.connector:hover {
+    top: -3.5px;
+    z-index: 12; }
 .model-decorator .ports .left .port .connector {
   left: -8px; }
+  .model-decorator .ports .left .port .connector:hover {
+    left: -11px; }
 .model-decorator .ports .right .port .connector {
   left: 60px; }
+  .model-decorator .ports .right .port .connector:hover {
+    left: 62px; }
 .model-decorator.accept-droppable {
   background-color: #00FF00 !important;
   cursor: alias; }

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
@@ -19,6 +19,19 @@
     margin-left: -8px;
     left: 50%;
 
+    &:hover {
+      height: 24px;
+      width: 24px;
+      margin-left: -12px;
+      z-index: 12;
+      &.top {
+        top: -16px;
+      }
+      &.bottom {
+        bottom: -16px;
+      }
+    }
+
     &.top {
       top: -10px;
     }
@@ -32,6 +45,10 @@
     .port {
       div.connector {
         top: ($port-height - 14)/2;
+        &:hover {
+          top: ($port-height - 14)/2 - 4px;
+          z-index: 12;
+        }
       }
     }
 
@@ -39,6 +56,9 @@
       .port {
         .connector {
           left: -7 - ($padding - 2);
+          &:hover {
+            left: -7 - ($padding - 2) - 3;
+          }
         }
       }
     }
@@ -47,6 +67,9 @@
       .port {
         .connector {
           left: $ports-width + 9 + ($padding - 2);
+          &:hover {
+            left: $ports-width + 9 + ($padding - 2) + 2;
+          }
         }
       }
     }

--- a/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.css
@@ -81,13 +81,29 @@
   cursor: pointer;
   border: 1px solid #0000FF;
   z-index: 10;
-  margin-left: -6px;
-  margin-top: -6px; }
+  margin-left: -5px;
+  margin-top: -5px; }
   .designer-item .svg-decorator .connector:hover {
     border-color: rgba(82, 168, 236, 0.8);
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+  .designer-item .svg-decorator .connector:hover {
+    height: 20px;
+    width: 20px;
+    z-index: 12; }
+    .designer-item .svg-decorator .connector:hover.cn {
+      margin-left: -10px;
+      margin-top: -13px; }
+    .designer-item .svg-decorator .connector:hover.cs {
+      margin-left: -10px;
+      margin-top: -7px; }
+    .designer-item .svg-decorator .connector:hover.ce {
+      margin-left: -7px;
+      margin-top: -10px; }
+    .designer-item .svg-decorator .connector:hover.cw {
+      margin-left: -13px;
+      margin-top: -10px; }
 .designer-item .svg-decorator.accept-droppable {
   background-color: #00FF00 !important;
   cursor: alias; }

--- a/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/SVGDecorator/DiagramDesigner/SVGDecorator.DiagramDesignerWidget.scss
@@ -37,8 +37,30 @@
     .connector {
       @include connector_basics;
 
-      margin-left: $connector-size / -2;
-      margin-top: $connector-size / -2;
+      margin-left: $connector-size / -2 + 1;
+      margin-top: $connector-size / -2 + 1;
+
+      &:hover {
+        height: 20px;
+        width: 20px;
+        z-index: 12;
+        &.cn {
+          margin-left: -10px;
+          margin-top: -13px;
+        }
+        &.cs {
+          margin-left: -10px;
+          margin-top: -7px;
+        }
+        &.ce {
+          margin-left: -7px;
+          margin-top: -10px;
+        }
+        &.cw {
+          margin-left: -13px;
+          margin-top: -10px;
+        }
+      }
     }
     &.accept-droppable {
       background-color: #00FF00 !important;


### PR DESCRIPTION
Note that in chrome the hover only works when starting a new connection. When dropping onto a connector the :hover class is not triggered (in firefox and edge the target will expand and become green).
Here is the bug reported..

https://bugs.chromium.org/p/chromium/issues/detail?id=122746