### PR TITLE
Limit what users and guests can see about other users/orgs

### DIFF
--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -311,12 +311,13 @@ function createAPI(app, mountPath, middlewareOpts) {
         var userId = getUserId(req);
 
         gmeAuth.getUser(userId)
-            .then(function (data) {
+            .then(function (userData) {
                 var receivedData = req.body;
 
-                if (receivedData.hasOwnProperty('siteAdmin') && !data.siteAdmin) {
+                if (userData.siteAdmin !== true &&
+                    (receivedData.hasOwnProperty('siteAdmin') || receivedData.hasOwnProperty('canCreate'))) {
                     res.status(403);
-                    throw new Error('setting siteAdmin property requires site admin role');
+                    throw new Error('setting siteAdmin and/or canCreate property requires site admin role');
                 }
 
                 return gmeAuth.updateUser(userId, receivedData);
@@ -606,7 +607,7 @@ function createAPI(app, mountPath, middlewareOpts) {
         ensureSameUserOrSiteAdmin(req, res)
             .then(function (userData) {
                 if (userData.siteAdmin !== true &&
-                    (req.body.hasOwnProperty('siteAdmin') && req.body.hasOwnProperty('canCreate'))) {
+                    (req.body.hasOwnProperty('siteAdmin') || req.body.hasOwnProperty('canCreate'))) {
                     res.status(403);
                     throw new Error('setting siteAdmin and/or canCreate property requires site admin role');
                 }

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -249,7 +249,7 @@ function createAPI(app, mountPath, middlewareOpts) {
             var filteredProjects = {};
             data = usersOrOrgs[i];
 
-            if (userData._id === data) {
+            if (userData._id === data._id) {
                 return userData;
             } else if (userData.siteAdmin === true) {
                 return data;

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -519,15 +519,21 @@ function GMEAuth(session, gmeConfig) {
     /**
      *
      * @param {object} [query]
+     * @param {object} [projection]
      * @param {function} [callback]
      * @returns {*}
      */
-    function listUsers(query, callback) {
+    function listUsers(query, projection, callback) {
         var query_ = {type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}};
 
         _resolveQuery(query_, query);
 
-        return collection.find(query_)
+        if (typeof projection === 'function') {
+            callback = projection;
+            projection = undefined;
+        }
+
+        return collection.find(query_, projection)
             .then(function (users) {
                 return Q.ninvoke(users, 'toArray');
             })

--- a/test/server/api/index.spec.js
+++ b/test/server/api/index.spec.js
@@ -155,12 +155,14 @@ describe('ORGANIZATION REST API', function () {
             });
 
             it('should get specific organization /api/v1/orgs/orgInit', function (done) {
-                agent.get(server.getUrl() + '/api/v1/orgs/orgInit').end(function (err, res) {
-                    expect(res.status).equal(200, err);
-                    expect(res.body.admins).to.deep.equal(['userAdminOrg']);
+                agent.get(server.getUrl() + '/api/v1/orgs/orgInit')
+                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(res.body.admins).to.deep.equal(['userAdminOrg']);
 
-                    done();
-                });
+                        done();
+                    });
             });
 
             it('should create a new organization as admin with valid data PUT /api/v1/orgs/newOrg', function (done) {
@@ -286,6 +288,7 @@ describe('ORGANIZATION REST API', function () {
                         };
 
                     agent.get(server.getUrl() + '/api/v1/orgs/' + orgId)
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
 
@@ -457,6 +460,7 @@ describe('ORGANIZATION REST API', function () {
             it('should delete organization as site admin DELETE /api/v1/orgs/orgToDelete', function (done) {
                 var orgName = 'orgToDelete';
                 agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(200, err); // org should exist at this point
 
@@ -466,6 +470,7 @@ describe('ORGANIZATION REST API', function () {
                                 expect(res2.status).equal(204, err);
 
                                 agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                     .end(function (err, res) {
                                         expect(res.status).equal(404, err); // org should not exist at this point
                                         done();
@@ -477,6 +482,7 @@ describe('ORGANIZATION REST API', function () {
             it('should delete organization as org admin DELETE /api/v1/orgs/orgToDelete2', function (done) {
                 var orgName = 'orgToDelete2';
                 agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {
                         expect(res.status).equal(200, err); // org should exist at this point
 
@@ -486,6 +492,7 @@ describe('ORGANIZATION REST API', function () {
                                 expect(res2.status).equal(204, err);
 
                                 agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                     .end(function (err, res) {
                                         expect(res.status).equal(404, err); // org should not exist at this point
                                         done();
@@ -560,6 +567,7 @@ describe('ORGANIZATION REST API', function () {
                 function (done) {
                     var orgName = 'orgInit';
                     agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                         .end(function (err, res) {
                             expect(res.status).equal(200, err); // org should exist at this point
 
@@ -570,6 +578,7 @@ describe('ORGANIZATION REST API', function () {
                                     expect(res2.status).equal(403, err);
 
                                     agent.get(server.getUrl() + '/api/v1/orgs/' + orgName)
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                         .end(function (err, res) {
                                             expect(res.status).equal(200, err); // org should still exist at this point
                                             done();
@@ -743,6 +752,7 @@ describe('ORGANIZATION REST API', function () {
                             expect(res2.status).equal(204, err);
 
                             agent.get(server.getUrl() + '/api/v1/orgs/' + orgId)
+                                .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                 .end(function (err, res) {
                                     expect(res.status).equal(200, err);
                                     expect(res.body.admins).to.deep.equal([userId]);
@@ -796,6 +806,7 @@ describe('ORGANIZATION REST API', function () {
                     var orgId = 'orgToRemoveAdmin',
                         userId = 'userAdminOrg';
                     agent.get(server.getUrl() + '/api/v1/orgs/' + orgId)
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
                             expect(res.body.admins).to.deep.equal([userId]);
@@ -806,6 +817,7 @@ describe('ORGANIZATION REST API', function () {
                                     expect(res2.status).equal(204, err);
 
                                     agent.get(server.getUrl() + '/api/v1/orgs/' + orgId)
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                         .end(function (err, res) {
                                             expect(res.status).equal(200, err);
                                             expect(res.body.admins).to.deep.equal([]);

--- a/test/server/api/index.spec.js
+++ b/test/server/api/index.spec.js
@@ -91,13 +91,15 @@ describe('ORGANIZATION REST API', function () {
                 agent = superagent.agent();
             });
 
-            it('should get all organizations /api/v1/orgs', function (done) {
-                agent.get(server.getUrl() + '/api/v1/orgs').end(function (err, res) {
-                    expect(res.status).equal(200, err);
-                    expect(res.body.length).to.be.above(3);
+            it('should get all organizations /api/v1/orgs if siteAdmin', function (done) {
+                agent.get(server.getUrl() + '/api/v1/orgs')
+                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(res.body.length).to.be.above(3);
 
-                    done();
-                });
+                        done();
+                    });
             });
 
             it('should get disabled orgs too if /api/v1/orgs?includeDisabled=true for site-admin', function (done) {
@@ -602,6 +604,7 @@ describe('ORGANIZATION REST API', function () {
                         expect(res2.status).equal(204, err);
 
                         agent.get(server.getUrl() + '/api/v1/users/userAddedToOrg')
+                            .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                             .end(function (err, res) {
                                 expect(res.status).equal(200, err);
                                 expect(res.body.orgs).to.deep.equal(['orgInit']);
@@ -649,6 +652,7 @@ describe('ORGANIZATION REST API', function () {
                     var orgId = 'orgToRemoveUser',
                         userId = 'userRemovedFromOrg';
                     agent.get(server.getUrl() + '/api/v1/users/' + userId)
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
                             expect(res.body.orgs).to.deep.equal([orgId]);
@@ -659,6 +663,7 @@ describe('ORGANIZATION REST API', function () {
                                     expect(res2.status).equal(204, err);
 
                                     agent.get(server.getUrl() + '/api/v1/users/' + userId)
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                         .end(function (err, res) {
                                             expect(res.status).equal(200, err);
                                             expect(res.body.orgs).to.deep.equal([]);
@@ -674,6 +679,7 @@ describe('ORGANIZATION REST API', function () {
                     var orgId = 'orgInit',
                         userId = 'userAdminOrg';
                     agent.get(server.getUrl() + '/api/v1/users/' + userId)
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
                             expect(res.body.orgs).to.deep.equal([orgId]);
@@ -685,6 +691,7 @@ describe('ORGANIZATION REST API', function () {
                                     expect(res2.status).equal(403, err);
 
                                     agent.get(server.getUrl() + '/api/v1/users/' + userId)
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                                         .end(function (err, res) {
                                             expect(res.status).equal(200, err);
                                             expect(res.body.orgs).to.deep.equal([orgId]);

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -636,7 +636,7 @@ describe('USER REST API', function () {
             });
 
             // AUTH METHODS
-            it('should get all users /api/v1/users if authenticated', function (done) {
+            it('should get all users /api/v1/users if authenticated and admin', function (done) {
                 agent.get(server.getUrl() + '/api/v1/users')
                     .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
                     .end(function (err, res) {

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -32,16 +32,18 @@ describe('USER REST API', function () {
                 .then(function (gmeAuth_) {
                     gmeAuth = gmeAuth_;
                     return Q.allDone([
-                        gmeAuth.addUser('guest', 'guest@example.com', 'guest', true, {overwrite: true}),
+                        gmeAuth.addUser('guest', 'guest@example.com', 'guest', true, {overwrite: true, data: {d: 1}}),
                         gmeAuth.addUser('admin', 'admin@example.com', 'admin', true, {
                             overwrite: true,
                             siteAdmin: true
                         }),
                         gmeAuth.addUser('user', 'user@example.com', 'plaintext', true, {overwrite: true}),
+                        gmeAuth.addUser('user2', 'user2@example.com', 'plaintext', true, {overwrite: true, data: {d: 1}}),
                         gmeAuth.addUser('user_to_delete', 'user@example.com', 'plaintext', true, {overwrite: true}),
                         gmeAuth.addUser('self_delete_1', 'user@example.com', 'plaintext', true, {overwrite: true}),
                         gmeAuth.addUser('self_delete_2', 'user@example.com', 'plaintext', true, {overwrite: true}),
-                        gmeAuth.addUser('user_to_modify', 'user@example.com', 'plaintext', true, {overwrite: true}),
+                        gmeAuth.addUser('user_to_modify', 'user@example.com', 'plaintext', true,
+                            {overwrite: true, data: {d: 1}}),
                         gmeAuth.addUser('user_without_create', 'user@example.com', 'plaintext', false, {overwrite: true}),
                         gmeAuth.addUser('user_w_data', 'e@mail.com', 'plaintext', false, {overwrite: true}),
                         gmeAuth.addUser('user_w_data1', 'e@mail.com', 'plaintext', false, {
@@ -328,15 +330,6 @@ describe('USER REST API', function () {
                     });
             });
 
-            it('should GET /api/v1/users/admin', function (done) {
-                agent.get(server.getUrl() + '/api/v1/users/admin')
-                    .end(function (err, res) {
-                        expect(res.status).equal(200, err);
-
-                        done();
-                    });
-            });
-
             it('should return with the same information GET /api/v1/user and /api/v1/users/guest', function (done) {
                 agent.get(server.getUrl() + '/api/v1/user')
                     .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
@@ -501,51 +494,6 @@ describe('USER REST API', function () {
                                     expect(res2.status).equal(403, err);
 
                                     done();
-                                });
-                        });
-                });
-
-            it('should fail to delete a specified user if not authenticated DELETE /api/v1/users/admin',
-                function (done) {
-                    agent.get(server.getUrl() + '/api/v1/users/admin')
-                        .end(function (err, res) {
-                            expect(res.status).equal(200, err);
-                            agent.del(server.getUrl() + '/api/v1/users/admin')
-                                .end(function (err, res2) {
-                                    expect(res2.status).equal(403, err);
-
-                                    agent.get(server.getUrl() + '/api/v1/users/admin')
-                                        .end(function (err, res2) {
-                                            expect(res.status).equal(200, err);
-
-                                            // make sure we did not lose any users
-                                            expect(res.body).deep.equal(res2.body);
-
-                                            done();
-                                        });
-                                });
-                        });
-                });
-
-            it('should fail to delete a specified user if acting user is not a site admin DELETE /api/v1/users/guest',
-                function (done) {
-                    agent.get(server.getUrl() + '/api/v1/users/user')
-                        .end(function (err, res) {
-                            expect(res.status).equal(200, err);
-                            agent.del(server.getUrl() + '/api/v1/users/user')
-                                //.set('Authorization', 'Basic ' + new Buffer('user:plaintext').toString('base64'))
-                                .end(function (err, res2) {
-                                    expect(res2.status).equal(403, err);
-
-                                    agent.get(server.getUrl() + '/api/v1/users/user')
-                                        .end(function (err, res2) {
-                                            expect(res.status).equal(200, err);
-
-                                            // make sure we did not lose any users
-                                            expect(res.body).deep.equal(res2.body);
-
-                                            done();
-                                        });
                                 });
                         });
                 });
@@ -1172,6 +1120,110 @@ describe('USER REST API', function () {
                 });
             });
 
+            // AUTH
+            it('should get users and filter depending on user-type /api/v1/users', function (done) {
+                var numberOfUsers;
+
+                agent.get(server.getUrl() + '/api/v1/users').end(function (err, res) {
+                    expect(res.status).equal(200, err);
+                    // Guest can only see him/herself.
+                    try {
+                        expect(res.body.length).to.equal(1);
+                        expect(res.body[0]._id).to.equal('guest');
+                    } catch (e) {
+                        return done(e);
+                    }
+
+                    agent.get(server.getUrl() + '/api/v1/users')
+                        .set('Authorization', 'Basic ' + new Buffer('user2:plaintext').toString('base64'))
+                        .end(function (err, res) {
+                            // Regular user can only see details about him/herself.
+                            try {
+                                numberOfUsers = res.body.length;
+                                expect(numberOfUsers > 1).to.equal(true);
+                                res.body.forEach(function (uData) {
+                                    if (uData._id !== 'user2') {
+                                        expect(uData.email.length).to.equal(0);
+                                        expect(Object.keys(uData.data).length).to.equal(0);
+                                    } else {
+                                        expect(uData.email.length > 1).to.equal(true);
+                                    }
+                                });
+                            } catch (e) {
+                                return done(e);
+                            }
+
+                            agent.get(server.getUrl() + '/api/v1/users')
+                                .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                                .end(function (err, res) {
+                                    // Admin can see all details about everyone.
+                                    var gotData = false;
+                                    try {
+                                        expect(res.body.length).to.equal(numberOfUsers);
+                                        res.body.forEach(function (uData) {
+                                            expect(uData.email.length > 1).to.equal(true);
+                                            if (uData._id !== 'admin' && Object.keys(uData.data).length > 0) {
+                                                gotData = true;
+                                            }
+                                        });
+
+                                        expect(gotData).to.equal(true);
+                                    } catch (e) {
+                                        return done(e);
+                                    }
+
+                                    done();
+                                });
+                    });
+                });
+            });
+
+            it('should 404 GET /api/v1/users/user if guest', function (done) {
+                agent.get(server.getUrl() + '/api/v1/users/user')
+                    .end(function (err, res) {
+                        expect(res.status).equal(404, err);
+
+                        done();
+                    });
+            });
+
+            it('should GET /api/v1/users/user if non guest user but filter out email and projects', function (done) {
+                agent.get(server.getUrl() + '/api/v1/users/user')
+                    .set('Authorization', 'Basic ' + new Buffer('user2:plaintext').toString('base64'))
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body.email.length).to.equal(0);
+                            expect(Object.keys(res.body.projects).length).to.equal(0);
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
+                    });
+            });
+
+            it('should GET /api/v1/users/user if admin and contain email', function (done) {
+                agent.get(server.getUrl() + '/api/v1/users/user')
+                    .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(Object.keys(res.body.projects).length).to.equal(1);
+                        expect(res.body.email.length > 1).to.equal(true);
+
+                        done();
+                    });
+            });
+
+            it('should GET /api/v1/users/guest if same user', function (done) {
+                agent.get(server.getUrl() + '/api/v1/users/guest')
+                    .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+
+                        done();
+                    });
+            });
+
             it('should get all users /api/v1/users', function (done) {
                 agent.get(server.getUrl() + '/api/v1/users')
                     .end(function (err, res) {
@@ -1182,6 +1234,55 @@ describe('USER REST API', function () {
                         done();
                     });
             });
+
+            it('should fail to delete a specified user if not authenticated DELETE /api/v1/users/admin',
+                function (done) {
+                    agent.get(server.getUrl() + '/api/v1/users/admin')
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                        .end(function (err, res) {
+                            expect(res.status).equal(200, err);
+                            agent.del(server.getUrl() + '/api/v1/users/admin')
+                                .end(function (err, res2) {
+                                    expect(res2.status).equal(403, err);
+
+                                    agent.get(server.getUrl() + '/api/v1/users/admin')
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                                        .end(function (err, res2) {
+                                            expect(res.status).equal(200, err);
+
+                                            // make sure we did not lose any users
+                                            expect(res.body).deep.equal(res2.body);
+
+                                            done();
+                                        });
+                                });
+                        });
+                });
+
+            it('should fail to delete a specified user if acting user is not a site admin DELETE /api/v1/users/guest',
+                function (done) {
+                    agent.get(server.getUrl() + '/api/v1/users/user')
+                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                        .end(function (err, res) {
+                            expect(res.status).equal(200, err);
+                            agent.del(server.getUrl() + '/api/v1/users/user')
+                            //.set('Authorization', 'Basic ' + new Buffer('user:plaintext').toString('base64'))
+                                .end(function (err, res2) {
+                                    expect(res2.status).equal(403, err);
+
+                                    agent.get(server.getUrl() + '/api/v1/users/user')
+                                        .set('Authorization', 'Basic ' + new Buffer('admin:admin').toString('base64'))
+                                        .end(function (err, res2) {
+                                            expect(res.status).equal(200, err);
+
+                                            // make sure we did not lose any users
+                                            expect(res.body).deep.equal(res2.body);
+
+                                            done();
+                                        });
+                                });
+                        });
+                });
 
             it('should get disabled user too if /api/v1/users?includeDisabled=true for site-admin', function (done) {
                 var dUsers,
@@ -2187,6 +2288,8 @@ describe('USER REST API', function () {
                 });
             });
 
+
+            // AUTH METHODS
             it('should get all users /api/v1/users', function (done) {
                 agent.get(server.getUrl() + '/api/v1/users').end(function (err, res) {
                     expect(res.status).equal(200, err);
@@ -2197,7 +2300,6 @@ describe('USER REST API', function () {
                 });
             });
 
-            // AUTH METHODS
             it('should return with guest user account and 200 GET /api/v1/user', function (done) {
                 agent.get(server.getUrl() + '/api/v1/user').end(function (err, res) {
                     expect(res.status).equal(200, err);

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -387,7 +387,6 @@ describe('USER REST API', function () {
             it('should fail to grant site admin access with no site admin roles PATCH /api/v1/user', function (done) {
                 var updates = {
                     email: 'new_email_address',
-                    canCreate: false,
                     siteAdmin: true
                 };
 
@@ -396,8 +395,31 @@ describe('USER REST API', function () {
                     .end(function (err, res) {
                         expect(res.status).equal(200, err);
                         expect(res.body.email).not.equal(updates.email);
+                        expect(res.body.siteAdmin).not.equal(updates.siteAdmin);
+
+                        agent.patch(server.getUrl() + '/api/v1/user')
+                            .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
+                            .send(updates)
+                            .end(function (err, res2) {
+                                expect(res2.status).equal(403, err);
+
+                                done();
+                            });
+                    });
+            });
+
+            it('should fail to set canCreate access with no site admin roles PATCH /api/v1/user', function (done) {
+                var updates = {
+                    email: 'new_email_address',
+                    canCreate: false
+                };
+
+                agent.get(server.getUrl() + '/api/v1/user')
+                    .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(res.body.email).not.equal(updates.email);
                         expect(res.body.canCreate).not.equal(updates.canCreate);
-                        expect(res.body.siteAdmin).not.equal(true);
 
                         agent.patch(server.getUrl() + '/api/v1/user')
                             .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
@@ -414,7 +436,6 @@ describe('USER REST API', function () {
                 function (done) {
                     var updates = {
                         email: 'new_email_address',
-                        canCreate: false,
                         siteAdmin: true
                     };
 
@@ -423,8 +444,32 @@ describe('USER REST API', function () {
                         .end(function (err, res) {
                             expect(res.status).equal(200, err);
                             expect(res.body.email).not.equal(updates.email);
-                            expect(res.body.canCreate).not.equal(updates.canCreate);
                             expect(res.body.siteAdmin).not.equal(true);
+
+                            agent.patch(server.getUrl() + '/api/v1/users/guest')
+                                .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
+                                .send(updates)
+                                .end(function (err, res2) {
+                                    expect(res2.status).equal(403, err);
+
+                                    done();
+                                });
+                        });
+                });
+
+            it('should fail to set canCreate access acc with no site admin roles PATCH /api/v1/users/guest',
+                function (done) {
+                    var updates = {
+                        email: 'new_email_address',
+                        canCreate: false
+                    };
+
+                    agent.get(server.getUrl() + '/api/v1/user')
+                        .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
+                        .end(function (err, res) {
+                            expect(res.status).equal(200, err);
+                            expect(res.body.email).not.equal(updates.email);
+                            expect(res.body.canCreate).not.equal(updates.canCreate);
 
                             agent.patch(server.getUrl() + '/api/v1/users/guest')
                                 .set('Authorization', 'Basic ' + new Buffer('guest:guest').toString('base64'))
@@ -795,8 +840,7 @@ describe('USER REST API', function () {
 
             it('should update self user with valid data PATCH /api/v1/user', function (done) {
                 var updates = {
-                    email: 'new_email_address',
-                    canCreate: false
+                    email: 'new_email_address'
                 };
 
                 agent.get(server.getUrl() + '/api/v1/user')
@@ -804,7 +848,6 @@ describe('USER REST API', function () {
                     .end(function (err, res) {
                         expect(res.status).equal(200, err);
                         expect(res.body.email).not.equal(updates.email);
-                        expect(res.body.canCreate).not.equal(updates.canCreate);
 
                         agent.patch(server.getUrl() + '/api/v1/user')
                             .set('Authorization', 'Basic ' + new Buffer('user:plaintext').toString('base64'))
@@ -817,7 +860,6 @@ describe('USER REST API', function () {
 
                                 // we have changed just these fields
                                 expect(res2.body.email).equal(updates.email);
-                                expect(res2.body.canCreate).equal(updates.canCreate);
                                 done();
                             });
                     });


### PR DESCRIPTION
First of all site-admins can see everything they could before - so no change there.

#### For authenticated users:
- `/api/users` - Filters out `email`, `settings`, `data`, `siteAdmin`, `canCreate` for all users except the user itself. Only projects that the authenticated user has access to are shown under `projects`. 
- `/api/users/:username` - Same as `/api/users` 
- `/api/orgs` - Only projects that the authenticated user has access to are shown under `projects`. 
- `/api/orgs/:orgId` - Same as `/api/orgs`

#### For guests
- `/api/users` - Only returns the guest-account
- `/api/users/:username` - returns 404 unless the guest account
- `/api/orgs` - Only returns organizations where the guest is a member.
- `/api/orgs/:orgId` - Returns 404 if the guest is not a member. 

By filter out the following is set:
- `email` - `""`
- `settings` and `data` - `{}`
- `siteAdmin` and `canCreate` - `false`