### PR TITLE
Concurrent tag creation (although different) revokes one insert

### DIFF
--- a/src/server/storage/mongo.js
+++ b/src/server/storage/mongo.js
@@ -481,7 +481,10 @@ function Mongo(mainLogger, gmeConfig) {
             Q.ninvoke(self.client, 'collection', projectId)
                 .then(function (result) {
                     collection = result;
-                    return Q.ninvoke(collection, 'insertOne', {_id: CONSTANTS.EMPTY_PROJECT_DATA});
+                    return Q.ninvoke(collection, 'insertMany', [
+                        {_id: CONSTANTS.EMPTY_PROJECT_DATA},
+                        {_id: self.CONSTANTS.TAGS}
+                    ]);
                 })
                 .then(function () {
                     deferred.resolve(new MongoProject(projectId, collection));


### PR DESCRIPTION
If the `"TAGS"` document didn't exist an `E11000` is returned by mongo since both requests attempts to create the document. 

Solution is to create the tag document at project creation.