### PR TITLE
Fixes #1443 Deleting invalid set throws exception

### DIFF
--- a/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
+++ b/src/client/js/Panels/ControllerBase/DiagramDesignerWidgetMultiTabMemberListControllerBase.js
@@ -1722,29 +1722,32 @@ define(['js/logger',
                 memberListSetsRegistry = memberListContainer.getOwnEditableRegistry(memberListSetsRegistryKey) || [];
             }
 
-            i = memberListSetsRegistry.length;
-            while (i--) {
-                if (memberListSetsRegistry[i].SetID === setID) {
-                    memberListSetsRegistry.splice(i, 1);
-                    break;
+            if(memberListSetsRegistry !== undefined && memberListSetsRegistryKey !== undefined){
+                i = memberListSetsRegistry.length;
+                while (i--) {
+                    if (memberListSetsRegistry[i].SetID === setID) {
+                        memberListSetsRegistry.splice(i, 1);
+                        break;
+                    }
                 }
+
+                //order remaining and reset order number
+                memberListSetsRegistry.sort(function (a, b) {
+                    if (a.order < b.order) {
+                        return -1;
+                    } else {
+                        return 1;
+                    }
+                });
+
+                i = memberListSetsRegistry.length;
+                while (i--) {
+                    memberListSetsRegistry[i].order = i;
+                }
+
+                this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
             }
 
-            //order remaining and reset order number
-            memberListSetsRegistry.sort(function (a, b) {
-                if (a.order < b.order) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            });
-
-            i = memberListSetsRegistry.length;
-            while (i--) {
-                memberListSetsRegistry[i].order = i;
-            }
-
-            this._client.setRegistry(memberListContainerID, memberListSetsRegistryKey, memberListSetsRegistry);
             //finally delete the sheet's SET
             this._client.deleteSet(memberListContainerID, setID);
 


### PR DESCRIPTION
When removing meta-invalid set, the set registry is not available, so the portions of set ordering should be skipped during removal.