### PR TITLE
Option to disabled the use of user-defined/dynamic SVGs

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -86,7 +86,8 @@ var path = require('path'),
                 DSN: '',
                 // see https://docs.sentry.io/clients/javascript/config/
                 ravenOptions: null // defaults to {release: <webgme-version>}
-            }
+            },
+            allowUserDefinedSVG: true
         },
 
         core: {

--- a/config/validator.js
+++ b/config/validator.js
@@ -148,6 +148,7 @@ function validateConfig(configOrFileName) {
     assertBoolean('config.client.errorReporting.enable', config.client.errorReporting.enable);
     assertString('config.client.errorReporting.DSN', config.client.errorReporting.DSN);
     assertObject('config.client.errorReporting.ravenOptions', config.client.errorReporting.ravenOptions, true);
+    assertBoolean('config.client.allowUserDefinedSVG', config.client.allowUserDefinedSVG);
 
     // core
     expectedKeys.push('core');

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
@@ -125,7 +125,6 @@ define([
                     testResult,
                     svg;
 
-
                 if (svgText.indexOf('<svg') >= 0 && svgText.indexOf('</svg>') > 0) {
                     testResult = WebGMEGlobal.SvgManager.testSvgTemplate(svgText, self._clientNode);
                     try {
@@ -171,7 +170,6 @@ define([
                 }
 
                 var filename = $(event.currentTarget).data('filename');
-
 
                 self._filter('$@$impossible$@$');
                 self._editor.show();
@@ -264,6 +262,10 @@ define([
             btnEdit.data('filename', svgPath);
             btnEdit.on('click', editBtnFn);
 
+            if (WebGMEGlobal.gmeConfig.client.allowUserDefinedSVG !== true) {
+                btnEdit.disable(true);
+            }
+
             btnEdit.addClass('glyphicon-pencil');
             btnEdit.addClass('btn-primary');
 
@@ -287,7 +289,6 @@ define([
                         btnEdit.disable(true);
                     }
                 }
-
 
                 divImg.find('.desc').text('-- CURRENT --');
                 divImg.find('.desc').attr('title', '-- CURRENT --');

--- a/src/client/js/Utils/SvgManager.js
+++ b/src/client/js/Utils/SvgManager.js
@@ -24,7 +24,7 @@ define([
     function isSvg(text) {
         var result = false;
 
-        if (DecoratorSVGIconList.indexOf(text) > -1) {
+        if (DecoratorSVGIconList.indexOf(text) > -1 || WebGMEGlobal.gmeConfig.client.allowUserDefinedSVG !== true) {
             return false;
         }
 
@@ -203,6 +203,10 @@ define([
      */
     function testSvgTemplate(templateString, clientNodeObj) {
         var svgContent;
+
+        if (WebGMEGlobal.gmeConfig.client.allowUserDefinedSVG !== true) {
+            return new Error('Not allowed to run or test unsafe script templates.');
+        }
 
         try {
             svgContent = ejs.render(templateString, clientNodeObj);


### PR DESCRIPTION
By default the dynamic svg usage is allowed, but as it poses security vulnerability it could be disabled.
This enhancement introduces the option `client.allowUserDefinedSVG`.
When disabled, the user is not allowed to use the SVG text editor and if the svg container registry has some textual content, it will not be run/compiled/rendered. Only relative pathes can be used in this mode.