### PR TITLE
If no logout url specified a logout will redirect to the (original) referrer

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -64,7 +64,7 @@ To configure the default behaviour of individual components (e.g. plugins, ui-wi
 - `config.authentication.logInUrl = '/profile/login'`
  - Where clients are redirected if not authenticated.
 - `config.authentication.logOutUrl = '/profile/login'`
- - Where clients are redirected after logout.
+ - Where clients are redirected after logout. Leave this empty to logout to the referrer (if none it will fall back on `config.authentication.logInUrl`).
 - `config.authentication.userManagementPage = 'webgme-user-management-page'`
  - Replaceable user-management page to use (use this if you have a fork of [webgme-user-management-page](https://github.com/webgme/user-management-page)).
  Given router will be mounted at `/profile`.

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -28,6 +28,7 @@ var path = require('path'),
             guestAccount: 'guest',
             logOutUrl: '/profile/login',
             logInUrl: '/profile/login',
+            logOutToReferrer: false,
             salts: 10,
             jwt: {
                 expiresIn: 3600 * 24 * 7,

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -28,7 +28,6 @@ var path = require('path'),
             guestAccount: 'guest',
             logOutUrl: '/profile/login',
             logInUrl: '/profile/login',
-            logOutToReferrer: false,
             salts: 10,
             jwt: {
                 expiresIn: 3600 * 24 * 7,

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.css
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.css
@@ -35,7 +35,6 @@
     border-right: 15px solid white;
     color: whitesmoke; }
     .decorator-svg-dialog .svg-editor .svg-display .displayed-svg {
-      background-image: url("../../../../img/transparent.svg");
       margin: auto;
       display: block;
       position: absolute;

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.scss
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/styles/DecoratorSVGExplorerDialog.scss
@@ -11,6 +11,7 @@ $img-margin: 3px;
 $desc-line-height: 20px;
 $desc-margin: 3px;
 
+
 .decorator-svg-dialog {
   .fixed-modal-body {
     overflow: hidden;

--- a/src/client/js/Panels/Header/HeaderPanel.js
+++ b/src/client/js/Panels/Header/HeaderPanel.js
@@ -111,9 +111,12 @@ define([
         navBarInner.append($('<div class="spacer pull-right"></div>'));
 
         //user info
-        if (this._config.disableUserProfile === false && WebGMEGlobal.gmeConfig.authentication.enable === true) {
+        if (WebGMEGlobal.gmeConfig.authentication.enable === true) {
             userProfileEl = $('<div/>', {class: 'inline pull-right', style: 'padding: 6px 0px;'});
-            this.defaultUserProfileWidget = new UserProfileWidget(userProfileEl, this._client);
+            this.defaultUserProfileWidget = new UserProfileWidget(userProfileEl, this._client, {
+                disableUserProfile: this._config.disableUserProfile
+            });
+
             navBarInner.append(userProfileEl);
         }
 

--- a/src/client/js/Widgets/UserProfile/UserProfileWidget.js
+++ b/src/client/js/Widgets/UserProfile/UserProfileWidget.js
@@ -1,38 +1,48 @@
-/*globals define, WebGMEGlobal*/
+/*globals define, WebGMEGlobal, $*/
 /*jshint browser: true*/
 
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
 
-define(['js/logger'], function (Logger) {
+define(['js/logger',
+    'css!./styles/UserProfileWidget.css'
+], function (Logger) {
     'use strict';
 
-    var UserProfileWidget,
-        USER_PROFILE_WIDGET_TEMPLATE_LOGGEDIN = '<i class="glyphicon glyphicon-user icon-white" title="Logged in as">' +
-            '</i> <a href="/profile/" target="_self" class="navbar-link" title="View profile">__USERNAME__</a> ' +
-            '<a href="/logout" target="_top" class="navbar-link">' +
-            '<i class="glyphicon glyphicon-eject icon-white" title="Log out"></i></a>',
-        USER_PROFILE_WIDGET_TEMPLATE_NOTLOGGEDIN = '<i class="glyphicon glyphicon-user" title="Not logged in"></i>';
+    var TEMPLATE = '<p class="navbar-text user-profile-container">' +
+        '<i class="glyphicon glyphicon-user icon-white" title="Logged in as"/>' +
+        '</p>';
 
-    UserProfileWidget = function (containerEl, client) {
+    function UserProfileWidget(containerEl, client, opts) {
         this._logger = Logger.create('gme:Widgets:UserProfile:UserProfileWidget', WebGMEGlobal.gmeConfig.client.log);
-
+        opts = opts || {};
         this._client = client;
         this._el = containerEl;
 
-        this._initializeUI();
+        this._initializeUI(opts);
 
         this._logger.debug('Created');
-    };
+    }
 
 
-    UserProfileWidget.prototype._initializeUI = function () {
-        var tmp = USER_PROFILE_WIDGET_TEMPLATE_NOTLOGGEDIN;
-            tmp = USER_PROFILE_WIDGET_TEMPLATE_LOGGEDIN.replace('__USERNAME__', WebGMEGlobal.userInfo._id);
-        tmp = '<p class="navbar-text">' + tmp + '</p>';
+    UserProfileWidget.prototype._initializeUI = function (opts) {
+        var widget = $(TEMPLATE),
+            userName = WebGMEGlobal.userInfo._id;
 
-        this._el.html(tmp);
+        if (opts.disableUserProfile) {
+            widget.append($('<span class="user-name-field"/>').text(userName));
+        } else {
+            widget.append(
+                $('<a href="/profile/" target="_self" class="navbar-link user-name-field" title="View profile"/>')
+                    .text(userName)
+            );
+            widget.append('<a href="/logout" target="_top" class="navbar-link">' +
+                '<i class="glyphicon glyphicon-eject icon-white" title="Log out"/></a>');
+        }
+
+        this._el.append(widget);
     };
 
 

--- a/src/client/js/Widgets/UserProfile/UserProfileWidget.js
+++ b/src/client/js/Widgets/UserProfile/UserProfileWidget.js
@@ -29,14 +29,9 @@ define(['js/logger',
 
     UserProfileWidget.prototype._initializeUI = function (opts) {
         var widget = $(TEMPLATE),
-            logoutUrl,
-            userName = WebGMEGlobal.userInfo._id;
-
-        if (window !== window.top) {
-            logoutUrl = '/logout?redirect=' + window.top.document.referrer;
-        } else {
-            logoutUrl = '/logout';
-        }
+            userName = WebGMEGlobal.userInfo._id,
+            referrer,
+            logoutUrl;
 
         if (opts.disableUserProfile) {
             widget.append($('<span class="user-name-field"/>').text(userName));
@@ -45,6 +40,15 @@ define(['js/logger',
                 $('<a href="/profile/" target="_self" class="navbar-link user-name-field" title="View profile"/>')
                     .text(userName)
             );
+
+            referrer = window.sessionStorage.getItem('originalReferrer');
+
+            if (referrer) {
+                logoutUrl = '/logout?redirectUrl=' + referrer;
+            } else {
+                logoutUrl = '/logout';
+            }
+
             widget.append($('<a target="_top" class="navbar-link">' +
                 '<i class="glyphicon glyphicon-eject icon-white" title="Log out"/></a>').attr('href', logoutUrl));
         }

--- a/src/client/js/Widgets/UserProfile/UserProfileWidget.js
+++ b/src/client/js/Widgets/UserProfile/UserProfileWidget.js
@@ -29,7 +29,14 @@ define(['js/logger',
 
     UserProfileWidget.prototype._initializeUI = function (opts) {
         var widget = $(TEMPLATE),
+            logoutUrl,
             userName = WebGMEGlobal.userInfo._id;
+
+        if (window !== window.top) {
+            logoutUrl = '/logout?redirect=' + window.top.document.referrer;
+        } else {
+            logoutUrl = '/logout';
+        }
 
         if (opts.disableUserProfile) {
             widget.append($('<span class="user-name-field"/>').text(userName));
@@ -38,8 +45,8 @@ define(['js/logger',
                 $('<a href="/profile/" target="_self" class="navbar-link user-name-field" title="View profile"/>')
                     .text(userName)
             );
-            widget.append('<a href="/logout" target="_top" class="navbar-link">' +
-                '<i class="glyphicon glyphicon-eject icon-white" title="Log out"/></a>');
+            widget.append($('<a target="_top" class="navbar-link">' +
+                '<i class="glyphicon glyphicon-eject icon-white" title="Log out"/></a>').attr('href', logoutUrl));
         }
 
         this._el.append(widget);

--- a/src/client/js/Widgets/UserProfile/styles/UserProfileWidget.css
+++ b/src/client/js/Widgets/UserProfile/styles/UserProfileWidget.css
@@ -1,3 +1,6 @@
 /**
- * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
+.user-profile-container .user-name-field {
+  margin-left: 4px;
+  margin-right: 4px; }

--- a/src/client/js/Widgets/UserProfile/styles/UserProfileWidget.scss
+++ b/src/client/js/Widgets/UserProfile/styles/UserProfileWidget.scss
@@ -1,3 +1,9 @@
 /**
- * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
+.user-profile-container {
+  .user-name-field {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
+}

--- a/src/client/js/start.js
+++ b/src/client/js/start.js
@@ -57,6 +57,12 @@ require(
             WebGMEGlobal.GitHubVersion = npmJSONFromSplit[npmJSONFromSplit.length - 1];
         }
 
+        // Set the referrer in the session store (if not already set)
+        if (typeof window.sessionStorage.getItem('originalReferrer') !== 'string') {
+            // Use top in case embedded in iframe.
+            window.sessionStorage.setItem('originalReferrer', window.top.document.referrer);
+        }
+
         // domDeferred will be resolved (with gmeApp) when the dom is ready (i.e. $ function invoked).
         $(function () {
             var d,

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -701,9 +701,8 @@ function StandAloneServer(gmeConfig) {
         if (gmeConfig.authentication.enable === false) {
             res.sendStatus(404);
         } else {
-            if (gmeConfig.authentication.logOutToReferrer) {
-                redirectUrl = req.get('Referrer');
-            }
+            redirectUrl = req.query('redirect');
+
             res.clearCookie(gmeConfig.authentication.jwt.cookieId);
             res.redirect(redirectUrl || gmeConfig.authentication.logOutUrl || '/');
         }

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -701,10 +701,10 @@ function StandAloneServer(gmeConfig) {
         if (gmeConfig.authentication.enable === false) {
             res.sendStatus(404);
         } else {
-            redirectUrl = req.query('redirect');
+            redirectUrl = req.query.redirectUrl;
 
             res.clearCookie(gmeConfig.authentication.jwt.cookieId);
-            res.redirect(redirectUrl || gmeConfig.authentication.logOutUrl || '/');
+            res.redirect(gmeConfig.authentication.logOutUrl || redirectUrl || gmeConfig.authentication.logInUrl || '/');
         }
     });
 

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -697,11 +697,15 @@ function StandAloneServer(gmeConfig) {
     logger.debug('creating login routing rules for the static server');
 
     __app.get('/logout', function (req, res) {
+        var redirectUrl;
         if (gmeConfig.authentication.enable === false) {
             res.sendStatus(404);
         } else {
+            if (gmeConfig.authentication.logOutToReferrer) {
+                redirectUrl = req.get('Referrer');
+            }
             res.clearCookie(gmeConfig.authentication.jwt.cookieId);
-            res.redirect(gmeConfig.authentication.logOutUrl || '/');
+            res.redirect(redirectUrl || gmeConfig.authentication.logOutUrl || '/');
         }
     });
 

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -489,4 +489,109 @@ describe('standalone server', function () {
             }
         );
     });
+
+    describe('http server with authentication', function () {
+        describe('logOutUrl set', function () {
+            var server;
+
+            before(function (done) {
+                // we have to set the config here
+                var gmeConfig = testFixture.getGmeConfig();
+                gmeConfig.authentication.enable = true;
+                gmeConfig.authentication.logOutUrl = '/profile/login';
+
+                server = WebGME.standaloneServer(gmeConfig);
+                serverBaseUrl = server.getUrl();
+                server.start(done);
+            });
+
+            after(function (done) {
+                server.stop(done);
+            });
+
+            it('should redirect to given logOutUrl when no referrer set', function (done) {
+                agent.get(serverBaseUrl + '/logout').end(function (err, res) {
+                    try {
+                        expect(err).to.equal(null);
+                        expect(res.status).to.equal(200);
+                        expect(res.redirects.length).to.equal(1);
+                        expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            });
+
+            it('should redirect to logOutUrl even when redirectUrl set', function (done) {
+                agent.get(serverBaseUrl + '/logout')
+                    .query({
+                        redirectUrl: '/gmeConfig.json'
+                    })
+                    .end(function (err, res) {
+                    try {
+                        expect(err).to.equal(null);
+                        expect(res.status).to.equal(200);
+                        expect(res.redirects.length).to.equal(1);
+                        expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            });
+        });
+
+        describe('logOutUrl not set', function () {
+            var server;
+
+            before(function (done) {
+                // we have to set the config here
+                var gmeConfig = testFixture.getGmeConfig();
+                gmeConfig.authentication.enable = true;
+                gmeConfig.authentication.logOutUrl = '';
+                gmeConfig.authentication.logInUrl = '/profile/login';
+
+                server = WebGME.standaloneServer(gmeConfig);
+                serverBaseUrl = server.getUrl();
+                server.start(done);
+            });
+
+            after(function (done) {
+                server.stop(done);
+            });
+
+            it('should redirect to given logInUrl when no referrer set', function (done) {
+                agent.get(serverBaseUrl + '/logout').end(function (err, res) {
+                    try {
+                        expect(err).to.equal(null);
+                        expect(res.status).to.equal(200);
+                        expect(res.redirects.length).to.equal(1);
+                        expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            });
+
+            it('should redirect to redirectUrl when query set', function (done) {
+                agent.get(serverBaseUrl + '/logout')
+                    .query({
+                        redirectUrl: '/gmeConfig.json'
+                    })
+                    .end(function (err, res) {
+                        try {
+                            expect(err).to.equal(null);
+                            expect(res.status).to.equal(200);
+                            expect(res.redirects.length).to.equal(1);
+                            expect(res.redirects[0]).to.equal(serverBaseUrl + '/gmeConfig.json');
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
+                    });
+            });
+        });
+    });
 });


### PR DESCRIPTION
The '/logout' path takes an optional query `redirectUrl` and if no `gmeConfig.authentication.logOutUrl` is set - it will redirect the request to that url. (If none above are set it will fallback on `gmeConfig.authentication.logInUrl`.)

On the client-side the webapp stores the (window.top.)document.referrer in the `sessionStore` once and passes the value at `/logout`. This is also implemented in [user-management-page #68](https://github.com/webgme/user-management-page/pull/68).

This PR also fixes #1474 by updating the UserProfileWidget.

