### PR TITLE
Split panel uses event capturing instead of event bubbling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.14.0-beta1",
+  "version": "2.14.0-beta2",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=0.12.0"


### PR DESCRIPTION
This resolves any issues with click handlers (inside the visualizers) that stops event propagation and hinders the correct active panel to be set.
