### PR TITLE
Fixes #1453 Do not trigger onChange at every keyup

### DIFF
--- a/src/client/js/Controls/PropertyGrid/Widgets/FloatWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/FloatWidget.js
@@ -39,7 +39,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
         this._input.prop('title', this._helpMessage);
 
-        this._input.on('keyup change', function (/* e */) {
+        this._input.on('change', function (/* e */) {
             self._onChange();
         });
 

--- a/src/client/js/Controls/PropertyGrid/Widgets/IntegerWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/IntegerWidget.js
@@ -34,7 +34,7 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
             this._input.attr(attr);
         }
 
-        this._input.on('keyup change click', function (/* e */) {
+        this._input.on('change click', function (/* e */) {
             self._onChange();
         });
 


### PR DESCRIPTION
for Float- and IntegerWidget as that resets the value at incomplete input.