### PR TITLE
Fixes #1418 exception in tree browser and introduces isInstanceOf on client API

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -1,6 +1,7 @@
 @import url("../bower_components/bootstrap/dist/css/bootstrap.min.css");
 @import url("../bower_components/bootstrap/dist/css/bootstrap-theme.min.css");
 @import url("../bower_components/codemirror/lib/codemirror.css");
+@import url("../bower_components/codemirror/theme/monokai.css");
 @import url("codemirror/codemirror.bootstrap.css");
 
 @import url("webgme_bootstrap_overrides.css");

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
@@ -12,9 +12,7 @@ define(['js/Constants',
     'text!assets/decoratorSVGList.json',
     'text!./templates/DecoratorSVGExplorerDialog.html',
     'codemirror/mode/htmlembedded/htmlembedded',
-    'css!./styles/DecoratorSVGExplorerDialog.css',
-    'css!codemirror/lib/codemirror.css',
-    'css!codemirror/theme/monokai.css'
+    'css!./styles/DecoratorSVGExplorerDialog.css'
 ], function (CONSTANTS,
              CodeMirror,
              decoratorSVGList,

--- a/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
+++ b/src/client/js/Panels/ObjectBrowser/TreeBrowserControl.js
@@ -906,7 +906,7 @@ define(['js/logger',
         for (id in validChildrenInfo) {
             validNode = this._client.getNode(id);
             // #1418 Make sure we do not create an instance in a base.
-            if (validNode && validNode.isInstanceOf(node) === false) {
+            if (validNode && validNode.isInstanceOf(nodeId) === false) {
                 title = validNode.getFullyQualifiedName();
                 types[title] = id;
             }

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -431,6 +431,16 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         }
     };
 
+    GMENode.prototype.isInstanceOf = function (basePath) {
+        var baseNode = _getNode(this._state.nodes, basePath);
+
+        if (baseNode) {
+            return this._state.core.isInstanceOf(this._state.nodes[this._id].node, baseNode);
+        } else {
+            return false;
+        }
+    };
+
     GMENode.prototype.isValidChildOf = function (parentPath) {
         var parentNode = _getNode(this._state.nodes, parentPath);
 

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -417,12 +417,11 @@ define([
         };
 
         /**
-         * Returns the calculated database id of the data of the node.
+         * Returns the calculated hash and database id of the data for the node.
          * @param {module:Core~Node} node - the node in question.
          *
-         * @return {module:Core~ObjectHash} Returns the so called Hash value of the data of the given node. If the string is empty,
-         * then it means that the node was mutated but not yet saved to the database, so it do not have a hash
-         * temporarily.
+         * @return {module:Core~ObjectHash} Returns the hash value of the data for the given node.
+         * An empty string is returned when the node was mutated and not persisted.
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
@@ -2280,21 +2279,23 @@ define([
         };
 
         /**
-         * Checks if the given typeNode is really a base of the node.
+         * Checks if the given node in any way inherits from the typeNode. In addition to checking if the node
+         * "isInstanceOf" of typeNode, this methods also takes mixins into account.
          * @param {module:Core~Node} node - the node in question.
-         * @param {module:Core~Node} type - the type node we want to check.
+         * @param {module:Core~Node} typeNode - the type node we want to check.
          *
-         * @return {bool} The function returns true if the type is in the inheritance chain of the node or false
-         * otherwise. Every node is type of itself.
+         * @return {bool} The function returns true if the typeNode is a base node, or a mixin of any of the
+         * base nodes, of the node.
+         * Every node is considered to be a type of itself.
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isTypeOf = function (node, type) {
+        this.isTypeOf = function (node, typeNode) {
             ensureNode(node, 'node');
-            ensureNode(type, 'type');
+            ensureNode(typeNode, 'typeNode');
 
-            return core.isTypeOf(node, type);
+            return core.isTypeOf(node, typeNode);
         };
 
         /**
@@ -2954,20 +2955,25 @@ define([
         };
 
         /**
-         * Checks if there is a node with the given name in the nodes inheritance chain (excluding itself).
+         * Checks if the node is an instance of base.
          * @param {module:Core~Node} node - the node in question.
-         * @param {string} name - the name of the base node.
+         * @param {module:Core~Node} base - a potential base of the node
          *
-         * @return {bool} The function returns true if it finds an ancestor with the given name attribute.
+         * @return {bool} Returns true if the base is on the inheritance chain of node.
+         * A node is considered to be an instance of itself here.
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isInstanceOf = function (node, name) {
+        this.isInstanceOf = function (node, base) {
             ensureNode(node, 'node');
-            ensureType(name, 'name', 'string');
+            if (typeof base === 'string') {
+                return core.isInstanceOfDeprecated(node, base);
+            }
 
-            return core.isInstanceOf(node, name);
+            ensureNode(base, 'base');
+
+            return core.isInstanceOf(node, base);
         };
 
         /**

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -1224,6 +1224,7 @@ define([
             }
         };
 
+        // FIXME: Do we really need both of these??
         this.getBaseRoot = function (node) {
             ASSERT(self.isValidNode(node));
             while (node.base !== null) {
@@ -1308,6 +1309,18 @@ define([
                 // We do not process relids for e.g. _sets and _meta.
                 processNewRelidLength(node, relid.length + 1);
             }
+        };
+
+        this.isInstanceOf = function (node, base) {
+            do {
+                if (node === base) {
+                    return true;
+                }
+
+                node = node.base;
+            } while (node);
+
+            return false;
         };
 
         this.getInstancePaths = function (node) {

--- a/src/common/core/metacore.js
+++ b/src/common/core/metacore.js
@@ -674,8 +674,8 @@ define([
             return null;
         };
 
-        this.isInstanceOf = function (node, name) {
-            //TODO this is name based query - doesn't check the node's own name
+        this.isInstanceOfDeprecated = function (node, name) {
+            console.warn('Passing a name to isInstanceOf of is deprecated and will eventually be removed!');
             node = self.getBase(node);
             while (node) {
                 if (self.getAttribute(node, 'name') === name) {

--- a/test/common/core/metacore.spec.js
+++ b/test/common/core/metacore.spec.js
@@ -114,10 +114,22 @@ describe('meta core', function () {
         core.isTypeOf(attrNode, setNode).should.be.false;
     });
 
-    it('check instances', function () {
+    it('check instances deprecated should still work', function () {
         core.isInstanceOf(attrNode, 'base').should.be.true;
         core.isInstanceOf(setNode, 'set').should.be.false;
         core.isInstanceOf(base, 'unknown').should.be.false;
+    });
+
+    it('check instance of it self should return true', function () {
+        core.isInstanceOf(attrNode, attrNode).should.be.true;
+    });
+
+    it('check instance of a base should return true', function () {
+        core.isInstanceOf(attrNode, base).should.be.true;
+    });
+
+    it('check instance when no base relation exists should return false', function () {
+        core.isInstanceOf(attrNode, setNode).should.be.true;
     });
 
     it('checking attribute values', function () {

--- a/test/common/core/metacore.spec.js
+++ b/test/common/core/metacore.spec.js
@@ -16,7 +16,6 @@ describe('meta core', function () {
         __should = testFixture.should,
         expect = testFixture.expect,
         projectId = testFixture.projectName2Id(projectName),
-        project,
         core,
         root,
         base,
@@ -129,7 +128,11 @@ describe('meta core', function () {
     });
 
     it('check instance when no base relation exists should return false', function () {
-        core.isInstanceOf(attrNode, setNode).should.be.true;
+        core.isInstanceOf(attrNode, setNode).should.be.false;
+    });
+
+    it('check instance when reverse holds should return false', function () {
+        core.isInstanceOf(base, attrNode).should.be.false;
     });
 
     it('checking attribute values', function () {

--- a/typings/webgme.d.ts
+++ b/typings/webgme.d.ts
@@ -1526,13 +1526,6 @@ declare namespace GmeClasses {
          */
         isFullyOverriddenMember(node: Core.Node, setName: GmeCommon.Name, memberPath: GmeCommon.Path): boolean;
         /**
-         * Checks if there is a node with the given name in the nodes inheritance chain (excluding itself).
-         * @param node the node in question.
-         * @param name the name of the class node.
-         * @return  true if it finds an ancestor with the given name attribute.
-         */
-        isInstanceOf(node: Core.Node, name: GmeCommon.Name): boolean;
-        /**
          * Returns true if the node in question is a library element.
          * @param node the node in question.
          * @return true if your node is a library element, false otherwise.
@@ -1560,7 +1553,16 @@ declare namespace GmeClasses {
          */
         isMetaNode(node: Core.Node): boolean;
         /**
-         * Checks if the given typeNode is really a base of the node.
+         * Checks if the node is an instance of base.
+         * @param node the node in question.
+         * @param type a candidate base node.
+         * @return true if the base is on the inheritance chain of node.
+         * A node is considered to be an instance of itself here.
+         */
+        isInstanceOf(node: Core.Node, base: Core.Node): boolean;
+        /**
+         * Checks if the given node in any way inherits from the typeNode. In addition to checking if the node
+         * "isInstanceOf" of typeNode, this methods also takes mixins into account.
          * @param node the node in question.
          * @param type a candidate base node.
          * @return true if the type is in the inheritance chain of the node or false otherwise. 

--- a/utils/prepublish.js
+++ b/utils/prepublish.js
@@ -22,12 +22,13 @@ function prepublish(jsdocConfigPath) {
             console.log('Done with REST API docs!');
         }, function (err) {
             console.error('Failed generating REST API docs!', err);
+            process.exit(1);
         });
 
         console.log('Installing bower components...');
         bower.commands.install(undefined, undefined, {cwd: process.cwd()})
             .on('end', function (/*installed*/) {
-                console.log('Done!');
+                console.log('Done with bower components!');
                 if (process.env.TEST_FOLDER) {
                     console.warn('TEST_FOLDER environment variable is set, skipping distribution scripts.');
                 } else {
@@ -38,16 +39,18 @@ function prepublish(jsdocConfigPath) {
                     webgmeBuild(function (err/*, data*/) {
                         if (err) {
                             console.error('Failed generating webgme.classes.build.js!', err);
+                            process.exit(1);
                         } else {
                             //console.log(data);
-                            console.log('Done!');
+                            console.log('Done with webgme.classes.build.js!');
                             console.log('Generating webgme.dist.build.js ...');
                             webgmeDist(function (err/*, data*/) {
                                 if (err) {
                                     console.error('Failed generating webgme.dist.build.js!', err);
+                                    process.exit(1);
                                 } else {
                                     //console.log(data);
-                                    console.log('Done!');
+                                    console.log('Done with webgme.dist.build.js!');
                                 }
                             });
                         }
@@ -56,6 +59,7 @@ function prepublish(jsdocConfigPath) {
             })
             .on('error', function (err) {
                 console.error(err);
+                process.exit(1);
             });
 
     if (jsdocConfigPath !== false) {
@@ -63,7 +67,7 @@ function prepublish(jsdocConfigPath) {
         childProcess.execFile(process.execPath, [
             path.join(__dirname, './jsdoc_build.js'),
             '-c', jsdocConfigPath || './jsdoc_conf.json']);
-        console.log('Done!');
+        console.log('Done with source code documentation!');
     }
 }
 


### PR DESCRIPTION
This also fixes the broken dist build and css rules being loaded more than once.

In addition it makes sure the postinstall/prepublish exits with non-zero code on errors.

Note! `core.isInstanceOf` now takes a node as a second argument and not a `string`. However it still accepts the string but logs a deprecation warning.