### PR TITLE
Enable specification of default webhooks via gmeConfig

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -261,3 +261,5 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
 - `config.webhooks.manager = 'memory'`
  - Type of webhook-manager for detecting events, can be `'memory'`, `'redis'`. Memory runs in the server process, whereas redis
  is running in a sub-process. Redis requires the socket.io adapter to be of type redis. (It is also possible to run the redis manager separately from the webgme server.)
+- `config.webhooks.defaults = {}`
+ - Collection of hooks that should be added to every new project. Keys are webhook-ids and values are object with at least `url` and `events` defined, see [wiki](https://github.com/webgme/webgme/wiki/GME-WebHooks) for available fields. 

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -238,7 +238,10 @@ var path = require('path'),
 
         webhooks: {
             enable: false,
-            manager: 'memory' // memory, redis
+            manager: 'memory', // memory, redis
+            defaults: {
+                //myHook: {url: 'http://127.0.0.1:9000/MyWebHook', events: 'all'}
+            }
         }
     };
 

--- a/src/server/storage/metadatastorage.js
+++ b/src/server/storage/metadatastorage.js
@@ -411,25 +411,23 @@ function MetadataStorage(mainLogger /*, gmeConfig*/) {
             .nodeify(callback);
     }
 
-    return {
-        start: start,
-        stop: stop,
+    self.start = start;
+    self.stop = stop;
 
-        getProjects: getProjects,
-        getProject: getProject,
-        addProject: addProject,
-        deleteProject: deleteProject,
-        transferProject: transferProject,
-        duplicateProject: duplicateProject,
-        updateProjectInfo: updateProjectInfo,
+    self.getProjects = getProjects;
+    self.getProject = getProject;
+    self.addProject = addProject;
+    self.deleteProject = deleteProject;
+    self.transferProject = transferProject;
+    self.duplicateProject = duplicateProject;
+    self.updateProjectInfo = updateProjectInfo;
 
-        getProjectHooks: getProjectHooks,
-        getProjectHook: getProjectHook,
-        addProjectHook: addProjectHook,
-        updateProjectHooks: updateProjectHooks,
-        updateProjectHook: updateProjectHook,
-        removeProjectHook: removeProjectHook
-    };
+    self.getProjectHooks = getProjectHooks;
+    self.getProjectHook = getProjectHook;
+    self.addProjectHook = addProjectHook;
+    self.updateProjectHooks = updateProjectHooks;
+    self.updateProjectHook = updateProjectHook;
+    self.removeProjectHook = removeProjectHook;
 }
 
 module.exports = MetadataStorage;

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -482,7 +482,7 @@ SafeStorage.prototype.duplicateProject = function (data, callback) {
                     throw new Error('Not authorized to create project for [' + data.ownerId + ']');
                 }
 
-                return self.metadataStorage.duplicateProject(data.ownerId, data.projectName, info);
+                return self.metadataStorage.duplicateProject(data.projectId, data.ownerId, data.projectName, info);
             })
             .then(function (newProjectId) {
                 data.newProjectId = newProjectId;

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -283,11 +283,32 @@ SafeStorage.prototype.createProject = function (data, callback) {
             })
             .then(function (projectId) {
                 data.projectId = projectId;
+
                 return self.authorizer.setAccessRights(data.ownerId, projectId, {
                     read: true,
                     write: true,
                     delete: true
                 }, projectAuthParams);
+            })
+            .then(function () {
+                // Add the default projectHooks
+                var hookIds = Object.keys(self.gmeConfig.webhooks.defaults),
+                    cnt = hookIds.length;
+
+                function addHooks() {
+                    if (cnt === 0) {
+                        return;
+                    } else {
+                        cnt -= 1;
+                        return self.metadataStorage.addProjectHook(data.projectId,
+                            hookIds[cnt], self.gmeConfig.webhooks.defaults[hookIds[cnt]])
+                            .then(function () {
+                                return addHooks();
+                            });
+                    }
+                }
+
+                return addHooks();
             })
             .then(function () {
                 return Storage.prototype.createProject.call(self, data);
@@ -461,8 +482,7 @@ SafeStorage.prototype.duplicateProject = function (data, callback) {
                     throw new Error('Not authorized to create project for [' + data.ownerId + ']');
                 }
 
-                // TODO: Should webhooks be copied over too?
-                return self.metadataStorage.addProject(data.ownerId, data.projectName, info);
+                return self.metadataStorage.duplicateProject(data.ownerId, data.projectName, info);
             })
             .then(function (newProjectId) {
                 data.newProjectId = newProjectId;

--- a/test/server/storage/safestorage.spec.js
+++ b/test/server/storage/safestorage.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe.only('SafeStorage', function () {
+describe('SafeStorage', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         expect = testFixture.expect,

--- a/test/server/storage/safestorage.spec.js
+++ b/test/server/storage/safestorage.spec.js
@@ -6,7 +6,7 @@
 
 var testFixture = require('../../_globals.js');
 
-describe('SafeStorage', function () {
+describe.only('SafeStorage', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         expect = testFixture.expect,
@@ -413,6 +413,59 @@ describe('SafeStorage', function () {
                         .to.equal('object does not exist #52896a42a5e46429f39923400ed5059f309991b8');
                     expect(objects['#52896a42a5e46429f39923400ed5059f309991b9'])
                         .to.equal('object does not exist #52896a42a5e46429f39923400ed5059f309991b9');
+                })
+                .nodeify(done);
+        });
+    });
+
+    describe('Default webhooks', function () {
+        var safeStorage,
+            projectName = 'seedForHook';
+
+        before(function (done) {
+            var configWithDefaults = JSON.parse(JSON.stringify(gmeConfig));
+            configWithDefaults.webhooks.defaults = {
+                'myHook1': {
+                    url: 'localhost:9001',
+                    events: 'all'
+                },
+                'myHook2': {
+                    url: 'localhost:9002',
+                    events: 'all'
+                }
+            };
+
+            safeStorage = testFixture.getMemoryStorage(logger, configWithDefaults, gmeAuth);
+            safeStorage.openDatabase()
+                .then(function () {
+                    return testFixture.importProject(safeStorage, {
+                        projectSeed: 'seeds/EmptyProject.webgmex',
+                        projectName: projectName,
+                        gmeConfig: configWithDefaults,
+                        logger: logger
+                    });
+                })
+                .nodeify(done);
+        });
+
+        after(function (done) {
+            safeStorage.closeDatabase(done);
+        });
+
+        it('should create project and add default webhooks', function (done) {
+            var projectName = 'CreatedWithDefaults',
+                data = {
+                    projectName: projectName
+                };
+
+            safeStorage.createProject(data)
+                .then(function (project) {
+                    return safeStorage.metadataStorage.getProjectHooks(project.projectId);
+                })
+                .then(function (hooks) {
+                    expect(Object.keys(hooks).length).to.equal(2);
+                    expect(hooks.myHook1.url).to.equal('localhost:9001');
+                    expect(hooks.myHook2.url).to.equal('localhost:9002');
                 })
                 .nodeify(done);
         });
@@ -1961,6 +2014,45 @@ describe('SafeStorage', function () {
                 .nodeify(done);
         });
 
+        it('duplicate project should have same hooks a source', function (done) {
+            var projectName = 'hooksAtDuplicate',
+                username = inOrgCanCreateAdmin,
+                data = {
+                    projectName: projectName,
+                    username: username
+                },
+                projectId;
+
+            safeStorage.createProject(data)
+                .then(function (project) {
+                    projectId = project.projectId;
+                    data.projectId = projectId;
+                    data.info = true;
+
+                    return safeStorage.metadataStorage.addProjectHook(projectId, 'dupHook',
+                        {
+                            url: 'localhost',
+                            events: 'all'
+                        }
+                    );
+                })
+                .then(function () {
+                    return safeStorage.duplicateProject({
+                        projectId: projectId,
+                        projectName: 'aDuplicateHooks',
+                        username: username
+                    });
+                })
+                .then(function (project) {
+                    return safeStorage.metadataStorage.getProjectHook(project.projectId, 'dupHook');
+                })
+                .then(function (hook) {
+                    expect(hook.url).to.equal('localhost');
+                    expect(hook.events).to.equal('all');
+                })
+                .nodeify(done);
+        });
+
         it('transferred project should have same kind a source', function (done) {
             var projectName = 'aKindOfTransferredProject',
                 username = inOrgCanCreateAdmin,
@@ -1992,6 +2084,45 @@ describe('SafeStorage', function () {
                 .then(function (projects) {
                     expect(projects.length).to.equal(1);
                     expect(projects[0].info.kind).to.equal('SomeOtherKindOfProject');
+                })
+                .nodeify(done);
+        });
+
+        it('transferred project should have same hooks a source', function (done) {
+            var projectName = 'hooksAtTransfer',
+                username = inOrgCanCreateAdmin,
+                data = {
+                    projectName: projectName,
+                    username: username
+                },
+                projectId;
+
+            safeStorage.createProject(data)
+                .then(function (project) {
+                    projectId = project.projectId;
+                    data.projectId = projectId;
+                    data.info = true;
+
+                    return safeStorage.metadataStorage.addProjectHook(projectId, 'transHook',
+                        {
+                            url: 'localhost',
+                            events: 'all'
+                        }
+                    );
+                })
+                .then(function () {
+                    return safeStorage.transferProject({
+                        projectId: projectId,
+                        newOwnerId: 'theOrg',
+                        username: username
+                    });
+                })
+                .then(function (projectId) {
+                    return safeStorage.metadataStorage.getProjectHook(projectId, 'transHook');
+                })
+                .then(function (hook) {
+                    expect(hook.url).to.equal('localhost');
+                    expect(hook.events).to.equal('all');
                 })
                 .nodeify(done);
         });


### PR DESCRIPTION
This PR also ensures that webhooks defined in transferred or duplicated projects are propagated to the new project.