### PR TITLE
Document Decorator extract marked options to component settings.

### DIFF
--- a/config/components.default.js
+++ b/config/components.default.js
@@ -3,6 +3,9 @@
 /**
  * @author pmeijer / https://github.com/pmeijer
  */
-var components = require('./components.json');
+
+// You need to add require-uncached as node-module if you wanna use the same approach.
+var requireUncached = require('require-uncached'),
+    components = requireUncached('./components.json');
 
 module.exports = components;

--- a/config/componentsGenericUIDefaults.json
+++ b/config/componentsGenericUIDefaults.json
@@ -122,5 +122,16 @@
   "GenericUIFooterControlsPanel": {
     "extraWidgets": {
     }
+  },
+  "GenericUIDocumentDecorator": {
+    "parserOptions": {
+      "gfm": true,
+      "tables": true,
+      "breaks": false,
+      "pedantic": false,
+      "sanitize": true,
+      "smartLists": true,
+      "smartypants": false
+    }
   }
 }


### PR DESCRIPTION
By setting the option `sanitize` to false. html tags aren't removed sub- and superscripts can be rendered in documentation nodes.

- H<sub>2</sub>O `<sub></sub>`
- m<sup>2</sup> `<sup></sup>`