### PR TITLE
Make sure panels do not leak any memory

### DIFF
--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -1773,6 +1773,8 @@ define(['js/logger',
                 this._toolbarItems[i].destroy();
             }
         }
+
+        this._toolbarItems = [];
     };
 
     MetaEditorControl.prototype._initializeToolbar = function () {

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -176,9 +176,9 @@ define(['js/logger',
     //might not be the best approach
     MetaEditorControl.prototype.destroy = function () {
         this._detachClientEventListeners();
+        this._removeToolbarItems();
         this._client.removeUI(this._territoryId);
         this._client.removeUI(this._metaAspectMembersTerritoryId);
-        this.diagramDesigner.clear();
     };
 
     /**********************************************************/

--- a/src/client/js/Toolbar/ToolbarItemBase.js
+++ b/src/client/js/Toolbar/ToolbarItemBase.js
@@ -33,7 +33,6 @@ define([], function () {
     ToolbarItemBase.prototype.destroy = function () {
         if (this.el) {
             this.el.remove();
-            this.el.empty();
             this.el = undefined;
         }
     };

--- a/src/client/js/Widgets/GraphViz/GraphVizWidget.js
+++ b/src/client/js/Widgets/GraphViz/GraphVizWidget.js
@@ -391,6 +391,8 @@ define([
     };
 
     GraphVizWidget.prototype.destroy = function () {
+        this.__svg.remove();
+        this.__svg = undefined;
     };
 
     GraphVizWidget.prototype.onActivate = function () {

--- a/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
+++ b/src/client/js/Widgets/MetaInconsistencyResult/MetaInconsistencyResultWidget.js
@@ -87,8 +87,7 @@ define(['css!./styles/MetaInconsistencyResultWidget.css'], function () {
     };
 
     MetaInconsistencyResultWidget.prototype.destroy = function () {
-        this._el.find('dd.path-link').off('click');
-
+        this._onLinkClickHandler = null;
         this._el.empty();
     };
 

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -276,7 +276,7 @@ function WorkerRequests(mainLogger, gmeConfig) {
 
                             if (typeof jsonProject.kind !== 'string') {
                                 jsonProject.kind = name;
-                                logger.info('Seed did not define a kind, the seed-name [' + name + '] will be used ' +
+                                logger.debug('Seed did not define a kind, the seed-name [' + name + '] will be used ' +
                                     'as kind for new project.');
                             }
 


### PR DESCRIPTION
- Make sure to destroy toolbar items in controller.
- Clear any timeouts
- Remove all UIs on the client (`client.removeUI(<territoryId>)`)
- Clean up handlers added outside of jquery (`$el.remove()` is called by the `PanelBase.prototype.destroy` method which clears all jquery data (including registered event handlers), however if in the case of the GraphViz it was using the `d3` framework to add handlers..