### PR TITLE
Closes #1434 by storing pending change and apply after update.

### DIFF
--- a/src/client/js/Controls/PropertyGrid/PropertyGrid.js
+++ b/src/client/js/Controls/PropertyGrid/PropertyGrid.js
@@ -33,9 +33,12 @@ define(['js/logger',
         this.__onFinishChange = null;
         this.__onReset = null;
 
+        this._pendingChange = null;
+
         this._gui = new PropertyGridPart({el: this.$el});
         this._gui.onChange(function (args) {
             self._logger.debug('onChange: ' + JSON.stringify(args));
+            self._pendingChange = args;
             if (self.__onChange) {
                 self.__onChange.call(self, args);
             }
@@ -43,6 +46,7 @@ define(['js/logger',
 
         this._gui.onFinishChange(function (args) {
             self._logger.debug('onFinishChange: ' + JSON.stringify(args));
+            self._pendingChange = null;
             if (self.__onFinishChange) {
                 self.__onFinishChange.call(self, args);
             }
@@ -115,6 +119,12 @@ define(['js/logger',
             if (propDesc.isFolder === true) {
                 this._folders[propDesc.name] = guiObj.addFolder(propDesc.name, propDesc.text);
             } else {
+                if (this._pendingChange && this._pendingChange.id === propDesc.id) {
+                    propDesc.originalValue = propDesc.value;
+                    propDesc.value = this._pendingChange.newValue;
+                    propDesc.focusWidget = true;
+                    this._pendingChange = null;
+                }
                 this._widgets[propDesc.id] = guiObj.add(propDesc);
             }
         }

--- a/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
+++ b/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
@@ -5,10 +5,10 @@
  * @author nabana / https://github.com/nabana
  */
 
-define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
-    'js/Constants',
+define([
+    'js/Controls/PropertyGrid/PropertyGridWidgetManager',
     'css!./styles/PropertyGridPart.css'
-], function (PropertyGridWidgetManager, CONSTANTS) {
+], function (PropertyGridWidgetManager) {
 
     'use strict';
 
@@ -148,14 +148,14 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
     };
 
     PropertyGridPart.prototype.add = function (propertyDesc) {
-        var widget,
+        var self = this,
             container = $('<div/>'),
             spnName = $('<span/>', {class: 'property-name'}),
             divAction = $('<div/>', {class: 'p-reset'}),
-            li,
-            self = this,
             extraCss = {},
-            actionBtn;
+            widget,
+            actionBtn,
+            li;
 
         if (this.__widgets[propertyDesc.name] !== undefined) {
             throw new Error('You already have a widget with the name "' + propertyDesc.name + '"');
@@ -230,13 +230,17 @@ define(['js/Controls/PropertyGrid/PropertyGridWidgetManager',
 
         container.append(spnName).append(divAction).append(widget.el);
 
-        li = this._addRow(undefined, container, undefined);
+        li = this._addRow(undefined, container);
 
         li.addClass(CLASS_CONTROLLER_ROW);
         if (propertyDesc.valueType) {
             li.addClass(propertyDesc.valueType);
         } else {
             li.addClass(typeof propertyDesc.value);
+        }
+
+        if (propertyDesc.focusWidget) {
+            widget.focus();
         }
 
         return widget;

--- a/src/client/js/Controls/PropertyGrid/Widgets/DialogWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/DialogWidget.js
@@ -39,11 +39,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase', 'clipboard'], function (W
                 e.stopPropagation();
                 e.preventDefault();
 
-                dialog.show(function (newValue) {
-                        self.setValue(newValue);
-                        self.fireFinishChange();
-                    },
-                    self.getValue());
+                dialog.show(propertyDesc);
             });
         }
 

--- a/src/client/js/Controls/PropertyGrid/Widgets/FloatWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/FloatWidget.js
@@ -19,7 +19,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
         this._input = INPUT_BASE.clone();
 
-        this._input.val(propertyDesc.value);
+        this._input.val(this.propertyValue);
 
         this.min = null;
         if (typeof propertyDesc.minValue === 'number') {
@@ -39,7 +39,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
         this._input.prop('title', this._helpMessage);
 
-        this._input.on('change', function (/* e */) {
+        this._input.on('keyup change', function (/* e */) {
             self._onChange();
         });
 
@@ -102,6 +102,10 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
         this._input.off('blur');
         this._input.off('keydown');
         WidgetBase.prototype.destroy.call(this);
+    };
+
+    FloatWidget.prototype.focus = function () {
+        this._input.focus();
     };
 
     return FloatWidget;

--- a/src/client/js/Controls/PropertyGrid/Widgets/IntegerWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/IntegerWidget.js
@@ -18,7 +18,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
         this._input = INPUT_BASE.clone();
 
-        this._input.val(propertyDesc.value);
+        this._input.val(this.propertyValue);
 
         if (typeof propertyDesc.minValue === 'number') {
             attr = {};
@@ -34,7 +34,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
             this._input.attr(attr);
         }
 
-        this._input.on('change', function (/* e */) {
+        this._input.on('keyup change click', function (/* e */) {
             self._onChange();
         });
 
@@ -92,6 +92,10 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
         this._input.off('blur');
         this._input.off('keydown');
         WidgetBase.prototype.destroy.call(this);
+    };
+
+    IntegerWidget.prototype.focus = function () {
+        this._input.focus();
     };
 
     return IntegerWidget;

--- a/src/client/js/Controls/PropertyGrid/Widgets/MetaTypeWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/MetaTypeWidget.js
@@ -24,8 +24,8 @@ define([
 
         WidgetBase.call(this, propertyDesc);
 
-        activeSelection = WebGMEGlobal.State.getActiveSelection();
-        activeNode = WebGMEGlobal.State.getActiveObject();
+        activeSelection = propertyDesc.activeSelection || WebGMEGlobal.State.getActiveSelection();
+        activeNode = propertyDesc.activeObject || WebGMEGlobal.State.getActiveObject();
         if (activeSelection && activeSelection.length > 0) {
             if (activeSelection.length === 1) {
                 this._gmeNodeId = activeSelection[0];

--- a/src/client/js/Controls/PropertyGrid/Widgets/NumberBoxWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/NumberBoxWidget.js
@@ -91,6 +91,10 @@ define(['js/Controls/PropertyGrid/Widgets/NumberWidgetBase'], function (NumberWi
         }
     };
 
+    NumberBoxWidget.prototype.focus = function () {
+        this.__input.focus();
+    };
+
     return NumberBoxWidget;
 });
 

--- a/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
@@ -69,6 +69,9 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
         }
     };
 
-    return StringWidget;
+    StringWidget.prototype.focus = function () {
+        this.__input.focus();
+    };
 
+    return StringWidget;
 });

--- a/src/client/js/Controls/PropertyGrid/Widgets/WidgetBase.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/WidgetBase.js
@@ -8,14 +8,14 @@ define(['jquery'], function () {
 
     'use strict';
 
-    var EL_BASE = $('<div/>', {class: 'widget'}),
-        WidgetBase;
+    var EL_BASE = $('<div/>', {class: 'widget'});
 
-    WidgetBase = function (propertyDesc) {
+    function WidgetBase(propertyDesc) {
         this.el = EL_BASE.clone();
 
         this.propertyValue = propertyDesc.value;
-        this.originalValue = propertyDesc.value;
+        this.originalValue = typeof propertyDesc.originalValue === 'undefined' ?
+            propertyDesc.value : propertyDesc.originalValue;
         this.propertyName = propertyDesc.name;
         this.propertyID = propertyDesc.id;
         this.propertyText = propertyDesc.text;
@@ -36,7 +36,7 @@ define(['jquery'], function () {
 
         // The function to be called on finishing change.
         this.__onFinishChange = undefined;
-    };
+    }
 
     WidgetBase.prototype.onChange = function (fnc) {
         this.__onChange = fnc;
@@ -87,6 +87,10 @@ define(['jquery'], function () {
 
     WidgetBase.prototype.updateDisplay = function () {
         return this;
+    };
+
+    WidgetBase.prototype.focus = function () {
+
     };
 
     WidgetBase.prototype.remove = function () {

--- a/src/client/js/client.js
+++ b/src/client/js/client.js
@@ -639,10 +639,13 @@ define([
 
             if (!state.viewer && !state.readOnlyProject && state.nodes[ROOT_PATH]) {
                 if (state.msg) {
-                    state.msg += '\n' + msg;
+                    if (msg) {
+                        state.msg += '\n' + msg;
+                    }
                 } else {
-                    state.msg += msg;
+                    state.msg = msg;
                 }
+
                 if (!state.inTransaction) {
                     ASSERT(state.project && state.core && state.branchName);
 
@@ -1771,7 +1774,7 @@ define([
             }
             if (state.core) {
                 state.inTransaction = true;
-                msg = msg || '[';
+                msg = typeof msg === 'string' ? msg : '[';
                 saveRoot(msg);
             } else {
                 logger.error('Can not start transaction with no core available.');

--- a/src/client/js/client/gmeNodeSetter.js
+++ b/src/client/js/client/gmeNodeSetter.js
@@ -93,7 +93,8 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setAttribute(' + path + ',' + name + ',' + JSON.stringify(value) + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setAttribute(' + path + ',' + name + ',' + JSON.stringify(value) + ')');
             }
         }
 
@@ -108,7 +109,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delAttribute(' + path + ',' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delAttribute(' + path + ',' + name + ')');
             }
         }
 
@@ -123,7 +124,8 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setRegistry(' + path + ',' + name + ',' + JSON.stringify(value) + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setRegistry(' + path + ',' + name + ',' + JSON.stringify(value) + ')');
             }
         }
 
@@ -138,7 +140,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delRegistry(' + path + ',' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delRegistry(' + path + ',' + name + ')');
             }
         }
 
@@ -158,7 +160,8 @@ define([], function () {
                 _setAttrAndRegistry(newNode, desc);
                 newPath = storeNode(newNode);
 
-                saveRoot(msg || 'copyNode(' + path + ', ' + parentPath + ', ' + JSON.stringify(desc) + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'copyNode(' + path + ', ' + parentPath + ', ' + JSON.stringify(desc) + ')');
                 return newPath;
             }
         }
@@ -176,7 +179,8 @@ define([], function () {
                     }
                 }
 
-                msg = msg || 'copyMoreNodes(' + JSON.stringify(pathsToCopy) + ',' + parameters.parentId + ')';
+                msg = typeof msg === 'string' ?
+                    msg : 'copyMoreNodes(' + JSON.stringify(pathsToCopy) + ',' + parameters.parentId + ')';
 
                 if (pathsToCopy.length < 1) {
                     // empty on purpose
@@ -235,7 +239,7 @@ define([], function () {
                 }
             }
 
-            saveRoot(msg || 'moveMoreNodes(' + JSON.stringify(returnParams) + ')');
+            saveRoot(typeof msg === 'string' ? msg : 'moveMoreNodes(' + JSON.stringify(returnParams) + ')');
             return returnParams;
         }
 
@@ -293,7 +297,7 @@ define([], function () {
 
             }
 
-            msg = msg || 'createChildren(' + JSON.stringify(result) + ')';
+            msg = typeof msg === 'string' ? msg : 'createChildren(' + JSON.stringify(result) + ')';
             saveRoot(msg);
             return result;
         }
@@ -303,7 +307,7 @@ define([], function () {
 
             if (node) {
                 state.core.deleteNode(node);
-                saveRoot(msg || 'deleteNode(' + path + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'deleteNode(' + path + ')');
             }
         }
 
@@ -321,7 +325,7 @@ define([], function () {
             }
 
             if (didDelete) {
-                saveRoot(msg || 'deleteNodes(' + paths + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'deleteNodes(' + paths + ')');
             }
         }
 
@@ -355,7 +359,7 @@ define([], function () {
 
                 storeNode(newNode);
                 newID = state.core.getPath(newNode);
-                saveRoot(msg || 'createNode(' + parameters.parentId + ',' + parameters.baseId + ',' + newID + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'createNode(' + parameters.parentId + ',' + parameters.baseId + ',' + newID + ')');
             }
 
             return newID;
@@ -373,7 +377,7 @@ define([], function () {
                     state.core.setPointer(node, name, targetNode);
                 }
 
-                saveRoot(msg || 'setPointer(' + path + ',' + name + ',' + target + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setPointer(' + path + ',' + name + ',' + target + ')');
             }
         }
 
@@ -382,7 +386,7 @@ define([], function () {
 
             if (node) {
                 state.core.delPointer(node, name);
-                saveRoot(msg || 'delPointer(' + path + ',' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delPointer(' + path + ',' + name + ')');
             }
         }
 
@@ -394,7 +398,7 @@ define([], function () {
 
             if (node && memberNode) {
                 state.core.addMember(node, setId, memberNode);
-                saveRoot(msg || 'addMember(' + path + ',' + memberPath + ',' + setId + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'addMember(' + path + ',' + memberPath + ',' + setId + ')');
             }
         }
 
@@ -404,7 +408,7 @@ define([], function () {
 
             if (node) {
                 state.core.delMember(node, setId, memberPath);
-                saveRoot(msg || 'removeMember(' + path + ',' + memberPath + ',' + setId + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'removeMember(' + path + ',' + memberPath + ',' + setId + ')');
             }
         }
 
@@ -414,8 +418,8 @@ define([], function () {
 
             if (node) {
                 state.core.setMemberAttribute(node, setId, memberPath, name, value);
-                saveRoot(msg || 'setMemberAttribute(' + path + ',' + memberPath + ',' + setId + ',' + name +
-                    ',' + value + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setMemberAttribute(' + path + ',' + memberPath + ',' + setId + ',' + name + ',' + value + ')');
             }
         }
 
@@ -425,7 +429,8 @@ define([], function () {
 
             if (node) {
                 state.core.delMemberAttribute(node, setId, memberPath, name);
-                saveRoot(msg || 'delMemberAttribute(' + path + ',' + memberPath + ',' + setId + ',' + name + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'delMemberAttribute(' + path + ',' + memberPath + ',' + setId + ',' + name + ')');
             }
         }
 
@@ -435,7 +440,8 @@ define([], function () {
 
             if (node) {
                 state.core.setMemberRegistry(node, setId, memberPath, name, value);
-                saveRoot(msg || 'setMemberRegistry(' + path + ',' + memberPath + ',' + setId + ',' + name + ',' +
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setMemberRegistry(' + path + ',' + memberPath + ',' + setId + ',' + name + ',' +
                     JSON.stringify(value) + ')');
             }
         }
@@ -446,7 +452,8 @@ define([], function () {
 
             if (node) {
                 state.core.delMemberRegistry(node, setId, memberPath, name);
-                saveRoot(msg || 'delMemberRegistry(' + path + ',' + memberPath + ',' + setId + ',' + name + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'delMemberRegistry(' + path + ',' + memberPath + ',' + setId + ',' + name + ')');
             }
         }
 
@@ -457,7 +464,8 @@ define([], function () {
 
             if (node) {
                 state.core.setSetAttribute(node, setName, attrName, attrValue);
-                saveRoot(msg || 'setSetAttribute(' + path + ',' + setName + ',' + attrName + ',' +
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setSetAttribute(' + path + ',' + setName + ',' + attrName + ',' +
                     JSON.stringify(attrValue) + ')');
             }
         }
@@ -467,7 +475,8 @@ define([], function () {
 
             if (node) {
                 state.core.delSetAttribute(node, setName, attrName);
-                saveRoot(msg || 'delSetAttribute(' + path + ',' + setName + ',' + attrName + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'delSetAttribute(' + path + ',' + setName + ',' + attrName + ')');
             }
         }
 
@@ -476,8 +485,8 @@ define([], function () {
 
             if (node) {
                 state.core.setSetRegistry(node, setName, regName, regValue);
-                saveRoot(msg || 'setSetRegistry(' + path + ',' + setName + ',' + regName + ',' +
-                    JSON.stringify(regValue) + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setSetRegistry(' + path + ',' + setName + ',' + regName + ',' + JSON.stringify(regValue) + ')');
             }
         }
 
@@ -486,7 +495,8 @@ define([], function () {
 
             if (node) {
                 state.core.delSetRegistry(node, setName, regName);
-                saveRoot(msg || 'delSetRegistry(' + path + ',' + setName + ',' + regName + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'delSetRegistry(' + path + ',' + setName + ',' + regName + ')');
             }
         }
 
@@ -495,7 +505,7 @@ define([], function () {
 
             if (node) {
                 state.core.createSet(node, setId);
-                saveRoot(msg || 'createSet(' + path + ',' + setId + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'createSet(' + path + ',' + setId + ')');
             }
         }
 
@@ -510,7 +520,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delSet(' + path + ',' + setId + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delSet(' + path + ',' + setId + ')');
             }
         }
 
@@ -526,7 +536,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setBase(' + path + ',' + basePath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setBase(' + path + ',' + basePath + ')');
             }
         }
 
@@ -537,7 +547,7 @@ define([], function () {
 
             if (node && parentNode) {
                 movedPath = storeNode(state.core.moveNode(node, parentNode));
-                saveRoot(msg || 'moveNode(' + path + ',' + parentPath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'moveNode(' + path + ',' + parentPath + ')');
             }
 
             return movedPath;
@@ -554,7 +564,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delBase(' + path + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delBase(' + path + ')');
             }
         }
 
@@ -678,7 +688,7 @@ define([], function () {
                     }
                 }
 
-                saveRoot(msg || 'setMeta(' + path + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setMeta(' + path + ')');
             }
         }
 
@@ -693,7 +703,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'addMixin(' + path + ',' + mixinPath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'addMixin(' + path + ',' + mixinPath + ')');
             }
         }
 
@@ -708,7 +718,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg, 'delMixin(' + path + ',' + mixinPath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delMixin(' + path + ',' + mixinPath + ')');
             }
         }
 
@@ -732,7 +742,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setChildMeta(' + path + ',' + childPath + ',' +
+                saveRoot(typeof msg === 'string' ? msg : 'setChildMeta(' + path + ',' + childPath + ',' +
                     (min || -1) + ',' + (max || -1) + ')');
             }
         }
@@ -762,7 +772,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'Meta.setChildrenMeta(' + path + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'Meta.setChildrenMeta(' + path + ')');
             }
         }
 
@@ -777,7 +787,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delChildMeta(' + path + ', ' + typeId + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delChildMeta(' + path + ', ' + typeId + ')');
             }
         }
 
@@ -792,7 +802,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setAttributeMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setAttributeMeta(' + path + ', ' + name + ')');
             }
         }
 
@@ -807,7 +817,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delAttributeMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delAttributeMeta(' + path + ', ' + name + ')');
             }
         }
 
@@ -823,7 +833,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setPointerMetaTarget(' + path + ', ' + name + ', ' + targetPath + ',' +
+                saveRoot(typeof msg === 'string' ? msg : 'setPointerMetaTarget(' + path + ', ' + name + ', ' + targetPath + ',' +
                     min || -1 + ',' + max || -1 + ')');
             }
         }
@@ -839,7 +849,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delPointerMetaTarget(' + path + ', ' + name + ', ' + targetPath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delPointerMetaTarget(' + path + ', ' + name + ', ' + targetPath + ')');
             }
         }
 
@@ -854,7 +864,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delPointerMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delPointerMeta(' + path + ', ' + name + ')');
             }
         }
 
@@ -888,7 +898,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setPointerMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setPointerMeta(' + path + ', ' + name + ')');
             }
         }
 
@@ -904,7 +914,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'setAspectMetaTarget(' + path + ', ' + name + ',' + targetPath + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'setAspectMetaTarget(' + path + ', ' + name + ',' + targetPath + ')');
             }
         }
 
@@ -919,7 +929,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delAspectMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delAspectMeta(' + path + ', ' + name + ')');
             }
         }
 
@@ -947,7 +957,8 @@ define([], function () {
                     }
                 }
 
-                saveRoot(msg || 'setAspectMetaTargets(' + path + ', ' + name + ',' + JSON.stringify(targetPaths) + ')');
+                saveRoot(typeof msg === 'string' ?
+                    msg : 'setAspectMetaTargets(' + path + ', ' + name + ',' + JSON.stringify(targetPaths) + ')');
             }
         }
 
@@ -962,7 +973,7 @@ define([], function () {
                     return;
                 }
 
-                saveRoot(msg || 'delAspectMeta(' + path + ', ' + name + ')');
+                saveRoot(typeof msg === 'string' ? msg : 'delAspectMeta(' + path + ', ' + name + ')');
             }
         }
 


### PR DESCRIPTION
Whenever there is a change in the widget (w/o submit) the pending value is stored and applied after an update. That widget is focused after the update as well.

This PR also detaches dialogs opened from the Property Editor. That way they can persist themselves after updates made in the model.