### PR TITLE
Fixes blob server crash

### DIFF
--- a/src/server/middleware/blob/BlobFSBackend.js
+++ b/src/server/middleware/blob/BlobFSBackend.js
@@ -126,11 +126,16 @@ BlobFSBackend.prototype.getObject = function (hash, writeStream, bucket, callbac
         readStream;
 
     fs.lstat(filename, function (err, stat) {
-        if ((err && err.code === 'ENOENT') || !stat.isFile()) {
+        if (err) {
+            if (err.code !== 'ENOENT') {
+                return callback(new BlobError('getObject error: ' + err.code || 'unknown'), 500);
+            } else {
+                return callback(new BlobError('Requested object does not exist: ' + hash, 404));
+            }
+        } else if (stat.isFile() === false) {
             return callback(new BlobError('Requested object does not exist: ' + hash, 404));
-        } else if (err) {
-            return callback('getObject error: ' + err.code || 'unknown');
         }
+
         readStream = fs.createReadStream(filename);
 
         writeStream.on('finish', function () {

--- a/src/server/middleware/blob/BlobServer.js
+++ b/src/server/middleware/blob/BlobServer.js
@@ -51,20 +51,25 @@ function createExpressBlob(options) {
     }); */
 
     __app.get('/metadata', ensureAuthenticated, function (req, res) {
-        blobBackend.listAllMetadata(req.query.all, function (err, metadata) {
-            if (err) {
-                logger.error(err);
-                res.status(err.statusCode || 500);
-                res.send(err.message || err);
-            } else {
-                res.status(200);
-                res.setHeader('Content-type', 'application/json');
-                res.end(JSON.stringify(metadata, null, 4));
-            }
-        });
+        if (options.gmeConfig.debug) {
+            blobBackend.listAllMetadata(req.query.all, function (err, metadata) {
+                if (err) {
+                    logger.error(err);
+                    res.status(err.statusCode || 500);
+                    res.send(err.message || err);
+                } else {
+                    res.status(200);
+                    res.setHeader('Content-type', 'application/json');
+                    res.end(JSON.stringify(metadata, null, 4));
+                }
+            });
+        } else {
+            res.status(404);
+            res.send('Listing metadata only possible in debug mode.');
+        }
     });
 
-    __app.get('/metadata/:metadataHash', ensureAuthenticated, function (req, res) {
+    __app.get('/metadata/:metadataHash([0-9a-f]{40,40})', ensureAuthenticated, function (req, res) {
         blobBackend.getMetadata(req.params.metadataHash, function (err, hash, metadata) {
             if (err) {
                 logger.error(err);

--- a/test/common/blob/BlobClient.spec.js
+++ b/test/common/blob/BlobClient.spec.js
@@ -458,6 +458,82 @@ describe('BlobClient', function () {
                 });
             });
         });
+
+
+        it('getMetadata should 404 when metadataHash does not exist', function (done) {
+            var bc = new BlobClient(bcParam),
+                faultyHash = '0214c7b2d364f26020f870ed9b193f59f007070a';
+
+            bc.getMetadata(faultyHash)
+                .then(function () {
+                    throw new Error('Should have failed!');
+                })
+                .catch(function (err) {
+                    expect(err.status).to.equal(404);
+                })
+                .nodeify(done);
+        });
+
+        it('getMetadata should 404 when metadataHash not valid hash', function (done) {
+            var bc = new BlobClient(bcParam),
+                faultyHash = '883';
+
+            bc.getMetadata(faultyHash)
+                .then(function () {
+                    throw new Error('Should have failed!');
+                })
+                .catch(function (err) {
+                    expect(err.status).to.equal(404);
+                })
+                .nodeify(done);
+        });
+
+        it('getMetadata should 404 when metadataHash not valid hash (array)', function (done) {
+            var bc = new BlobClient(bcParam),
+                faultyHash = ['882', '42'];
+
+            bc.getMetadata(faultyHash)
+                .then(function () {
+                    throw new Error('Should have failed!');
+                })
+                .catch(function (err) {
+                    expect(err.status).to.equal(404);
+                })
+                .nodeify(done);
+        });
+
+        it('getMetadata should 404 when metadataHash does not exist', function (done) {
+            var bc = new BlobClient(bcParam),
+                faultyHash = '0214c7b2d364f26020f870ed9b193f59f007070a';
+
+            bc.getMetadata(faultyHash)
+                .then(function () {
+                    throw new Error('Should have failed!');
+                })
+                .catch(function (err) {
+                    expect(err.status).to.equal(404);
+                })
+                .nodeify(done);
+        });
+
+        it('getMetadata should 404 when metadataHash not valid hash (array of existing hashes)', function (done) {
+            var bc = new BlobClient(bcParam);
+
+            bc.putFiles({
+                'a.txt': 'text in a',
+                'b.txt': 'text in b',
+            }).then(function (hashes) {
+
+                return bc.getMetadata([hashes['a.txt'], hashes['b.txt']]);
+            })
+                .then(function () {
+                    throw new Error('Should have failed!');
+                })
+                .catch(function (err) {
+                    expect(err.status).to.equal(404);
+                })
+                .nodeify(done);
+        });
     });
 
     describe('[https]', function () {

--- a/test/server/middleware/blob/BlobServer.spec.js
+++ b/test/server/middleware/blob/BlobServer.spec.js
@@ -19,9 +19,10 @@ describe('BlobServer', function () {
         serverBaseUrl,
         bcParam = {};
 
-    beforeEach(function (done) {
+    before(function (done) {
         // we have to set the config here
         var gmeConfig = testFixture.getGmeConfig();
+        gmeConfig.debug = true;
         serverBaseUrl = 'http://127.0.0.1:' + gmeConfig.server.port;
         bcParam.serverPort = gmeConfig.server.port;
         bcParam.server = '127.0.0.1';
@@ -41,7 +42,7 @@ describe('BlobServer', function () {
         });
     });
 
-    afterEach(function (done) {
+    after(function (done) {
         if (server) {
             server.stop(done);
         } else {
@@ -49,77 +50,93 @@ describe('BlobServer', function () {
         }
     });
 
+    function checkContentDisposition(res) {
+        return contentDisposition.parse(res.header['content-disposition']);
+    }
+
     it('should return 200 at /rest/blob/metadata', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/metadata').end(function (err, res) {
-            should.equal(res.status, 200, err);
-            server.stop(function (err) {
-                server = null;
-                done(err);
-            });
+            try {
+                should.equal(res.status, 200, err);
+                done();
+            } catch (e) {
+                done(e);
+            }
         });
     });
 
     it('should return 500 at /rest/blob/createMetadata if data is malformed', function (done) {
         agent.post(serverBaseUrl + '/rest/blob/createMetadata')
             .type('text')
-            .send('hello')
+            .send('hello1')
             .end(function (err, res) {
-                should.equal(res.status, 500, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                try {
+                    should.equal(res.status, 500, err);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
             });
     });
 
     it('should return 404 at /rest/blob/metadata/non-existing-hash', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/metadata/non-existing-hash').end(function (err, res) {
-            should.equal(res.status, 404, err);
-            server.stop(function (err) {
-                server = null;
-                done(err);
-            });
+            try {
+                should.equal(res.status, 404, err);
+                done();
+            } catch (e) {
+                done(e);
+            }
         });
     });
 
     it('should return 404 at /rest/blob/download/non-existing-hash', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/download/non-existing-hash').end(function (err, res) {
-            should.equal(res.status, 404, err);
-            server.stop(function (err) {
-                server = null;
-                done(err);
-            });
+            try {
+                should.equal(res.status, 404, err);
+                done();
+            } catch (e) {
+                done(e);
+            }
         });
     });
 
     it('should return 404 at /rest/blob/view/non-existing-hash', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/view/non-existing-hash').end(function (err, res) {
-            should.equal(res.status, 404, err);
-            server.stop(function (err) {
-                server = null;
-                done(err);
-            });
+            try {
+                should.equal(res.status, 404, err);
+                done();
+            } catch (e) {
+                done(e);
+            }
         });
     });
 
     it('should return empty object at /rest/blob/metadata/ with no public metadata', function (done) {
         var bc = new BlobClient(bcParam),
             artifact = new Artifact('notPublic', bc);
+
         artifact.save(function (err, hash) {
             if (err) {
                 done(err);
                 return;
             }
             agent.get(serverBaseUrl + '/rest/blob/metadata/' + hash).end(function (err, res) {
-                should.equal(res.status, 200, err);
-                should.equal(res.body.isPublic, false);
-                agent.get(serverBaseUrl + '/rest/blob/metadata').end(function (err, res) {
+                try {
                     should.equal(res.status, 200, err);
-                    should.equal(Object.keys(res.body).length, 0);
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    should.equal(res.body.isPublic, false);
+                } catch (e) {
+                    return done(e);
+                }
+
+                agent.get(serverBaseUrl + '/rest/blob/metadata').end(function (err, res) {
+                    try {
+                        should.equal(res.status, 200, err);
+                        should.equal(Object.keys(res.body).length, 0);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 });
             });
         });
@@ -141,15 +158,21 @@ describe('BlobServer', function () {
                 return;
             }
             agent.get(serverBaseUrl + '/rest/blob/metadata/' + hash).end(function (err, res) {
-                should.equal(res.status, 200, err);
-                should.equal(res.body.isPublic, true);
-                agent.get(serverBaseUrl + '/rest/blob/metadata').end(function (err, res) {
+                try {
                     should.equal(res.status, 200, err);
-                    should.equal(res.body[hash].name, 'public.zip');
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    should.equal(res.body.isPublic, true);
+                } catch (e) {
+                    done(e);
+                }
+
+                agent.get(serverBaseUrl + '/rest/blob/metadata').end(function (err, res) {
+                    try {
+                        should.equal(res.status, 200, err);
+                        should.equal(res.body[hash].name, 'public.zip');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 });
             });
         });
@@ -158,7 +181,7 @@ describe('BlobServer', function () {
     it('should download non-public artifact at /rest/blob/download/valid-hash', function (done) {
         var bc = new BlobClient(bcParam),
             artifact = new Artifact('notPublic', bc);
-        artifact.addFile('tt.txt', 'ttt', function (err/*, fHash*/) {
+        artifact.addFile('tt1.txt', 'ttt1', function (err/*, fHash*/) {
             if (err) {
                 done(err);
                 return;
@@ -169,16 +192,14 @@ describe('BlobServer', function () {
                     return;
                 }
                 agent.get(serverBaseUrl + '/rest/blob/download/' + hash).end(function (err, res) {
-                    var checkContentDisposition = function () {
-                        return contentDisposition.parse(res.header['content-disposition']);
-                    };
-                    should.equal(res.status, 200, err);
-                    expect(checkContentDisposition).to.not.throw(TypeError);
-                    should.equal(checkContentDisposition().parameters.filename, 'notPublic.zip');
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    try {
+                        should.equal(res.status, 200, err);
+                        checkContentDisposition(res);
+                        should.equal(checkContentDisposition(res).parameters.filename, 'notPublic.zip');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 });
             });
         });
@@ -187,7 +208,7 @@ describe('BlobServer', function () {
     it('should download non-public artifact "Case (1).zip" at /rest/blob/download/valid-hash', function (done) {
         var bc = new BlobClient(bcParam),
             artifact = new Artifact('Case (1)', bc);
-        artifact.addFile('tt.txt', 'ttt', function (err/*, fHash*/) {
+        artifact.addFile('tt2.txt', 'ttt2', function (err/*, fHash*/) {
             if (err) {
                 done(err);
                 return;
@@ -198,16 +219,14 @@ describe('BlobServer', function () {
                     return;
                 }
                 agent.get(serverBaseUrl + '/rest/blob/download/' + hash).end(function (err, res) {
-                    var checkContentDisposition = function () {
-                        return contentDisposition.parse(res.header['content-disposition']);
-                    };
-                    should.equal(res.status, 200, err);
-                    expect(checkContentDisposition).to.not.throw(TypeError);
-                    should.equal(checkContentDisposition().parameters.filename, 'Case (1).zip');
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    try {
+                        should.equal(res.status, 200, err);
+                        checkContentDisposition(res);
+                        should.equal(checkContentDisposition(res).parameters.filename, 'Case (1).zip');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 });
             });
         });
@@ -222,16 +241,14 @@ describe('BlobServer', function () {
                 return;
             }
             agent.get(serverBaseUrl + '/rest/blob/download/' + hash).end(function (err, res) {
-                var checkContentDisposition = function () {
-                    return contentDisposition.parse(res.header['content-disposition']);
-                };
-                should.equal(res.status, 200, err);
-                expect(checkContentDisposition).to.not.throw(TypeError);
-                should.equal(checkContentDisposition().parameters.filename, 'notPublic.zip');
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                try {
+                    should.equal(res.status, 200, err);
+                    checkContentDisposition(res);
+                    should.equal(checkContentDisposition(res).parameters.filename, 'notPublic.zip');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
             });
         });
     });
@@ -239,7 +256,7 @@ describe('BlobServer', function () {
     it('should view non-public artifact at /rest/blob/view/valid-hash', function (done) {
         var bc = new BlobClient(bcParam),
             artifact = new Artifact('notPublic', bc);
-        artifact.addFile('tt.txt', 'ttt', function (err/*, fHash*/) {
+        artifact.addFile('tt3.txt', 'ttt3', function (err/*, fHash*/) {
             if (err) {
                 done(err);
                 return;
@@ -250,16 +267,14 @@ describe('BlobServer', function () {
                     return;
                 }
                 agent.get(serverBaseUrl + '/rest/blob/view/' + hash).end(function (err, res) {
-                    var checkContentDisposition = function () {
-                        return contentDisposition.parse(res.header['content-disposition']);
-                    };
-                    should.equal(res.status, 200, err);
-                    expect(checkContentDisposition).to.not.throw(TypeError);
-                    should.equal(checkContentDisposition().parameters.filename, 'notPublic.zip');
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    try {
+                        should.equal(res.status, 200, err);
+                        checkContentDisposition(res);
+                        should.equal(checkContentDisposition(res).parameters.filename, 'notPublic.zip');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
                 });
             });
         });
@@ -274,16 +289,14 @@ describe('BlobServer', function () {
                 return;
             }
             agent.get(serverBaseUrl + '/rest/blob/view/' + hash).end(function (err, res) {
-                var checkContentDisposition = function () {
-                    return contentDisposition.parse(res.header['content-disposition']);
-                };
-                should.equal(res.status, 200, err);
-                expect(checkContentDisposition).to.not.throw(TypeError);
-                should.equal(checkContentDisposition().parameters.filename, 'notPublic.zip');
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                try {
+                    should.equal(res.status, 200, err);
+                    checkContentDisposition(res);
+                    should.equal(checkContentDisposition(res).parameters.filename, 'notPublic.zip');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
             });
         });
     });

--- a/test/server/middleware/blob/BlobServer.spec.js
+++ b/test/server/middleware/blob/BlobServer.spec.js
@@ -10,7 +10,6 @@ describe('BlobServer', function () {
 
     var agent = testFixture.superagent.agent(),
         should = testFixture.should,
-        expect = testFixture.expect,
         rimraf = testFixture.rimraf,
         BlobClient = testFixture.BlobClient,
         Artifact = testFixture.requirejs('blob/Artifact'),
@@ -81,6 +80,27 @@ describe('BlobServer', function () {
 
     it('should return 404 at /rest/blob/metadata/non-existing-hash', function (done) {
         agent.get(serverBaseUrl + '/rest/blob/metadata/non-existing-hash').end(function (err, res) {
+            try {
+                should.equal(res.status, 404, err);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
+    it('should return 404 at /rest/blob/metadata/%very long hash%', function (done) {
+        // This is what caused the server to crash at #1425
+        var longHash = '[',
+            i;
+        for (i = 0; i < 30; i += 1) {
+            longHash += '003471abc9d72d86c712657b2e1e129980ae77a3,';
+        }
+
+        longHash += ']';
+
+
+        agent.get(serverBaseUrl + '/rest/blob/metadata/' + longHash).end(function (err, res) {
             try {
                 should.equal(res.status, 404, err);
                 done();


### PR DESCRIPTION
By giving a too long `metadataHash` at `/rest/blob/metadata/:metadataHash` the blob FS backend threw an exception. 
This is fixed in two ways. The logic for the error checking is fixed and won't throw any more and the path is guarded by a regular expression for the `metadataHash`.

In addition the route `/rest/blob/metadata` is only enabled in debug mode.