### PR TITLE
Plugin API for invoking other plugins from a plugin

### DIFF
--- a/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
+++ b/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
@@ -7,24 +7,26 @@
  */
 
 define([
+    'common/util/tarjan',
     'js/Controls/PropertyGrid/PropertyGridWidgetManager',
     'text!./templates/PluginConfigDialog.html',
     'css!./styles/PluginConfigDialog.css'
-], function (PropertyGridWidgetManager,
+], function (Tarjan,
+             PropertyGridWidgetManager,
              pluginConfigDialogTemplate) {
 
     'use strict';
 
-    var PluginConfigDialog,
+    var GLOBAL_OPTS_ID = 'Global Options',
         PLUGIN_DATA_KEY = 'plugin',
         ATTRIBUTE_DATA_KEY = 'attribute',
     //jscs:disable maximumLineLength
-        PLUGIN_CONFIG_SECTION_BASE = $('<div><fieldset><form class="form-horizontal" role="form"></form><fieldset></div>'),
+        PLUGIN_CONFIG_SECTION_BASE = $('<div><div class="dependency-title"></div><fieldset><form class="form-horizontal" role="form"></form><fieldset></div>'),
         ENTRY_BASE = $('<div class="form-group"><div class="row"><label class="col-sm-4 control-label">NAME</label><div class="col-sm-8 controls"></div></div><div class="row description"><div class="col-sm-4"></div></div></div>'),
     //jscs:enable maximumLineLength
         DESCRIPTION_BASE = $('<div class="desc muted col-sm-8"></div>');
 
-    PluginConfigDialog = function (params) {
+    function PluginConfigDialog(params) {
         this._propertyGridWidgetManager = new PropertyGridWidgetManager();
         this._propertyGridWidgetManager.registerWidgetForType('boolean', 'iCheckBox');
         this._pluginWidgets = {};
@@ -32,7 +34,7 @@ define([
         this._globalConfig = null;
         this._pluginConfig = null;
         this._client = params.client;
-    };
+    }
 
     PluginConfigDialog.prototype.show = function (globalOptions, pluginMetadata, prevConfig, callback) {
         var self = this;
@@ -63,28 +65,6 @@ define([
         });
 
         this._dialog.modal('show');
-    };
-
-    PluginConfigDialog.prototype._closeAndSave = function () {
-        var invalids = this._dialog.find('input:invalid'),
-            self = this;
-
-        if (invalids.length === 0) {
-            self._pluginConfig = {};
-            self._globalConfig = {};
-
-            Object.keys(self._pluginWidgets).forEach(function (name) {
-                self._pluginConfig[name] = self._pluginWidgets[name].getValue();
-            });
-
-            Object.keys(self._globalWidgets).forEach(function (name) {
-                self._globalConfig[name] = self._globalWidgets[name].getValue();
-            });
-
-            this._dialog.modal('hide');
-        } else {
-            $(invalids[0]).focus();
-        }
     };
 
     PluginConfigDialog.prototype._initDialog = function () {
@@ -125,9 +105,7 @@ define([
         this._title.text(this._pluginMetadata.name + ' ' + 'v' + this._pluginMetadata.version);
 
         // Generate the widget in the body
-        this._generateConfigSection(true);
-        this._divContainer.append($('<hr class="global-and-plugin-divider">'));
-        this._generateConfigSection();
+        this._generateSections();
 
         this._btnSave.on('click', function (event) {
             self._closeAndSave();
@@ -145,46 +123,56 @@ define([
         });
     };
 
-    PluginConfigDialog.prototype._generateConfigSection = function (isGlobal) {
-        var len = isGlobal ? this._globalOptions.length : this._pluginMetadata.configStructure.length,
-            i,
-            el,
-            pluginConfigEntry,
-            widget,
-            descEl,
-            containerEl,
-            pluginSectionEl = PLUGIN_CONFIG_SECTION_BASE.clone();
+    PluginConfigDialog.prototype._generateSections = function () {
+        this._generateConfigSection(GLOBAL_OPTS_ID, this._globalOptions);
+        this._divContainer.append($('<hr class="global-and-plugin-divider">'));
+        this._generateConfigSection(this._pluginMetadata.id, this._pluginMetadata.configStructure);
 
-        if (isGlobal) {
-            pluginSectionEl.data(PLUGIN_DATA_KEY, 'Global Options');
-        } else {
-            pluginSectionEl.data(PLUGIN_DATA_KEY, this._pluginMetadata.id);
+        function addDependencySection() {
+
+        }
+    };
+
+    PluginConfigDialog.prototype._generateConfigSection = function (id, structure, title) {
+        var pluginSectionEl = PLUGIN_CONFIG_SECTION_BASE.clone(),
+            self = this,
+            containerEl;
+
+        pluginSectionEl.data(PLUGIN_DATA_KEY, id);
+
+        if (title) {
+            pluginSectionEl.find('.dependency-title').text(title);
         }
 
         this._divContainer.append(pluginSectionEl);
+
         containerEl = pluginSectionEl.find('.form-horizontal');
 
-        for (i = 0; i < len; i += 1) {
-            pluginConfigEntry = isGlobal ? this._globalOptions[i] : this._pluginMetadata.configStructure[i];
-            descEl = undefined;
+        structure.forEach(function (pluginConfigEntry) {
+            var widget,
+                el,
+                descEl;
 
             // Make sure not modify the global metadata.
             pluginConfigEntry = JSON.parse(JSON.stringify(pluginConfigEntry));
 
-            if (!isGlobal && this._prevConfg.hasOwnProperty(pluginConfigEntry.name)) {
+            // FIXME: This needs to be recursive
+            if (id !== GLOBAL_OPTS_ID && self._prevConfg.hasOwnProperty(pluginConfigEntry.name)) {
                 // Use stored value if available.
-                pluginConfigEntry.value = this._prevConfg[pluginConfigEntry.name];
+                pluginConfigEntry.value = self._prevConfg[pluginConfigEntry.name];
             }
 
-            if (this._client.getProjectAccess().write === false && pluginConfigEntry.writeAccessRequired === true) {
+            if (self._client.getProjectAccess().write === false && pluginConfigEntry.writeAccessRequired === true) {
                 pluginConfigEntry.readOnly = true;
             }
 
-            widget = this._propertyGridWidgetManager.getWidgetForProperty(pluginConfigEntry);
-            if (isGlobal) {
-                this._globalWidgets[pluginConfigEntry.name] = widget;
+            widget = self._propertyGridWidgetManager.getWidgetForProperty(pluginConfigEntry);
+
+            // FIXME: This needs to be recursive
+            if (id === GLOBAL_OPTS_ID) {
+                self._globalWidgets[pluginConfigEntry.name] = widget;
             } else {
-                this._pluginWidgets[pluginConfigEntry.name] = widget;
+                self._pluginWidgets[pluginConfigEntry.name] = widget;
             }
 
             el = ENTRY_BASE.clone();
@@ -211,7 +199,7 @@ define([
                 descEl.append(' The maximum value is: ' + pluginConfigEntry.maxValue + '.');
             }
 
-            if (isGlobal && pluginConfigEntry.name === 'runOnServer' && pluginConfigEntry.readOnly === true) {
+            if (id === GLOBAL_OPTS_ID && pluginConfigEntry.name === 'runOnServer' && pluginConfigEntry.readOnly === true) {
                 // Do not display the boolean box #676
                 descEl.css({
                     color: 'grey',
@@ -228,26 +216,30 @@ define([
             }
 
             containerEl.append(el);
-        }
+        });
     };
 
-    PluginConfigDialog.prototype._readConfig = function () {
-        var newConfig = {},
-            plugin,
-            attrName;
 
-        for (plugin in this._widgets) {
-            if (this._widgets.hasOwnProperty(plugin)) {
-                for (attrName in this._widgets[plugin]) {
-                    if (this._widgets[plugin].hasOwnProperty(attrName)) {
-                        newConfig[plugin] = newConfig[plugin] || {};
-                        newConfig[plugin][attrName] = this._widgets[plugin][attrName].getValue();
-                    }
-                }
-            }
+    PluginConfigDialog.prototype._closeAndSave = function () {
+        var invalids = this._dialog.find('input:invalid'),
+            self = this;
+
+        if (invalids.length === 0) {
+            self._pluginConfig = {};
+            self._globalConfig = {};
+
+            Object.keys(self._pluginWidgets).forEach(function (name) {
+                self._pluginConfig[name] = self._pluginWidgets[name].getValue();
+            });
+
+            Object.keys(self._globalWidgets).forEach(function (name) {
+                self._globalConfig[name] = self._globalWidgets[name].getValue();
+            });
+
+            this._dialog.modal('hide');
+        } else {
+            $(invalids[0]).focus();
         }
-
-        return newConfig;
     };
 
     return PluginConfigDialog;

--- a/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
+++ b/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
@@ -122,7 +122,7 @@ define([
         this._modalHeader.prepend(iconEl);
 
         this._title = this._modalHeader.find('.modal-title');
-        this._title.text(this._pluginMetadata.id + ' ' + 'v' + this._pluginMetadata.version);
+        this._title.text(this._pluginMetadata.name + ' ' + 'v' + this._pluginMetadata.version);
 
         // Generate the widget in the body
         this._generateConfigSection(true);

--- a/src/client/js/Dialogs/PluginConfig/styles/PluginConfigDialog.css
+++ b/src/client/js/Dialogs/PluginConfig/styles/PluginConfigDialog.css
@@ -16,6 +16,10 @@
   .plugin-config-dialog .modal-body .global-and-plugin-divider {
     margin-top: 0;
     margin-bottom: 10px; }
+  .plugin-config-dialog .modal-body .dependency-title {
+    color: grey;
+    font-style: italic;
+    position: relative; }
 .plugin-config-dialog .modal-footer {
   padding: 10px;
   margin-top: 5px; }

--- a/src/client/js/Dialogs/PluginConfig/styles/PluginConfigDialog.scss
+++ b/src/client/js/Dialogs/PluginConfig/styles/PluginConfigDialog.scss
@@ -24,6 +24,11 @@
       margin-top: 0;
       margin-bottom: 10px;
     }
+    .dependency-title {
+      color: grey;
+      font-style: italic;
+      position: relative;
+    }
   }
 
   .modal-footer {

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -27,6 +27,10 @@ define([
      */
     var BlobClient = function (parameters) {
         var self = this;
+
+        // Store these to be able to create a new instance from an instance.
+        this.parameters = parameters;
+
         this.artifacts = [];
         if (parameters && parameters.logger) {
             this.logger = parameters.logger;
@@ -69,8 +73,6 @@ define([
         }
         this.relativeUrl = '/rest/blob/';
         this.blobUrl = this.origin + this.relativeUrl;
-        // TODO: TOKEN???
-        // TODO: any ways to ask for this or get it from the configuration?
 
         this.isNodeOrNodeWebKit = typeof process !== 'undefined';
         if (this.isNodeOrNodeWebKit) {
@@ -89,6 +91,15 @@ define([
 
         this.logger.debug('origin', this.origin);
         this.logger.debug('blobUrl', this.blobUrl);
+    };
+
+    /**
+     * Creates and returns a new instance of a BlobClient with the same settings as the current one.
+     * This can be used to avoid issues with the artifacts being book-kept at the instance.
+     * @returns {BlobClient} A new instance of a BlobClient
+     */
+    BlobClient.prototype.getNewInstance = function () {
+        return new BlobClient(this.parameters);
     };
 
     BlobClient.prototype.getMetadataURL = function (hash) {

--- a/src/common/util/tarjan.js
+++ b/src/common/util/tarjan.js
@@ -1,0 +1,192 @@
+/*globals define*/
+/**
+ * Module for finding strongly connected components in a directed graph, that is circular references.
+ *
+ * Based on https://gist.github.com/chadhutchins/1440602 but with constant time stack lookup.
+ * https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+ *
+ * The example below returns the SCC v2,v3,v4
+ *     v1 -*  v2
+ *            / *
+ *           *   \
+ *          v3 -* v4
+ * @example
+ *
+ * var t = new Tarjan();
+ *
+ * t.addVertex(1);
+ * t.addVertex(2);
+ * t.addVertex(3);
+ * t.addVertex(4);
+ *
+ * t.connectVertices(1, 2); // Order matters
+ * t.connectVertices(2, 3);
+ * t.connectVertices(3, 4);
+ * t.connectVertices(4, 2);
+ *
+ * t.calculateSCCs();   -> [[1, 2, 3]]
+ * t.hasLoops(); -> true
+ *
+ *
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+define([], function () {
+    'use strict';
+    function Vertex(id) {
+        this.id = id;
+        this.connectedVertices = [];
+        this.index = -1;
+        this.lowlink = -1;
+    }
+
+    Vertex.prototype.connectTo = function (vertex) {
+        this.connectedVertices.push(vertex);
+    };
+
+    function Graph() {
+        // Assumption: ids are unique.
+        this.vertices = {};
+    }
+
+    Graph.prototype.addVertex = function (id) {
+        if (this.vertices.hasOwnProperty(id)) {
+            return false;
+        } else {
+            this.vertices[id] = new Vertex(id);
+            return true;
+        }
+    };
+
+    Graph.prototype.connectVertices = function (id1, id2) {
+        if (this.vertices.hasOwnProperty(id1) === false) {
+            throw new Error('Vertex [' + id1 + '] was never added to graph!');
+        }
+
+        if (this.vertices.hasOwnProperty(id2) === false) {
+            throw new Error('Vertex [' + id2 + '] was never added to graph!');
+        }
+
+        this.vertices[id1].connectTo(this.vertices[id2]);
+    };
+
+    function Tarjan() {
+        this.index = 0;
+        this.stackLookup = {};
+        this.stack = [];
+        this.graph = new Graph();
+        this.SCCs = [];
+        this.didRun = false;
+    }
+
+    /**
+     * Adds a vertex with given id.
+     * @param {string|number} id
+     * @returns {boolean} false if it was already added.
+     */
+    Tarjan.prototype.addVertex = function (id) {
+        if (this.didRun) {
+            throw new Error('Cannot modify graph after algorithm ran!');
+        }
+
+        return this.graph.addVertex(id);
+    };
+
+    /**
+     * Creates a connection from vertex at id1 to vertex at id2
+     * @param {string|number} id1
+     * @param {string|number} id2
+     */
+    Tarjan.prototype.connectVertices = function (id1, id2) {
+        if (this.didRun) {
+            throw new Error('Cannot modify graph after algorithm ran!');
+        }
+
+        this.graph.connectVertices(id1, id2);
+    };
+
+    /**
+     * Checks if there are any loops in the graph.
+     * @returns {boolean}
+     */
+    Tarjan.prototype.hasLoops = function () {
+        var i;
+
+        this.calculateSCCs();
+
+        for (i = 0; i < this.SCCs.length; i += 1) {
+            if (this.SCCs[i].length > 1) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    /**
+     * Returns the strongly connected components (by ids)
+     * @returns {Array<Array<String|Number>>} An array with all SCCs.
+     */
+    Tarjan.prototype.calculateSCCs = function () {
+        var id;
+
+        if (this.didRun === false) {
+            for (id in this.graph.vertices) {
+                if (this.graph.vertices[id].index < 0) {
+                    this._strongConnect(this.graph.vertices[id]);
+                }
+            }
+
+            this.didRun = true;
+        }
+
+        return this.SCCs;
+    };
+
+    Tarjan.prototype._strongConnect = function (vertex) {
+        var i,
+            connectedVertex,
+            sccVertices = [],
+            topVertex;
+        // Set the depth index for v to the smallest unused index
+        vertex.index = this.index;
+        vertex.lowlink = this.index;
+        this.index = this.index + 1;
+
+        this.stack.push(vertex);
+        this.stackLookup[vertex.id] = true;
+        // Consider successors of vertex
+        // aka... consider each vertex in vertex.connections
+        for (i = 0; i < vertex.connectedVertices.length; i += 1) {
+            connectedVertex = vertex.connectedVertices[i];
+            if (connectedVertex.index < 0) {
+                // Successor connectedVertex has not yet been visited; recurse on it
+                this._strongConnect(connectedVertex);
+                vertex.lowlink = Math.min(vertex.lowlink, connectedVertex.lowlink);
+            } else if (this.stackLookup[connectedVertex.id]) {
+                // Successor connectedVertex is in stack S and hence in the current SCC
+                vertex.lowlink = Math.min(vertex.lowlink, connectedVertex.index);
+            }
+        }
+
+        // If vertex is a root node, pop the stack and generate an SCC.
+        if (vertex.lowlink === vertex.index) {
+            // start a new strongly connected component
+            if (this.stack.length > 0) {
+                do {
+                    topVertex = this.stack.pop();
+                    this.stackLookup[topVertex.id] = false;
+                    // add topVertex to current strongly connected component
+                    sccVertices.push(topVertex.id);
+                } while (vertex.id !== topVertex.id);
+            }
+            // output the current strongly connected component
+            // ... i'm going to push the results to a member scc array variable
+            if (sccVertices.length > 0) {
+                this.SCCs.push(sccVertices);
+            }
+        }
+    };
+
+    return Tarjan;
+});

--- a/src/common/util/tarjan.js
+++ b/src/common/util/tarjan.js
@@ -24,7 +24,7 @@
  * t.connectVertices(3, 4);
  * t.connectVertices(4, 2);
  *
- * t.calculateSCCs();   -> [[1, 2, 3]]
+ * t.calculateSCCs();   -> [[1], [2, 3, 4]]
  * t.hasLoops(); -> true
  *
  *

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -47,7 +47,7 @@ define([], function () {
      * @param {PluginMessage} pluginMessage
      */
     InterPluginResult.prototype.addMessage = function (pluginMessage) {
-        this.pluginResult.messages.push(pluginMessage);
+        this.pluginResult.addMessage(pluginMessage);
     };
 
     InterPluginResult.prototype.getArtifacts = function () {

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -34,13 +34,7 @@ define(['plugin/PluginResultBase'], function (PluginResultBase) {
      * @param {string} message
      */
     InterPluginResult.prototype.addCommitMessage = function (message) {
-        if (typeof message === 'string') {
-            this.commitMessages.push(message);
-        } else {
-            // In order to be called from other plugin via PluginBase.invokePlugin
-            // the plugin must use PluginBase.save instead of persisting/committing on its own.
-            throw new Error('Plugin is being called from other plugin - addCommit takes string.');
-        }
+        this.commitMessages.push(message);
     };
 
     /**

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -1,0 +1,87 @@
+/*globals define*/
+/*jshint browser: true, node:true*/
+
+/**
+ * A module representing the result from an invoked plugin.
+ * @author pmeijer / https://github.com/meijer
+ */
+
+define([], function () {
+    'use strict';
+
+    /**
+     * Initializes a new instance of a plugin result object passed from an invoked plugin.
+     * @constructor
+     * @alias InterPluginResult
+     */
+    var InterPluginResult = function (pluginResult, pluginInstance) {
+        this.pluginResult = pluginResult;
+        this.success = false;
+        this.error = null;
+
+        this.artifacts = [];
+        this.commitMessages = [];
+
+        this.pluginInstance = pluginInstance;
+    };
+
+    /**
+     * Gets the success flag of this result object
+     *
+     * @returns {boolean}
+     */
+    InterPluginResult.prototype.getSuccess = function () {
+        return this.success;
+    };
+
+    /**
+     * Sets the success flag of this result.
+     *
+     * @param {boolean} value
+     */
+    InterPluginResult.prototype.setSuccess = function (value) {
+        this.success = value;
+    };
+
+    /**
+     * Adds a new plugin message to the messages list.
+     *
+     * @param {PluginMessage} pluginMessage
+     */
+    InterPluginResult.prototype.addMessage = function (pluginMessage) {
+        this.pluginResult.messages.push(pluginMessage);
+    };
+
+    InterPluginResult.prototype.getArtifacts = function () {
+        return this.artifacts;
+    };
+
+    /**
+     * Adds a saved artifact to the result - linked via its hash.
+     *
+     * @param {string} hash - Hash of saved artifact.
+     */
+    InterPluginResult.prototype.addArtifact = function (hash) {
+        this.artifacts.push(hash);
+    };
+
+    /**
+     *
+     * @param {string} message
+     */
+    InterPluginResult.prototype.addCommit = function (message) {
+        if (typeof message === 'string') {
+            this.commitMessages.push(message);
+        } else {
+            // In order to be called from other plugin via PluginBase.invokePlugin
+            // the plugin must use PluginBase.save instead of persisting/committing on its own.
+            throw new Error('Plugin is being called from other plugin - addCommit takes string.');
+        }
+    };
+
+    InterPluginResult.prototype.getCommitMessages = function () {
+        return this.commitMessages;
+    };
+
+    return InterPluginResult;
+});

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -6,68 +6,34 @@
  * @author pmeijer / https://github.com/meijer
  */
 
-define([], function () {
+define(['plugin/PluginResultBase'], function (PluginResultBase) {
     'use strict';
 
     /**
      * Initializes a new instance of a plugin result object passed from an invoked plugin.
      * @constructor
+     * @augments PluginResultBase
      * @alias InterPluginResult
      */
-    var InterPluginResult = function (pluginResult, pluginInstance) {
-        this.pluginResult = pluginResult;
+    var InterPluginResult = function (pluginInstance) {
         this.success = false;
         this.artifacts = [];
+        this.messages = [];
         this.commitMessages = [];
 
         this.pluginInstance = pluginInstance;
+        this.pluginName = pluginInstance.getName();
     };
+
+    // Prototypical inheritance from PluginResultBase.
+    InterPluginResult.prototype = Object.create(PluginResultBase.prototype);
+    InterPluginResult.prototype.constructor = InterPluginResult;
 
     /**
-     * Gets the success flag of this result object
-     *
-     * @returns {boolean}
-     */
-    InterPluginResult.prototype.getSuccess = function () {
-        return this.success;
-    };
-
-    /**
-     * Sets the success flag of this result.
-     *
-     * @param {boolean} value
-     */
-    InterPluginResult.prototype.setSuccess = function (value) {
-        this.success = value;
-    };
-
-    /**
-     * Adds a new plugin message to the messages list.
-     *
-     * @param {PluginMessage} pluginMessage
-     */
-    InterPluginResult.prototype.addMessage = function (pluginMessage) {
-        this.pluginResult.addMessage(pluginMessage);
-    };
-
-    InterPluginResult.prototype.getArtifacts = function () {
-        return this.artifacts;
-    };
-
-    /**
-     * Adds a saved artifact to the result - linked via its hash.
-     *
-     * @param {string} hash - Hash of saved artifact.
-     */
-    InterPluginResult.prototype.addArtifact = function (hash) {
-        this.artifacts.push(hash);
-    };
-
-    /**
-     *
+     * Adds commit message to result.
      * @param {string} message
      */
-    InterPluginResult.prototype.addCommit = function (message) {
+    InterPluginResult.prototype.addCommitMessage = function (message) {
         if (typeof message === 'string') {
             this.commitMessages.push(message);
         } else {
@@ -77,6 +43,10 @@ define([], function () {
         }
     };
 
+    /**
+     * Gets the added commitMessages.
+     * @param {string[]} messages
+     */
     InterPluginResult.prototype.getCommitMessages = function () {
         return this.commitMessages;
     };

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -17,8 +17,6 @@ define([], function () {
     var InterPluginResult = function (pluginResult, pluginInstance) {
         this.pluginResult = pluginResult;
         this.success = false;
-        this.error = null;
-
         this.artifacts = [];
         this.commitMessages = [];
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -452,7 +452,7 @@ define([
         commitMessage = message ? commitMessage + ' - ' + message : commitMessage;
 
         if (this.callDepth > 0) {
-            self.logger.info('Call-depth is greater than zero, will not persist "', this.callDepth, '"');
+            self.logger.debug('Call-depth is greater than zero, will not persist "', this.callDepth, '"');
             // How to handle this neatly..
             self.addCommitToResult(commitMessage);
             return Q.resolve({
@@ -475,7 +475,7 @@ define([
             .then(function (commitResult) {
                 if (commitResult.status === STORAGE_CONSTANTS.SYNCED) {
                     self.currentHash = commitResult.hash;
-                    self.logger.info('"' + self.branchName + '" was updated to the new commit.');
+                    self.logger.debug('"' + self.branchName + '" was updated to the new commit.');
                     self.addCommitToResult(STORAGE_CONSTANTS.SYNCED);
                     return commitResult;
                 } else if (commitResult.status === STORAGE_CONSTANTS.FORKED) {
@@ -522,7 +522,7 @@ define([
             .then(function (forkResult) {
                 if (forkResult.status === STORAGE_CONSTANTS.SYNCED) {
                     self.branchName = forkName;
-                    self.logger.info('"' + self.branchName + '" was updated to the new commit.' +
+                    self.logger.debug('"' + self.branchName + '" was updated to the new commit.' +
                         '(Successive saves will try to save to this new branch.)');
                     self.addCommitToResult(STORAGE_CONSTANTS.FORKED);
 
@@ -557,7 +557,7 @@ define([
 
         if (this.callDepth > 0) {
             self.logger.warn('callDepth is greater than zero, will not fast-forward "', this.callDepth, '"');
-            return Q.resolve(false);
+            return Q.resolve(false).nodeify(callback);
         }
 
         return self.project.getBranchHash(self.branchName)
@@ -617,7 +617,7 @@ define([
         };
 
         if (this.callDepth > 0) {
-            this.logger.info('callDepth is greater than zero, will append commit-message to result:', status);
+            this.logger.debug('callDepth is greater than zero, will append commit-message to result:', status);
             this.result.addCommitMessage(status);
         } else {
             this.result.addCommit(newCommit);
@@ -750,7 +750,7 @@ define([
                 if (self._currentConfig.hasOwnProperty('_dependencies') &&
                     self._currentConfig._dependencies.hasOwnProperty(pluginId) &&
                     self._currentConfig._dependencies[pluginId].hasOwnProperty('pluginConfig')) {
-                    console.log(self._currentConfig._dependencies[pluginId].pluginConfig);
+
                     for (cfgKey in self._currentConfig._dependencies[pluginId].pluginConfig) {
                         pluginConfig[cfgKey] = self._currentConfig._dependencies[pluginId].pluginConfig[cfgKey];
                     }

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -708,13 +708,11 @@ define([
             .then(function (PluginClass) {
                 var pluginConfig,
                     metaName,
-                    index,
-                    i,
                     cfgKey;
 
                 pluginInstance = new PluginClass();
 
-                pluginInstance.initialize(self.logger.fork(pluginId), self.blobClient, self.gmeConfig);
+                pluginInstance.initialize(self.logger.fork(pluginId), self.blobClient.getNewInstance(), self.gmeConfig);
                 pluginInstance.result = new InterPluginResult(self.result, pluginInstance);
 
                 ['core', 'project', 'branch', 'projectName', 'projectId', 'branchName', 'branchHash', 'commitHash',
@@ -746,19 +744,9 @@ define([
                 pluginConfig = pluginInstance.getDefaultConfig();
 
                 // 2. If the current-plugin has a sub-config for this plugin (from the default UI) - add those.
-                index = -1;
-                if (typeof self._currentConfig._dependencies && self._currentConfig._dependencies.length > 0) {
-                    for (i = 0; i < self._currentConfig._dependencies.length; i += 1) {
-                        if (self._currentConfig._dependencies[i].id === pluginId) {
-                            index = i;
-                            break;
-                        }
-                    }
-                }
-
-                if (index > -1) {
-                    for (cfgKey in self._currentConfig._dependencies[index].pluginConfig) {
-                        pluginConfig[cfgKey] = self._currentConfig._dependencies[index].pluginConfig[cfgKey];
+                if (self._currentConfig._dependencies && self._currentConfig._dependencies.hasOwnProperty(pluginId)) {
+                    for (cfgKey in self._currentConfig._dependencies[pluginId].pluginConfig) {
+                        pluginConfig[cfgKey] = self._currentConfig._dependencies[pluginId].pluginConfig[cfgKey];
                     }
                 }
 
@@ -882,6 +870,22 @@ define([
      */
     PluginBase.prototype.getMetadata = function () {
         return this.pluginMetadata;
+    };
+
+    /**
+     * Gets the ids of the directly defined dependencies of the plugin
+     *
+     * @returns {string[]}
+     */
+    PluginBase.prototype.getPluginDependencies = function () {
+        if (this.pluginMetadata && this.pluginMetadata.dependencies) {
+            return this.pluginMetadata.dependencies
+                .map(function (data) {
+                    return data.id;
+                });
+        } else {
+            return [];
+        }
     };
     //</editor-fold>
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -758,8 +758,8 @@ define([
 
                 // 3. Finally use the specific config passed here.
                 if (context.pluginConfig) {
-                    for (cfgKey in context.pluginConfig[pluginId]) {
-                        pluginConfig[cfgKey] = context.pluginConfig[pluginId][cfgKey];
+                    for (cfgKey in context.pluginConfig) {
+                        pluginConfig[cfgKey] = context.pluginConfig[cfgKey];
                     }
                 }
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -453,8 +453,7 @@ define([
 
         if (this.callDepth > 0) {
             self.logger.debug('Call-depth is greater than zero, will not persist "', this.callDepth, '"');
-            // How to handle this neatly..
-            self.addCommitToResult(commitMessage);
+            self.result.addCommitMessage(commitMessage);
             return Q.resolve({
                 hash: self.currentHash,
                 // TODO: Do we need a status? Which one? SYNCED so it can proceed?
@@ -616,13 +615,8 @@ define([
             status: status
         };
 
-        if (this.callDepth > 0) {
-            this.logger.debug('callDepth is greater than zero, will append commit-message to result:', status);
-            this.result.addCommitMessage(status);
-        } else {
-            this.result.addCommit(newCommit);
-            this.logger.debug('newCommit added', newCommit);
-        }
+        this.result.addCommit(newCommit);
+        this.logger.debug('newCommit added', newCommit);
     };
 
     /**

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -744,7 +744,10 @@ define([
                 pluginConfig = pluginInstance.getDefaultConfig();
 
                 // 2. If the current-plugin has a sub-config for this plugin (from the default UI) - add those.
-                if (self._currentConfig._dependencies && self._currentConfig._dependencies.hasOwnProperty(pluginId)) {
+                if (self._currentConfig.hasOwnProperty('_dependencies') &&
+                    self._currentConfig._dependencies.hasOwnProperty(pluginId) &&
+                    self._currentConfig._dependencies[pluginId].hasOwnProperty('pluginConfig')) {
+                    console.log(self._currentConfig._dependencies[pluginId].pluginConfig);
                     for (cfgKey in self._currentConfig._dependencies[pluginId].pluginConfig) {
                         pluginConfig[cfgKey] = self._currentConfig._dependencies[pluginId].pluginConfig[cfgKey];
                     }
@@ -757,6 +760,7 @@ define([
                     }
                 }
 
+                pluginInstance.setCurrentConfig(pluginConfig);
                 pluginInstance.isConfigured = true;
                 pluginInstance.callDepth = self.callDepth += 1;
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -700,8 +700,8 @@ define([
 
                 pluginInstance = new PluginClass();
 
-                pluginInstance.initialize(this.logger.fork(pluginId), this.blobClient, this.gmeConfig);
-                pluginInstance.result = new InterPluginResult(this.result, pluginInstance);
+                pluginInstance.initialize(self.logger.fork(pluginId), self.blobClient, self.gmeConfig);
+                pluginInstance.result = new InterPluginResult(self.result, pluginInstance);
 
                 ['core', 'project', 'branch', 'projectName', 'projectId', 'branchName', 'branchHash', 'commitHash',
                     'currentHash', 'rootNode', 'notificationHandlers']
@@ -709,22 +709,22 @@ define([
                         pluginInstance[sameField] = self[sameField];
                     });
 
-                pluginInstance.activeNode = context.activeNode || this.activeNode;
-                pluginInstance.activeSelection = context.activeSelection || this.activeSelection;
+                pluginInstance.activeNode = context.activeNode || self.activeNode;
+                pluginInstance.activeSelection = context.activeSelection || self.activeSelection;
 
                 if (context.namespace) {
-                    pluginInstance.namespace = this.namespace === '' ?
-                        context : this.namespace + '.' + context.namespace;
+                    pluginInstance.namespace = self.namespace === '' ?
+                        context : self.namespace + '.' + context.namespace;
 
                     pluginInstance.META = {};
-                    for (metaName in this.META) {
+                    for (metaName in self.META) {
                         if (metaName.indexOf('.') > -1) {
-                            this.META[metaName.substring(metaName.indexOf('.') + 1)] = this.META[metaName];
+                            self.META[metaName.substring(metaName.indexOf('.') + 1)] = self.META[metaName];
                         }
                     }
                 } else {
-                    pluginInstance.namespace = this.namespace;
-                    pluginInstance.META = this.META;
+                    pluginInstance.namespace = self.namespace;
+                    pluginInstance.META = self.META;
                 }
 
                 // TODO: For the config should we pass other dependents as well?
@@ -733,9 +733,9 @@ define([
                 pluginConfig = pluginInstance.getDefaultConfig();
 
                 // 2. If the current-plugin has a sub-config for this plugin (from the default UI) - add those.
-                if (typeof this._currentConfig[pluginId] && this._currentConfig[pluginId] !== null) {
-                    for (cfgKey in this._currentConfig[pluginId]) {
-                        pluginConfig[cfgKey] = this._currentConfig[pluginId][cfgKey];
+                if (typeof self._currentConfig[pluginId] && self._currentConfig[pluginId] !== null) {
+                    for (cfgKey in self._currentConfig[pluginId]) {
+                        pluginConfig[cfgKey] = self._currentConfig[pluginId][cfgKey];
                     }
                 }
 
@@ -747,13 +747,14 @@ define([
                 }
 
                 pluginInstance.isConfigured = true;
-                pluginInstance.callDepth = this.callDepth += 1;
+                pluginInstance.callDepth = self.callDepth += 1;
 
-                return Q.ninvoke(pluginInstance.main);
+                return Q.ninvoke(pluginInstance, 'main');
             })
-            .then(deferred.resolve)
+            .then(function (res) {
+                deferred.resolve(res);
+            })
             .catch(function (err) {
-                console.log(err);
                 deferred.reject(err);
             });
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -12,6 +12,7 @@
 define([
     'q',
     'plugin/PluginConfig',
+    'plugin/PluginResultBase',
     'plugin/PluginResult',
     'plugin/InterPluginResult',
     'plugin/PluginMessage',
@@ -20,6 +21,7 @@ define([
     'common/storage/constants'
 ], function (Q,
              PluginConfig,
+             PluginResultBase,
              PluginResult,
              InterPluginResult,
              PluginMessage,
@@ -121,7 +123,7 @@ define([
         this.META = null;
 
         /**
-         * @type {PluginResult}
+         * @type {PluginResultBase}
          */
         this.result = null;
 
@@ -499,7 +501,8 @@ define([
                     return commitResult;
                 } else if (!self.branchName) {
                     self.currentHash = commitResult.hash;
-                    self.addCommitToResult(null);
+                    self.addCommitToResult(commitResult.status);
+                    return commitResult;
                 } else {
                     throw new Error('setBranchHash returned unexpected status' + commitResult.status);
                 }
@@ -615,7 +618,7 @@ define([
 
         if (this.callDepth > 0) {
             this.logger.info('callDepth is greater than zero, will append commit-message to result:', status);
-            this.result.addCommit(status);
+            this.result.addCommitMessage(status);
         } else {
             this.result.addCommit(newCommit);
             this.logger.debug('newCommit added', newCommit);
@@ -713,7 +716,7 @@ define([
                 pluginInstance = new PluginClass();
 
                 pluginInstance.initialize(self.logger.fork(pluginId), self.blobClient.getNewInstance(), self.gmeConfig);
-                pluginInstance.result = new InterPluginResult(self.result, pluginInstance);
+                pluginInstance.result = new InterPluginResult(pluginInstance);
 
                 ['core', 'project', 'branch', 'projectName', 'projectId', 'branchName', 'branchHash', 'commitHash',
                     'currentHash', 'rootNode', 'notificationHandlers']
@@ -762,7 +765,7 @@ define([
 
                 pluginInstance.setCurrentConfig(pluginConfig);
                 pluginInstance.isConfigured = true;
-                pluginInstance.callDepth = self.callDepth += 1;
+                pluginInstance.callDepth = self.callDepth + 1;
 
                 return Q.ninvoke(pluginInstance, 'main');
             })

--- a/src/plugin/PluginResult.js
+++ b/src/plugin/PluginResult.js
@@ -7,8 +7,9 @@
  * @author lattmann / https://github.com/lattmann
  */
 
-define(['plugin/PluginMessage'], function (PluginMessage) {
+define(['plugin/PluginMessage', 'plugin/PluginResultBase'], function (PluginMessage, PluginResultBase) {
     'use strict';
+
     /**
      * Initializes a new instance of a plugin result object.
      *
@@ -16,6 +17,7 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
      *
      * @param config - deserializes an existing configuration to this object.
      * @constructor
+     * @augments PluginResultBase
      * @alias PluginResult
      */
     var PluginResult = function (config) {
@@ -55,54 +57,9 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
         }
     };
 
-    /**
-     * Gets the success flag of this result object
-     *
-     * @returns {boolean}
-     */
-    PluginResult.prototype.getSuccess = function () {
-        return this.success;
-    };
-
-    /**
-     * Sets the success flag of this result.
-     *
-     * @param {boolean} value
-     */
-    PluginResult.prototype.setSuccess = function (value) {
-        this.success = value;
-    };
-
-    /**
-     * Returns with the plugin messages.
-     *
-     * @returns {PluginMessage[]}
-     */
-    PluginResult.prototype.getMessages = function () {
-        return this.messages;
-    };
-
-    /**
-     * Adds a new plugin message to the messages list.
-     *
-     * @param {PluginMessage} pluginMessage
-     */
-    PluginResult.prototype.addMessage = function (pluginMessage) {
-        this.messages.push(pluginMessage);
-    };
-
-    PluginResult.prototype.getArtifacts = function () {
-        return this.artifacts;
-    };
-
-    /**
-     * Adds a saved artifact to the result - linked via its hash.
-     *
-     * @param {string} hash - Hash of saved artifact.
-     */
-    PluginResult.prototype.addArtifact = function (hash) {
-        this.artifacts.push(hash);
-    };
+    // Prototypical inheritance from PluginResultBase.
+    PluginResult.prototype = Object.create(PluginResultBase.prototype);
+    PluginResult.prototype.constructor = PluginResult;
 
     /**
      *
@@ -113,15 +70,6 @@ define(['plugin/PluginMessage'], function (PluginMessage) {
      */
     PluginResult.prototype.addCommit = function (commitData) {
         this.commits.push(commitData);
-    };
-
-    /**
-     * Gets the name of the plugin to which the result object belongs to.
-     *
-     * @returns {string}
-     */
-    PluginResult.prototype.getPluginName = function () {
-        return this.pluginName;
     };
 
     //------------------------------------------------------------------------------------------------------------------

--- a/src/plugin/PluginResultBase.js
+++ b/src/plugin/PluginResultBase.js
@@ -1,0 +1,89 @@
+/*globals define*/
+/*jshint browser: true, node:true*/
+
+/**
+ * A module representing the base class for PluginResult and InterPluginResult.
+ * @author pmeijer / https://github.com/meijer
+ */
+
+define([], function () {
+    'use strict';
+
+    /**
+     * Initializes a new instance of a plugin result object.
+     * @constructor
+     * @alias PluginResultBase
+     * @param {string} pluginName - name of plugin.
+     */
+    var PluginResultBase = function (pluginName) {
+        this.success = false;
+        this.artifacts = [];
+        this.messages = [];
+        this.pluginName = pluginName;
+    };
+
+    /**
+     * Gets the success flag of this result object
+     *
+     * @returns {boolean}
+     */
+    PluginResultBase.prototype.getSuccess = function () {
+        return this.success;
+    };
+
+    /**
+     * Sets the success flag of this result.
+     *
+     * @param {boolean} value
+     */
+    PluginResultBase.prototype.setSuccess = function (value) {
+        this.success = value;
+    };
+
+    /**
+     * Returns with the plugin messages.
+     *
+     * @returns {PluginMessage[]}
+     */
+    PluginResultBase.prototype.getMessages = function () {
+        return this.messages;
+    };
+
+    /**
+     * Adds a new plugin message to the messages list.
+     *
+     * @param {PluginMessage} pluginMessage
+     */
+    PluginResultBase.prototype.addMessage = function (pluginMessage) {
+        this.messages.push(pluginMessage);
+    };
+
+    /**
+     * Returns all artifacts stored.
+     *
+     * @returns {string[]} hashes - Hashes of the stored artifacts.
+     */
+    PluginResultBase.prototype.getArtifacts = function () {
+        return this.artifacts;
+    };
+
+    /**
+     * Adds a saved artifact to the result - linked via its hash.
+     *
+     * @param {string} hash - Hash of saved artifact.
+     */
+    PluginResultBase.prototype.addArtifact = function (hash) {
+        this.artifacts.push(hash);
+    };
+
+    /**
+     * Gets the name of the plugin to which the result object belongs to.
+     *
+     * @returns {string}
+     */
+    PluginResultBase.prototype.getPluginName = function () {
+        return this.pluginName;
+    };
+
+    return PluginResultBase;
+});

--- a/src/plugin/coreplugins/CustomPluginConfig/widget/ConfigWidget.js
+++ b/src/plugin/coreplugins/CustomPluginConfig/widget/ConfigWidget.js
@@ -1,4 +1,4 @@
-/*globals, define, $, WebGMEGlobal*/
+/*globals define, WebGMEGlobal*/
 /**
  * Example of custom plugin configuration. Typically a dialog would show up here.
  * @author pmeijer / https://github.com/pmeijer

--- a/src/plugin/coreplugins/GenerateAll/GenerateAll.js
+++ b/src/plugin/coreplugins/GenerateAll/GenerateAll.js
@@ -1,0 +1,73 @@
+/*globals define*/
+/*jshint node:true, browser:true*/
+/**
+ * Plugin for generating AddOns.
+ *
+ * @author pmeijer / https://github.com/pmeijer
+ * @module CorePlugins:GenerateAll
+ */
+
+define([
+    'plugin/PluginBase',
+    'text!./metadata.json',
+    'q'
+], function (PluginBase, pluginMetadata, Q) {
+    'use strict';
+
+    pluginMetadata = JSON.parse(pluginMetadata);
+
+    function GenerateAll() {
+        // Call base class's constructor
+        PluginBase.call(this);
+        this.pluginMetadata = pluginMetadata;
+    }
+
+    GenerateAll.metadata = pluginMetadata;
+
+    // Prototypical inheritance from PluginBase.
+    GenerateAll.prototype = Object.create(PluginBase.prototype);
+    GenerateAll.prototype.constructor = GenerateAll;
+
+    GenerateAll.prototype.main = function (callback) {
+        var self = this;
+
+        Q.allSettled([
+            self.invokePlugin('AddOnGenerator', {}),
+            self.invokePlugin('PluginGenerator', {})
+        ])
+            .then(function (results) {
+                var hasFailures = false;
+
+                results.forEach(function (result) {
+                    // Result is instances of InterPluginResult
+                    if (result.getSuccess() === false) {
+                        hasFailures = true;
+                    } else {
+                        // Messages and notifications from the invoked plugin are already added/emitted.
+                        // Artifacts are stored on the blob - we want them reported in the final result.
+                        result.getArtifacts().forEach(function (metadataHash) {
+                            self.result.addArtifact(metadataHash);
+                        });
+
+                        // Since we're the caller we know that these plugins don't save we do not care about commits.
+                        // But to get the messages of the attempted saves we can use result.getCommitMessages
+                        // and append these to our final save.
+                    }
+                });
+
+                if (hasFailures) {
+                    throw new Error('Called plugin failed with error');
+                }
+
+                self.result.setSucces(true);
+                callback(null, self.result);
+            })
+            .catch(function (err) {
+                self.result.setSucces(false);
+                self.result.error(err.message);
+                callback(err, self.result);
+            });
+    };
+
+    return GenerateAll;
+});

--- a/src/plugin/coreplugins/GenerateAll/GenerateAll.js
+++ b/src/plugin/coreplugins/GenerateAll/GenerateAll.js
@@ -51,7 +51,7 @@ define([
 
                         // Plugin message are available at getMessages (here we prepend the plugin name)
                         result.getMessages().forEach(function (message) {
-                            message.message = result.getPluginName() + ':' + message.message;
+                            message.message = result.getPluginName() + ' : ' + message.message;
                             self.result.addMessage(message);
                         });
 

--- a/src/plugin/coreplugins/GenerateAll/GenerateAll.js
+++ b/src/plugin/coreplugins/GenerateAll/GenerateAll.js
@@ -64,7 +64,7 @@ define([
             })
             .catch(function (err) {
                 self.result.setSuccess(false);
-                self.result.setError(err.message);
+                self.logger.error(err.stack);
                 callback(err, self.result);
             })
             .done();

--- a/src/plugin/coreplugins/GenerateAll/GenerateAll.js
+++ b/src/plugin/coreplugins/GenerateAll/GenerateAll.js
@@ -33,7 +33,11 @@ define([
 
         Q.all([
             self.invokePlugin('AddOnGenerator', {}),
-            self.invokePlugin('PluginGenerator', {})
+            self.invokePlugin('DecoratorGenerator', {}),
+            self.invokePlugin('LayoutGenerator', {}),
+            self.invokePlugin('PluginGenerator', {}),
+            self.invokePlugin('RestRouterGenerator', {}),
+            self.invokePlugin('VisualizerGenerator', {})
         ])
             .then(function (results) {
                 var hasFailures = false;

--- a/src/plugin/coreplugins/GenerateAll/GenerateAll.js
+++ b/src/plugin/coreplugins/GenerateAll/GenerateAll.js
@@ -31,7 +31,7 @@ define([
     GenerateAll.prototype.main = function (callback) {
         var self = this;
 
-        Q.allSettled([
+        Q.all([
             self.invokePlugin('AddOnGenerator', {}),
             self.invokePlugin('PluginGenerator', {})
         ])
@@ -59,14 +59,15 @@ define([
                     throw new Error('Called plugin failed with error');
                 }
 
-                self.result.setSucces(true);
+                self.result.setSuccess(true);
                 callback(null, self.result);
             })
             .catch(function (err) {
-                self.result.setSucces(false);
-                self.result.error(err.message);
+                self.result.setSuccess(false);
+                self.result.setError(err.message);
                 callback(err, self.result);
-            });
+            })
+            .done();
     };
 
     return GenerateAll;

--- a/src/plugin/coreplugins/GenerateAll/metadata.json
+++ b/src/plugin/coreplugins/GenerateAll/metadata.json
@@ -1,0 +1,22 @@
+{
+  "id": "GenerateAll",
+  "name": "Generate All",
+  "version": "2.16.0",
+  "description": "A plugin that calls all generator plugins and returns their result",
+  "icon": {
+    "src": "",
+    "class": "fa fa-cogs"
+  },
+  "disableServerSideExecution": false,
+  "disableBrowserSideExecution": false,
+  "writeAccessRequired": false,
+  "dependencies": [
+    {
+      "id": "AddOnGenerator"
+    },
+    {
+      "id": "PluginGenerator"
+    }
+  ],
+  "configStructure": []
+}

--- a/src/plugin/coreplugins/GenerateAll/metadata.json
+++ b/src/plugin/coreplugins/GenerateAll/metadata.json
@@ -13,13 +13,11 @@
   "dependencies": [
     {
       "id": "AddOnGenerator",
-      "propagateConfig": true,
-      "configurableNamespace": false
+      "propagateConfig": true
     },
     {
       "id": "PluginGenerator",
-      "propagateConfig": true,
-      "configurableNamespace": true
+      "propagateConfig": true
     }
   ],
   "configStructure": []

--- a/src/plugin/coreplugins/GenerateAll/metadata.json
+++ b/src/plugin/coreplugins/GenerateAll/metadata.json
@@ -12,10 +12,14 @@
   "writeAccessRequired": false,
   "dependencies": [
     {
-      "id": "AddOnGenerator"
+      "id": "AddOnGenerator",
+      "propagateConfig": true,
+      "configurableNamespace": false
     },
     {
-      "id": "PluginGenerator"
+      "id": "PluginGenerator",
+      "propagateConfig": true,
+      "configurableNamespace": true
     }
   ],
   "configStructure": []

--- a/src/plugin/coreplugins/GenerateAll/metadata.json
+++ b/src/plugin/coreplugins/GenerateAll/metadata.json
@@ -18,6 +18,22 @@
     {
       "id": "PluginGenerator",
       "propagateConfig": true
+    },
+    {
+      "id": "LayoutGenerator",
+      "propagateConfig": true
+    },
+    {
+      "id": "DecoratorGenerator",
+      "propagateConfig": true
+    },
+    {
+      "id": "RestRouterGenerator",
+      "propagateConfig": true
+    },
+    {
+      "id": "VisualizerGenerator",
+      "propagateConfig": true
     }
   ],
   "configStructure": []

--- a/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
+++ b/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
@@ -27,9 +27,6 @@ define([
         // Call base class' constructor.
         PluginBase.call(this);
         this.pluginMetadata = pluginMetadata;
-
-        // we do not know the meta types, will be populated during run time
-        this.metaTypes = {};
     }
 
     MinimalWorkingExample.metadata = pluginMetadata;
@@ -52,7 +49,6 @@ define([
         // These are all instantiated at this point.
         var self = this,
             currentConfiguration = self.getCurrentConfig();
-        self.updateMETA(self.metaTypes);
         // Using the logger.
         self.logger.debug('This is a debug message.');
         self.logger.info('This is an info message.');
@@ -60,13 +56,9 @@ define([
         self.logger.error('This is an error message.');
 
         // Using the coreAPI to create an object.
-        var newNode = self.core.createNode({parent: self.rootNode, base: self.META.FCO});
+        var newNode = self.core.createNode({parent: self.rootNode, base: self.core.getFCO(self.rootNode)});
         self.core.setAttribute(newNode, 'name', 'My new obj');
         self.core.setRegistry(newNode, 'position', {x: 70, y: 70});
-
-        if (self.isMetaTypeOf(newNode, self.metaTypes.FCO)) {
-            self.logger.info('The new node is an FCO');
-        }
 
         var newNodeMetaType = self.getMetaType(newNode);
         self.logger.info('The new node is a(n) ' + self.core.getAttribute(newNodeMetaType, 'name'));

--- a/src/server/middleware/blob/BlobRunPluginClient.js
+++ b/src/server/middleware/blob/BlobRunPluginClient.js
@@ -28,6 +28,7 @@ var BlobClientClass = requireJS('blob/BlobClient'),
  */
 function BlobRunPluginClient(blobBackend, logger, opts) {
     BlobClientClass.call(this, {logger: logger});
+    this.opts = opts;
     this.blobBackend = blobBackend;
     this.writeBlobFilesDir = opts && opts.writeBlobFilesDir;
     if (this.writeBlobFilesDir) {
@@ -41,6 +42,10 @@ BlobRunPluginClient.prototype = Object.create(BlobClientClass.prototype);
 
 // Override the constructor with this object's constructor
 BlobRunPluginClient.prototype.constructor = BlobRunPluginClient;
+
+BlobRunPluginClient.prototype.getNewInstance = function () {
+    return new BlobRunPluginClient(this.blobBackend, this.logger, this.opts);
+};
 
 BlobRunPluginClient.prototype.getMetadata = function (metadataHash, callback) {
     var self = this,

--- a/test-karma/client/js/branchstatus.spec.js
+++ b/test-karma/client/js/branchstatus.spec.js
@@ -19,6 +19,7 @@ describe('branch status', function () {
         projectId;
 
     before(function (done) {
+        this.timeout(5000);
         requirejs([
             'js/client',
             'js/logger',

--- a/test/common/util/tarjan.spec.js
+++ b/test/common/util/tarjan.spec.js
@@ -1,0 +1,142 @@
+/*jshint node:true, mocha:true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+describe('tarjan algorithm', function () {
+    'use strict';
+    var testFixture = require('../../_globals.js'),
+        Tarjan = testFixture.requirejs('common/util/tarjan'),
+        expect = testFixture.expect;
+
+    function sortRes(a, b) {
+        if (a.length < b.length) {
+            return -1;
+        } else if (a.length === b.length) {
+            return 0;
+        }
+        return 1;
+    }
+
+    it('should do example correctly', function () {
+        var t = new Tarjan();
+        t.addVertex(1);
+        t.addVertex(2);
+        t.addVertex(3);
+        t.addVertex(4);
+        t.connectVertices(1, 2);
+        t.connectVertices(2, 3);
+        t.connectVertices(3, 4);
+        t.connectVertices(4, 2);
+
+        expect(t.hasLoops()).to.equal(true);
+        expect(t.calculateSCCs().length).to.equal(2);
+        t.calculateSCCs().sort(sortRes);
+
+        expect(t.calculateSCCs()[0]).to.deep.equal([1]);
+        expect(t.calculateSCCs()[1].sort()).to.deep.equal([2, 3, 4]);
+    });
+
+    it('should return hasLoops false if chain', function () {
+        var t = new Tarjan();
+        t.addVertex(1);
+        t.addVertex(2);
+        t.addVertex(3);
+        t.connectVertices(1, 2);
+        t.connectVertices(2, 3);
+
+        expect(t.hasLoops()).to.equal(false);
+        expect(t.calculateSCCs().length).to.equal(3);
+        t.calculateSCCs().forEach(function (scc) {
+            expect(scc.length).to.equal(1);
+        });
+    });
+
+    it('should return hasLoops false if two independent vertices', function () {
+        var t = new Tarjan();
+        t.addVertex(1);
+        t.addVertex(2);
+
+        expect(t.hasLoops()).to.equal(false);
+        expect(t.calculateSCCs().length).to.equal(2);
+        t.calculateSCCs().forEach(function (scc) {
+            expect(scc.length).to.equal(1);
+        });
+    });
+
+    it('addVertex should return false if node already added', function () {
+        var t = new Tarjan();
+        expect(t.addVertex(1)).to.equal(true);
+        expect(t.addVertex(1)).to.equal(false);
+    });
+
+    it('should throw if adding vertex after it ran', function (done) {
+        var t = new Tarjan();
+        t.addVertex(1);
+
+        expect(t.hasLoops()).to.equal(false);
+
+        try {
+            t.addVertex(2);
+            done(new Error('should have thrown'));
+        } catch (e) {
+            if (e.message.indexOf('Cannot modify graph after algorithm ran') === 0) {
+                done();
+            } else {
+                done(e);
+            }
+        }
+    });
+
+    it('should throw if adding connection after it ran', function (done) {
+        var t = new Tarjan();
+        t.addVertex(1);
+        t.addVertex(2);
+
+        expect(t.hasLoops()).to.equal(false);
+
+        try {
+            t.connectVertices(1, 2);
+            done(new Error('should have thrown'));
+        } catch (e) {
+            if (e.message.indexOf('Cannot modify graph after algorithm ran') === 0) {
+                done();
+            } else {
+                done(e);
+            }
+        }
+    });
+
+    it('should throw if connecting vertices that do not exist 1', function (done) {
+        var t = new Tarjan();
+        t.addVertex(1);
+
+        try {
+            t.connectVertices(1, 2);
+            done(new Error('should have thrown'));
+        } catch (e) {
+            if (e.message.indexOf('Vertex [2] was never added to graph') === 0) {
+                done();
+            } else {
+                done(e);
+            }
+        }
+    });
+
+    it('should throw if connecting vertices that do not exist 2', function (done) {
+        var t = new Tarjan();
+        t.addVertex(2);
+
+        try {
+            t.connectVertices(1, 2);
+            done(new Error('should have thrown'));
+        } catch (e) {
+            if (e.message.indexOf('Vertex [1] was never added to graph') === 0) {
+                done();
+            } else {
+                done(e);
+            }
+        }
+    });
+
+});

--- a/test/plugin/coreplugins/GenerateAll/GenerateAll.spec.js
+++ b/test/plugin/coreplugins/GenerateAll/GenerateAll.spec.js
@@ -1,0 +1,124 @@
+/*jshint node:true, mocha:true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+var testFixture = require('../../../_globals');
+
+describe.only('Generate All Plugin', function () {
+    'use strict';
+
+    var pluginName = 'GenerateAll',
+        projectName = 'GenerateAllPluginProj',
+        Q = testFixture.Q,
+        blobClient,
+        gmeConfig,
+        storage,
+        expect,
+        project,
+        commitHash,
+        gmeAuth,
+        importResult,
+        pluginManager;
+
+    before(function (done) {
+        var logger = testFixture.logger.fork(pluginName),
+            PluginCliManager = require('../../../../src/plugin/climanager'),
+            BlobClient = require('../../../../src/server/middleware/blob/BlobClientWithFSBackend');
+
+        gmeConfig = testFixture.getGmeConfig();
+        blobClient = new BlobClient(gmeConfig, logger);
+
+        expect = testFixture.expect;
+
+        var importParam = {
+            projectSeed: './seeds/EmptyProject.webgmex',
+            projectName: projectName,
+            logger: logger,
+            gmeConfig: gmeConfig
+        };
+
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                return testFixture.importProject(storage, importParam);
+            })
+            .then(function (importResult_) {
+                importResult = importResult_;
+                project = importResult.project;
+                commitHash = importResult.commitHash;
+                pluginManager = new PluginCliManager(project, logger, gmeConfig);
+            })
+            .nodeify(done);
+    });
+
+    beforeEach(function (done) {
+        testFixture.rimraf('./test-tmp/blob-local-storage', done);
+    });
+
+    after(function (done) {
+        Q.allDone([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
+            .nodeify(done);
+    });
+
+    it('should run GenerateAll with no specified config and succeed and return 6 unique artifacts', function (done) {
+        var pluginContext = {
+                branchName: 'master'
+            },
+            pluginConfig = {};
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                var hashes = {};
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(6);
+
+                result.artifacts.forEach(function (hash) {
+                    expect(!hashes[hash]).to.equal(true);
+                    hashes[hash] = true;
+                });
+            })
+            .nodeify(done);
+    });
+
+    it('should run GenerateAll and pass config parameter of dependency', function (done) {
+        var pluginContext = {
+                branchName: 'master'
+            },
+            pluginConfig = {
+                _dependencies: {
+                    DecoratorGenerator: {
+                        pluginConfig: {
+                            decoratorName: 'ComingFromGenerateAllPlugin'
+                        }
+                    }
+                }
+            };
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(6);
+
+                return Q.allDone(result.artifacts
+                    .map(function (hash) {
+                        return blobClient.getMetadata(hash);
+                    }));
+            })
+            .then(function (res) {
+                var names = res.map(function (metadata) {
+                    return metadata.name;
+                });
+
+                expect(names).to.include('ComingFromGenerateAllPluginDecorator.zip');
+            })
+            .nodeify(done);
+    });
+});

--- a/test/plugin/coreplugins/GenerateAll/GenerateAll.spec.js
+++ b/test/plugin/coreplugins/GenerateAll/GenerateAll.spec.js
@@ -5,7 +5,7 @@
 
 var testFixture = require('../../../_globals');
 
-describe.only('Generate All Plugin', function () {
+describe('Generate All Plugin', function () {
     'use strict';
 
     var pluginName = 'GenerateAll',

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -38,7 +38,8 @@ describe('CorePlugins', function () {
             'RestRouterGenerator',
             'CustomPluginConfig',
             'GuidCollider',
-            'GenerateAll'
+            'GenerateAll',
+            'SavingDependency'
         ],
 
         pluginsShouldFail = [

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -37,7 +37,8 @@ describe('CorePlugins', function () {
             'FastForward',
             'RestRouterGenerator',
             'CustomPluginConfig',
-            'GuidCollider'
+            'GuidCollider',
+            'GenerateAll'
         ],
 
         pluginsShouldFail = [

--- a/test/plugin/scenarios/SavingDependency.spec.js
+++ b/test/plugin/scenarios/SavingDependency.spec.js
@@ -1,0 +1,224 @@
+/*jshint node:true, mocha:true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+var testFixture = require('../../_globals');
+
+describe('Saving dependency plugin', function () {
+    'use strict';
+
+    var pluginName = 'SavingDependency',
+        projectName = 'SavingDependencyPluginProj',
+        Q = testFixture.Q,
+        blobClient,
+        gmeConfig,
+        storage,
+        expect,
+        project,
+        core,
+        commitHash,
+        gmeAuth,
+        importResult,
+        pluginManager;
+
+    before(function (done) {
+        var logger = testFixture.logger.fork(pluginName),
+            PluginCliManager = require('../../../src/plugin/climanager'),
+            BlobClient = require('../../../src/server/middleware/blob/BlobClientWithFSBackend');
+
+        gmeConfig = testFixture.getGmeConfig();
+        blobClient = new BlobClient(gmeConfig, logger);
+
+        expect = testFixture.expect;
+
+        var importParam = {
+            projectSeed: './seeds/EmptyProject.webgmex',
+            projectName: projectName,
+            logger: logger,
+            gmeConfig: gmeConfig
+        };
+
+        testFixture.clearDBAndGetGMEAuth(gmeConfig, projectName)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                storage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return storage.openDatabase();
+            })
+            .then(function () {
+                return testFixture.importProject(storage, importParam);
+            })
+            .then(function (importResult_) {
+                importResult = importResult_;
+                project = importResult.project;
+                commitHash = importResult.commitHash;
+                core = importResult.core;
+
+                pluginManager = new PluginCliManager(project, logger, gmeConfig);
+
+                return Q.allDone([
+                    project.createBranch('b1', commitHash),
+                    project.createBranch('b2', commitHash),
+                    project.createBranch('b3', commitHash),
+                    project.createBranch('b4', commitHash),
+                    project.createBranch('b5', commitHash),
+                    project.createBranch('b6', commitHash)
+                    ]);
+            })
+            .nodeify(done);
+    });
+
+    beforeEach(function (done) {
+        testFixture.rimraf('./test-tmp/blob-local-storage', done);
+    });
+
+    after(function (done) {
+        Q.allDone([
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
+            .nodeify(done);
+    });
+
+    it('should run SavingDependency with no specified config and save the model', function (done) {
+        var pluginContext = {
+                branchName: 'b1'
+            },
+            pluginConfig = {};
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(7);
+                expect(result.commits.length).to.equal(2);
+                return testFixture.loadRootNodeFromCommit(project, core, result.commits[1].commitHash);
+            })
+            .then(function (rootNode) {
+                expect(core.getChildrenPaths(rootNode).length).to.equal(2);
+            })
+            .nodeify(done);
+    });
+
+    it('should run SavingDependency and not update model if save is false', function (done) {
+        var pluginContext = {
+                branchName: 'b2'
+            },
+            pluginConfig = {
+                save: false
+            };
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(7);
+                expect(result.commits.length).to.equal(1);
+                return project.getBranchHash('b2');
+            })
+            .then(function (branchHash) {
+                return testFixture.loadRootNodeFromCommit(project, core, branchHash);
+            })
+            .then(function (rootNode) {
+                expect(core.getChildrenPaths(rootNode).length).to.equal(1);
+            })
+            .nodeify(done);
+    });
+
+    it('should run SavingDependency and not update model if save is false for called plugin', function (done) {
+        var pluginContext = {
+                branchName: 'b3'
+            },
+            pluginConfig = {
+                save: true,
+                _dependencies: {
+                    MinimalWorkingExample: {
+                        pluginConfig: {
+                            save: false
+                        }
+                    }
+                }
+            };
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(7);
+                expect(result.commits.length).to.equal(1);
+                return project.getBranchHash('b3');
+            })
+            .then(function (branchHash) {
+                return testFixture.loadRootNodeFromCommit(project, core, branchHash);
+            })
+            .then(function (rootNode) {
+                expect(core.getChildrenPaths(rootNode).length).to.equal(1);
+            })
+            .nodeify(done);
+    });
+
+    it('should run SavingDependency and pass config parameter of dependency from different callers', function (done) {
+        var pluginContext = {
+                branchName: 'b4'
+            },
+            pluginConfig = {
+                _dependencies: {
+                    DecoratorGenerator: {
+                        pluginConfig: {
+                            decoratorName: 'NameTopLevel'
+                        }
+                    },
+                    GenerateAll: {
+                        pluginConfig: {
+                            _dependencies: {
+                                DecoratorGenerator: {
+                                    pluginConfig: {
+                                        decoratorName: 'NameNestedLevel'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+                expect(result.artifacts.length).to.equal(7);
+
+                return Q.allDone(result.artifacts
+                    .map(function (hash) {
+                        return blobClient.getMetadata(hash);
+                    }));
+            })
+            .then(function (res) {
+                var names = res.map(function (metadata) {
+                    return metadata.name;
+                });
+
+                expect(names).to.include('NameTopLevelDecorator.zip');
+                expect(names).to.include('NameNestedLevelDecorator.zip');
+            })
+            .nodeify(done);
+    });
+
+    it('should run SavingDependency and use explicitly from plugin passed config param', function (done) {
+        var pluginContext = {
+                branchName: 'b5'
+            },
+            pluginConfig = {
+                minimalShouldFail: false,
+                _dependencies: {
+                    MinimalWorkingExample: {
+                        pluginConfig: {
+                            shouldFail: true // It passes shouldFail: false so this should be ignored
+                        }
+                    }
+                }
+            };
+
+        Q.ninvoke(pluginManager, 'executePlugin', pluginName, pluginConfig, pluginContext)
+            .then(function (result) {
+                expect(result.success).to.equal(true);
+            })
+            .nodeify(done);
+    });
+});

--- a/test/plugin/scenarios/plugins/SavingDependency/SavingDependency.js
+++ b/test/plugin/scenarios/plugins/SavingDependency/SavingDependency.js
@@ -32,7 +32,11 @@ if (typeof define === 'undefined') {
                 config = self.getCurrentConfig();
 
             Q.all(this.getPluginDependencies().map(function (id) {
-                return self.invokePlugin(id);
+                var cfg = {};
+                if (id === 'MinimalWorkingExample') {
+                    cfg.pluginConfig = {shouldFail: config.minimalShouldFail};
+                }
+                return self.invokePlugin(id, cfg);
             }))
                 .then(function (results) {
                     var hasFailures = false,
@@ -50,9 +54,7 @@ if (typeof define === 'undefined') {
                                 self.result.addArtifact(metadataHash);
                             });
 
-                            // Plugin message are available at getMessages (here we prepend the plugin name)
                             result.getMessages().forEach(function (message) {
-                                message.message = result.getPluginName() + ':' + message.message;
                                 self.result.addMessage(message);
                             });
 

--- a/test/plugin/scenarios/plugins/SavingDependency/SavingDependency.js
+++ b/test/plugin/scenarios/plugins/SavingDependency/SavingDependency.js
@@ -1,0 +1,89 @@
+/*globals define*/
+/*jshint node:true, browser:true*/
+
+if (typeof define === 'undefined') {
+
+} else {
+    define([
+        'plugin/PluginConfig',
+        'plugin/PluginBase',
+        'text!./metadata.json',
+        'q'
+    ], function (PluginConfig,
+                 PluginBase,
+                 pluginMetadata,
+                 Q) {
+        'use strict';
+
+        pluginMetadata = JSON.parse(pluginMetadata);
+        var SavingDependency = function () {
+            // Call base class' constructor.
+            PluginBase.call(this);
+            this.pluginMetadata = pluginMetadata;
+        };
+
+        SavingDependency.metadata = pluginMetadata;
+
+        SavingDependency.prototype = Object.create(PluginBase.prototype);
+        SavingDependency.prototype.constructor = SavingDependency;
+
+        SavingDependency.prototype.main = function (callback) {
+            var self = this,
+                config = self.getCurrentConfig();
+
+            Q.all(this.getPluginDependencies().map(function (id) {
+                return self.invokePlugin(id);
+            }))
+                .then(function (results) {
+                    var hasFailures = false,
+                        commitMessages = [];
+
+                    results.forEach(function (result) {
+                        // Result is instance of InterPluginResult
+                        if (result.getSuccess() === false) {
+                            hasFailures = true;
+                        } else {
+                            // Notifications from the invoked plugin are already emitted.
+
+                            // Artifacts are stored on the blob - we want them reported in the final result.
+                            result.getArtifacts().forEach(function (metadataHash) {
+                                self.result.addArtifact(metadataHash);
+                            });
+
+                            // Plugin message are available at getMessages (here we prepend the plugin name)
+                            result.getMessages().forEach(function (message) {
+                                message.message = result.getPluginName() + ':' + message.message;
+                                self.result.addMessage(message);
+                            });
+
+                            // Attempted saves are not persisted and committed. The messages are accessible.
+                            commitMessages = commitMessages.concat(result.getCommitMessages());
+                        }
+
+                        // The instance of the invoked plugin is available at result.pluginInstance
+                    });
+
+                    if (hasFailures) {
+                        throw new Error('Called plugin failed with error');
+                    }
+
+                    // We make a single save at the end.
+                    if (config.save && commitMessages.length > 0) {
+                        return self.save('\n' + commitMessages.join('\n'));
+                    }
+                })
+                .then(function () {
+                    self.result.setSuccess(true);
+                    callback(null, self.result);
+                })
+                .catch(function (err) {
+                    self.result.setSuccess(false);
+                    self.logger.error(err.stack);
+                    callback(err, self.result);
+                })
+                .done();
+        };
+
+        return SavingDependency;
+    });
+}

--- a/test/plugin/scenarios/plugins/SavingDependency/metadata.json
+++ b/test/plugin/scenarios/plugins/SavingDependency/metadata.json
@@ -31,6 +31,14 @@
       "value": true,
       "valueType": "boolean",
       "readOnly": false
+    },
+    {
+      "name": "minimalShouldFail",
+      "displayName": "Should minimal fail",
+      "description": "Minimal Will fail if true",
+      "value": false,
+      "valueType": "boolean",
+      "readOnly": false
     }
   ]
 }

--- a/test/plugin/scenarios/plugins/SavingDependency/metadata.json
+++ b/test/plugin/scenarios/plugins/SavingDependency/metadata.json
@@ -1,0 +1,36 @@
+{
+  "id": "SavingDependency",
+  "name": "Saving Dependency",
+  "version": "2.16.0",
+  "description": "",
+  "icon": {
+    "src": "",
+    "class": "fa fa-cogs"
+  },
+  "disableServerSideExecution": false,
+  "disableBrowserSideExecution": false,
+  "dependencies": [
+    {
+      "id": "MinimalWorkingExample",
+      "propagateConfig": false
+    },
+    {
+      "id": "DecoratorGenerator",
+      "propagateConfig": true
+    },
+    {
+      "id": "GenerateAll",
+      "propagateConfig": true
+    }
+  ],
+  "configStructure": [
+    {
+      "name": "save",
+      "displayName": "Should save the model",
+      "description": "Will update the model if true",
+      "value": true,
+      "valueType": "boolean",
+      "readOnly": false
+    }
+  ]
+}


### PR DESCRIPTION
Dependency plugins can be specified in the metadata with the option to have plugin configurations propagate to the UI.

Invoked plugins can be configured to run under a name space relative the invoker.

Calls to save a bypassed in a transaction like manner and only the outer most plugin have the option to save. (This is to avoid potential inconsistencies in the shared core nodes and it also gives more control to the invoker).

https://github.com/webgme/webgme/wiki/GME-Plugins#invoking-other-plugins
