### PR TITLE
Do not show the delete project btn in navigator

### DIFF
--- a/src/client/js/Panels/Header/ProjectNavigatorController.js
+++ b/src/client/js/Panels/Header/ProjectNavigatorController.js
@@ -566,7 +566,9 @@ define([
             }
         };
 
-        if (self.config.disableProjectActions === false) {
+        // if (self.config.disableProjectActions === false) {
+        // #1455 Remove delete project item
+        if (false) {
             self.projects[projectId].menu[0].items.unshift({
                 id: 'deleteProject',
                 label: 'Delete project',


### PR DESCRIPTION
Removing a project is a major action and hovering the project name should not give that as the first option.
Deletion of projects are now done in the manage project item.