### PR TITLE
Fixes #1411 Uncaught exception at copy nodes

### DIFF
--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -854,6 +854,7 @@ define([
                 basePath,
                 nodePath,
                 node,
+                tempParent, tempSrc,
                 i, j, k;
 
             // This collects 1 and 3
@@ -932,9 +933,17 @@ define([
                         old2NewPath[relationsToPreserve[i].targetBase]
                     );
 
-                    oldTarget = self.overlayInquiry(parent, source, relationsToPreserve[i].name);
-                    if (oldTarget !== null && typeof oldTarget.value === 'string') {
-                        self.overlayRemove(parent, source, relationsToPreserve[i].name, oldTarget.value);
+                    tempParent = parent;
+                    tempSrc = source;
+                    while (tempParent !== null) {
+                        oldTarget = self.overlayInquiry(tempParent, tempSrc, relationsToPreserve[i].name);
+                        if (oldTarget !== null && typeof oldTarget.value === 'string') {
+                            self.overlayRemove(tempParent, tempSrc, relationsToPreserve[i].name, oldTarget.value);
+                            tempParent = null;
+                        } else {
+                            tempSrc = CONSTANTS.PATH_SEP + self.getRelid(tempParent) + tempSrc;
+                            tempParent = self.getParent(tempParent);
+                        }
                     }
                     self.overlayInsert(parent, source, relationsToPreserve[i].name, target);
                 }

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1513,4 +1513,19 @@ describe('coretype', function () {
             done();
         }, core.loadChildren(instanceOne));
     });
+
+    it('should copyNodes make sure that simple relations kept well and not duplicated', function(){
+        var root = core.createNode({}),
+            sourceParent = core.createNode({parent: root, relid: 'SP'}),
+            targetParent = core.createNode({parent: root, relid: 'TP'}),
+            child1 = core.createNode({parent: sourceParent, base: null, relid: 'C1'}),
+            child2 = core.createNode({parent: sourceParent, base: null, relid: 'C2'}),
+            copiedNodes;
+
+        core.setPointer(child1,'ref',child2);
+        copiedNodes = core.copyNodes([child1,child2],targetParent);
+        expect(copiedNodes).to.have.length(2);
+        expect(core.getPointerNames(copiedNodes[0])).to.have.members(['base','ref']);
+        expect(core.getPointerPath(copiedNodes[0],'ref')).to.eql(core.getPath(copiedNodes[1]));
+    });
 });


### PR DESCRIPTION
Copy of multiple nodes used the single node copy, but it was not able to properly clean up the copied relations that were preserved in other ways. In return this caused an exception later as the same pointer entry were found multiple times in the project.