### PR TITLE
Fixes updating of port-svgs in ModelDecorator resolves with wrong uri.

### DIFF
--- a/src/client/decorators/DocumentDecorator/PartBrowser/DocumentDecorator.PartBrowserWidget.js
+++ b/src/client/decorators/DocumentDecorator/PartBrowser/DocumentDecorator.PartBrowserWidget.js
@@ -1,4 +1,4 @@
-/*globals define, _, DEBUG, $*/
+/*globals define, _, DEBUG, $, WebGMEGlobal*/
 /*jshint browser: true*/
 
 /**
@@ -93,17 +93,15 @@ define([
     DocumentDecoratorPartBrowserWidget.prototype._updateSVG = function () {
         var client = this._control._client,
             nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]),
-            svgFile = '',
             svgURL,
             self = this;
 
         if (nodeObj) {
-            svgFile = nodeObj.getRegistry(REGISTRY_KEYS.SVG_ICON);
+            svgURL = WebGMEGlobal.SvgManager.getSvgUri(nodeObj, REGISTRY_KEYS.SVG_ICON);
         }
 
-        if (svgFile) {
+        if (svgURL) {
             // get the svg from the server in SYNC mode, may take some time
-            svgURL = CONSTANTS.ASSETS_DECORATOR_SVG_FOLDER + svgFile;
             if (!this.skinParts.$imgSVG) {
                 this.skinParts.$imgSVG = EMBEDDED_SVG_IMG_BASE.clone();
                 this.$el.append(this.skinParts.$imgSVG);

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
@@ -277,7 +277,7 @@ define([
                 portTitle = displayFormat.resolve(portNode);
                 this.ports[portId].update({
                     title: portTitle,
-                    svg: portNode.getRegistry(REGISTRY_KEYS.PORT_SVG_ICON)
+                    svg: WebGMEGlobal.SvgManager.getSvgUri(portNode, REGISTRY_KEYS.PORT_SVG_ICON)
                 });
                 this._updatePortPosition(portId);
             } else {
@@ -433,7 +433,7 @@ define([
             self = this;
 
         if (nodeObj) {
-            svgURL = WebGMEGlobal.SvgManager.getSvgUri(nodeObj,REGISTRY_KEYS.SVG_ICON);
+            svgURL = WebGMEGlobal.SvgManager.getSvgUri(nodeObj, REGISTRY_KEYS.SVG_ICON);
         }
 
         if (svgURL) {

--- a/src/client/decorators/SVGDecorator/Core/SVGDecorator.Core.js
+++ b/src/client/decorators/SVGDecorator/Core/SVGDecorator.Core.js
@@ -25,7 +25,6 @@ define([
 
     var SVGDecoratorCore,
         ABSTRACT_CLASS = 'abstract',
-        SVG_DIR = CONSTANTS.ASSETS_DECORATOR_SVG_FOLDER,
         FILL_COLOR_CLASS = 'fill-color',
         BORDER_COLOR_CLASS = 'border-color',
         TEXT_COLOR_CLASS = 'text-color';
@@ -186,61 +185,6 @@ define([
     };
 
     /***** UPDATE THE SVG ICON OF THE NODE *****/
-    SVGDecoratorCore.prototype._updateSVGFile = function () {
-        var client = this._control._client,
-            nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]),
-            svgFile = '',
-            svgURL,
-            self = this,
-            logger = this.logger;
-
-        if (nodeObj) {
-            svgFile = nodeObj.getRegistry(REGISTRY_KEYS.SVG_ICON);
-        }
-
-        if (svgFile) {
-            if (this._SVGFile !== svgFile) {
-                if (this.svgCache[svgFile]) {
-                    this._updateSVGContent(svgFile);
-                } else {
-                    // get the svg from the server in SYNC mode, may take some time
-                    svgURL = SVG_DIR + svgFile;
-                    $.ajax(svgURL, {async: false})
-                        .done(function (data) {
-                            // downloaded successfully
-                            // cache the content if valid
-                            var svgElements = $(data).find('svg');
-                            if (svgElements.length > 0) {
-                                self.svgCache[svgFile] = {
-                                    el: svgElements.first(),
-                                    customConnectionAreas: undefined
-                                };
-                                self._discoverCustomConnectionAreas(svgFile);
-                                self._getCustomDataFromSvg(svgFile);
-                                self.processCustomSvgData();
-                                self._updateSVGContent(svgFile);
-                            } else {
-                                self._updateSVGContent(undefined);
-                            }
-                        })
-                        .fail(function () {
-                            // download failed for this type
-                            logger.error('Failed to download SVG file: ' + svgFile);
-                            self._updateSVGContent(svgFile);
-                        });
-                }
-                this._SVGFile = svgFile;
-            }
-        } else {
-            if (svgFile !== '') {
-                logger.error('Invalid SVG file: "' + svgFile + '"');
-                this._updateSVGContent(undefined);
-            } else {
-                this._updateSVGContent('');
-            }
-        }
-    };
-
     SVGDecoratorCore.prototype._updateSVGContent = function () {
         var client = this._control._client,
             nodeObj = client.getNode(this._metaInfo[CONSTANTS.GME_ID]),
@@ -272,41 +216,6 @@ define([
 
         this._generateConnectors();
         this.$svgContent.append(this.$svgElement);
-    };
-
-    SVGDecoratorCore.prototype._getCustomDataFromSvg = function (svgFile) {
-        //Remove custom data from svg and store it appropriately
-        if (this.customData) {
-            var i = this.customData.length,
-                customDataName,
-                svgElement = this.svgCache[svgFile].el,
-                k;
-
-            while (i--) {
-                customDataName = this.customData[i];
-                this[customDataName] = svgElement.find('.' + customDataName);
-                k = this[customDataName].length;
-                while (k--) {
-                    this[customDataName][k].remove();
-                }
-            }
-        }
-    };
-
-    SVGDecoratorCore.prototype.processCustomSvgData = function () {
-        //OVERRIDE
-    };
-
-    SVGDecoratorCore.prototype.getSVGCustomData = function (dataName) {
-        var result = null;
-        if (this.customData && this.customData.indexOf(dataName) !== -1) {
-            if (this[dataName] instanceof Array) {
-                result = this[dataName].slice();
-            } else if (this[dataName] instanceof Object) {
-                result = _.extend({}, this[dataName]);
-            }
-        }
-        return result;
     };
 
     /***** FUNCTIONS TO OVERRIDE *****/


### PR DESCRIPTION
It needs to use the `WebGMEGlobal.SvgManager.getSvgUri(...)` instead of just the registry key.

This also fixes:
- DocumentDecorator svg icon supports in-model svgs.
- Removes dead code in svg decorator for handling svgs.
