### PR TITLE
Delay and batch part-browser updates from state changes

### DIFF
--- a/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
+++ b/src/client/js/Widgets/PartBrowser/PartBrowserWidget.js
@@ -10,10 +10,11 @@ define([
     'js/logger',
     'js/Constants',
     'js/DragDrop/DragSource',
+    'js/Loader/LoaderCircles',
     'js/Toolbar/ToolbarDropDownButton',
     'js/Toolbar/ToolbarRadioButtonGroup',
     'css!./styles/PartBrowserWidget.css'
-], function (Logger, CONSTANTS, dragSource, ToolbarDropDownButton, ToolbarRadioButtonGroup) {
+], function (Logger, CONSTANTS, dragSource, LoaderCircles, ToolbarDropDownButton, ToolbarRadioButtonGroup) {
 
     'use strict';
 
@@ -91,6 +92,8 @@ define([
 
         this._container.append(this._toolbar);
         this._container.append(this._partsContainer);
+        this._loader = new LoaderCircles({containerElement: this._el});
+
         this._el.append(this._container);
 
         // By default only names are listed.
@@ -451,6 +454,18 @@ define([
 
     PartBrowserWidget.prototype.onSelectorChanged = function (newValue) {
         this._logger.error('onSelectorChanged function should be overwritten for proper usage!', newValue);
+    };
+
+    PartBrowserWidget.prototype.showProgressbar = function () {
+        this._loader.start();
+        this._partsContainer.css('opacity', 0.3);
+        this._namelist.css('opacity', 0.3);
+    };
+
+    PartBrowserWidget.prototype.hideProgressbar = function () {
+        this._loader.stop();
+        this._partsContainer.css('opacity', 1);
+        this._namelist.css('opacity', 1);
     };
 
     return PartBrowserWidget;

--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -352,6 +352,9 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         for (i = 0; i < keys.length; i++) {
             if (this._state.nodes[keys[i]]) {
                 parameters.children.push(this._state.nodes[keys[i]].node);
+            } else {
+                this._logger.warn('Child node, ' + keys[i] + ', not loaded at getValidChildrenTypes' +
+                    'Detailed invocation - cardinality constraints will not be enforced properly.');
             }
         }
 
@@ -388,6 +391,9 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
         for (i = 0; i < keys.length; i++) {
             if (this._state.nodes[keys[i]]) {
                 parameters.members.push(this._state.nodes[keys[i]].node);
+            } else {
+                this._logger.warn('Member node, ' + keys[i] + ', not loaded at getValidSetMemberTypes' +
+                    'Detailed invocation - cardinality constraints will not be enforced properly.');
             }
         }
 


### PR DESCRIPTION
Also indicate when part-browser is being updated by adding a progress handler.

The delay unblocks the visualizer from updating and the part-browser doesn't start its rendering till the next frame.

The batching skips additional computations in split-mode when both the selected object and visualizer are changed. It also removes potential race conditions in such cases.