### PR TITLE
Fixes #1489 Non-meta nodes in aspects throws exception in getValidChildrenMetaNodes

### DIFF
--- a/src/client/js/client/gmeNodeGetter.js
+++ b/src/client/js/client/gmeNodeGetter.js
@@ -428,23 +428,11 @@ define(['js/RegistryKeys'], function (REG_KEYS) {
     };
 
     GMENode.prototype.isTypeOf = function (typeId) {
-        var typeNode = _getNode(this._state.nodes, typeId);
-
-        if (typeNode) {
-            return this._state.core.isTypeOf(this._state.nodes[this._id].node, typeNode);
-        } else {
-            return false;
-        }
+        return this._state.core.isTypeOf(this._state.nodes[this._id].node, typeId);
     };
 
     GMENode.prototype.isInstanceOf = function (baseId) {
-        var baseNode = _getNode(this._state.nodes, baseId);
-
-        if (baseNode) {
-            return this._state.core.isInstanceOf(this._state.nodes[this._id].node, baseNode);
-        } else {
-            return false;
-        }
+        return this._state.core.isInstanceOf(this._state.nodes[this._id].node, baseId);
     };
 
     GMENode.prototype.isValidChildOf = function (parentPath) {

--- a/src/client/js/client/gmeNodeSetter.js
+++ b/src/client/js/client/gmeNodeSetter.js
@@ -1001,7 +1001,7 @@ define([], function () {
         function isTypeOf(path, typePath) {
             var node = _getNode(path);
 
-            if (node && typeNode) {
+            if (node) {
                 return state.core.isTypeOf(node, typePath);
             }
 

--- a/src/client/js/client/gmeNodeSetter.js
+++ b/src/client/js/client/gmeNodeSetter.js
@@ -999,11 +999,10 @@ define([], function () {
         // TODO: These should be removed at next version bump.
 
         function isTypeOf(path, typePath) {
-            var node = _getNode(path),
-                typeNode = _getNode(typePath);
+            var node = _getNode(path);
 
             if (node && typeNode) {
-                return state.core.isTypeOf(node, typeNode);
+                return state.core.isTypeOf(node, typePath);
             }
 
             return false;

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -1959,21 +1959,21 @@ define([
          * @throws {CoreIllegalOperationError} If the context of the operation is not allowed.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.delMemberAttribute = function (node, setName, path, attrName) {
+        this.delMemberAttribute = function (node, setName, memberPath, attrName) {
             ensureNode(node, 'node');
             ensureType(setName, 'setName', 'string');
-            ensurePath(path, 'path');
+            ensurePath(memberPath, 'memberPath');
             ensureType(attrName, 'attrName', 'string');
             var names = core.getSetNames(node);
             if (names.indexOf(setName) === -1) {
                 throw new CoreIllegalOperationError('Cannot access member information of unknown set.');
             }
             var paths = core.getMemberPaths(node, setName);
-            if (paths.indexOf(path) === -1) {
+            if (paths.indexOf(memberPath) === -1) {
                 throw new CoreIllegalOperationError('Cannot access attributes of an unknown member.');
             }
 
-            return core.delMemberAttribute(node, setName, path, attrName);
+            return core.delMemberAttribute(node, setName, memberPath, attrName);
         };
 
         /**
@@ -2306,20 +2306,24 @@ define([
          * Checks if the given node in any way inherits from the typeNode. In addition to checking if the node
          * "isInstanceOf" of typeNode, this methods also takes mixins into account.
          * @param {module:Core~Node} node - the node in question.
-         * @param {module:Core~Node} typeNode - the type node we want to check.
+         * @param {module:Core~Node | string} typeNodeOrPath - the type node we want to check or its path.
          *
-         * @return {bool} The function returns true if the typeNode is a base node, or a mixin of any of the
-         * base nodes, of the node.
+         * @return {bool} The function returns true if the typeNodeOrPath represents a base node,
+         * or a mixin of any of the base nodes, of the node.
          * Every node is considered to be a type of itself.
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isTypeOf = function (node, typeNode) {
+        this.isTypeOf = function (node, typeNodeOrPath) {
             ensureNode(node, 'node');
-            ensureNode(typeNode, 'typeNode');
+            if (typeof typeNodeOrPath === 'string') {
+                ensurePath(typeNodeOrPath, 'typeNodeOrPath');
+            } else {
+                ensureNode(typeNodeOrPath, 'typeNodeOrPath');
+            }
 
-            return core.isTypeOf(node, typeNode);
+            return core.isTypeOf(node, typeNodeOrPath);
         };
 
         /**
@@ -3027,7 +3031,7 @@ define([
         /**
          * Checks if the node is an instance of base.
          * @param {module:Core~Node} node - the node in question.
-         * @param {module:Core~Node} base - a potential base of the node
+         * @param {module:Core~Node | string} baseNodeOrPath - a potential base node (or its path) of the node
          *
          * @return {bool} Returns true if the base is on the inheritance chain of node.
          * A node is considered to be an instance of itself here.
@@ -3035,15 +3039,19 @@ define([
          * @throws {CoreIllegalArgumentError} If some of the parameters doesn't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.
          */
-        this.isInstanceOf = function (node, base) {
+        this.isInstanceOf = function (node, baseNodeOrPath) {
+            var noPath;
             ensureNode(node, 'node');
-            if (typeof base === 'string') {
-                return core.isInstanceOfDeprecated(node, base);
+            if (typeof baseNodeOrPath === 'string') {
+                noPath = ensurePath(baseNodeOrPath, 'baseNodeOrPath', true);
+                if (noPath) {
+                    return core.isInstanceOfDeprecated(node, baseNodeOrPath);
+                }
+            } else {
+                ensureNode(baseNodeOrPath, 'baseNodeOrPath');
             }
 
-            ensureNode(base, 'base');
-
-            return core.isInstanceOf(node, base);
+            return core.isInstanceOf(node, baseNodeOrPath);
         };
 
         /**

--- a/src/common/core/metacore.js
+++ b/src/common/core/metacore.js
@@ -29,13 +29,6 @@ define([
         logger.debug('initialized MetaCore');
 
         //<editor-fold=Helper Functions>
-        function sameNode(nodeA, nodeB) {
-            if (self.getPath(nodeA) === self.getPath(nodeB)) {
-                return true;
-            }
-            return false;
-        }
-
         function getMetaNode(node) {
             return self.getChild(node, CONSTANTS.META_NODE);
         }
@@ -133,19 +126,11 @@ define([
         //</editor-fold>
 
         //<editor-fold=Added Methods>
-        this.isTypeOf = function (node, typeNode) {
-            while (node) {
-                if (sameNode(node, typeNode)) {
-                    return true;
-                }
-                node = self.getBase(node);
-            }
-            return false;
-        };
+        this.isTypeOf = function (node, typeNodeOrNode) {
+            var typePath = typeof typeNodeOrNode === 'string' ? typeNodeOrNode : self.getPath(typeNodeOrNode);
 
-        this.isTypeOfPath = function (node, typePath) {
             while (node) {
-                if (self.getPath(node) === typePath) {
+                if (typePath === self.getPath(node)) {
                     return true;
                 }
                 node = self.getBase(node);

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -98,17 +98,6 @@ define([
                 delete rules.max;
                 delete rules.min;
 
-                //we need to clear nodes that are not on the meta sheet
-                // and we have to initialize the counters
-                keys = Object.keys(rules);
-                for (i = 0; i < keys.length; i += 1) {
-                    if (metaNodes[keys[i]]) {
-                        typeCounters[keys[i]] = 0;
-                    } else {
-                        delete rules[keys[i]];
-                    }
-                }
-
                 keys = Object.keys(rules);
                 for (i = 0; i < children.length; i += 1) {
                     for (j = 0; j < keys.length; j += 1) {

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -101,7 +101,10 @@ define([
                 keys = Object.keys(rules);
                 for (i = 0; i < children.length; i += 1) {
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOfPath(children[i], keys[j])) {
+                        if (innerCore.isTypeOf(children[i], keys[j])) {
+                            if (!typeCounters[keys[j]]) {
+                                typeCounters[keys[j]] = 0;
+                            }
                             typeCounters[keys[j]] += 1;
                         }
                     }
@@ -114,7 +117,7 @@ define([
                         if (rules[keys[j]].max &&
                             rules[keys[j]].max > -1 &&
                             rules[keys[j]].max <= typeCounters[keys[j]] &&
-                            innerCore.isTypeOfPath(validNodes[i], keys[j])) {
+                            innerCore.isTypeOf(validNodes[i], keys[j])) {
                             validNodes.splice(i, 1); //FIXME slow, use only push instead
                             break;
                         }
@@ -134,7 +137,7 @@ define([
                 while (i--) {
                     inAspect = false;
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOfPath(validNodes[i], keys[j])) {
+                        if (innerCore.isTypeOf(validNodes[i], keys[j])) {
                             inAspect = true;
                             break;
                         }
@@ -205,7 +208,7 @@ define([
                 keys = Object.keys(rules);
                 for (i = 0; i < members.length; i += 1) {
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOfPath(members[i], keys[j])) {
+                        if (innerCore.isTypeOf(members[i], keys[j])) {
                             typeCounters[keys[j]] += 1;
                         }
                     }
@@ -218,7 +221,7 @@ define([
                         if (rules[keys[j]].max &&
                             rules[keys[j]].max > -1 &&
                             rules[keys[j]].max <= typeCounters[keys[j]] &&
-                            innerCore.isTypeOfPath(validNodes[i], keys[j])) {
+                            innerCore.isTypeOf(validNodes[i], keys[j])) {
                             validNodes.splice(i, 1); //FIXME slow, use only push instead
                             break;
                         }

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -112,7 +112,7 @@ define([
                 keys = Object.keys(rules);
                 for (i = 0; i < children.length; i += 1) {
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOf(children[i], metaNodes[keys[j]])) {
+                        if (innerCore.isTypeOfPath(children[i], keys[j])) {
                             typeCounters[keys[j]] += 1;
                         }
                     }
@@ -125,7 +125,7 @@ define([
                         if (rules[keys[j]].max &&
                             rules[keys[j]].max > -1 &&
                             rules[keys[j]].max <= typeCounters[keys[j]] &&
-                            innerCore.isTypeOf(validNodes[i], metaNodes[keys[j]])) {
+                            innerCore.isTypeOfPath(validNodes[i], keys[j])) {
                             validNodes.splice(i, 1); //FIXME slow, use only push instead
                             break;
                         }
@@ -145,7 +145,7 @@ define([
                 while (i--) {
                     inAspect = false;
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOf(validNodes[i], metaNodes[keys[j]])) {
+                        if (innerCore.isTypeOfPath(validNodes[i], keys[j])) {
                             inAspect = true;
                             break;
                         }
@@ -216,7 +216,7 @@ define([
                 keys = Object.keys(rules);
                 for (i = 0; i < members.length; i += 1) {
                     for (j = 0; j < keys.length; j += 1) {
-                        if (innerCore.isTypeOf(members[i], metaNodes[keys[j]])) {
+                        if (innerCore.isTypeOfPath(members[i], keys[j])) {
                             typeCounters[keys[j]] += 1;
                         }
                     }
@@ -229,7 +229,7 @@ define([
                         if (rules[keys[j]].max &&
                             rules[keys[j]].max > -1 &&
                             rules[keys[j]].max <= typeCounters[keys[j]] &&
-                            innerCore.isTypeOf(validNodes[i], metaNodes[keys[j]])) {
+                            innerCore.isTypeOfPath(validNodes[i], keys[j])) {
                             validNodes.splice(i, 1); //FIXME slow, use only push instead
                             break;
                         }

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -300,7 +300,7 @@ define([
             return ['containment'];
         }
 
-        function isTypeOf(node, typeNode, alreadyVisited) {
+        function isTypeOf(node, typeNodeOrPath, alreadyVisited) {
             var base, mixins, i,
                 path = self.getPath(node);
 
@@ -310,47 +310,18 @@ define([
 
             alreadyVisited[path] = true;
 
-            if (innerCore.isTypeOf(node, typeNode)) {
+            if (innerCore.isTypeOf(node, typeNodeOrPath)) {
                 return true;
             }
 
             base = self.getBase(node);
-            if (base && isTypeOf(base, typeNode, alreadyVisited)) {
+            if (base && isTypeOf(base, typeNodeOrPath, alreadyVisited)) {
                 return true;
             }
 
             mixins = getOrderedMixinList(node);
             for (i = 0; i < mixins.length; i += 1) {
-                if (isTypeOf(mixins[i], typeNode, alreadyVisited)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        function isTypeOfPath(node, typePath, alreadyVisited) {
-            var base, mixins, i,
-                path = self.getPath(node);
-
-            if (alreadyVisited[path]) {
-                return false;
-            }
-
-            alreadyVisited[path] = true;
-
-            if (innerCore.isTypeOfPath(node, typePath)) {
-                return true;
-            }
-
-            base = self.getBase(node);
-            if (base && isTypeOfPath(base, typePath, alreadyVisited)) {
-                return true;
-            }
-
-            mixins = getOrderedMixinList(node);
-            for (i = 0; i < mixins.length; i += 1) {
-                if (isTypeOfPath(mixins[i], typePath, alreadyVisited)) {
+                if (isTypeOf(mixins[i], typeNodeOrPath, alreadyVisited)) {
                     return true;
                 }
             }
@@ -382,20 +353,12 @@ define([
 
         //<editor-fold=Modified Methods>
 
-        this.isTypeOf = function (node, typeNode) {
+        this.isTypeOf = function (node, typeNodeOrPath) {
             if (!realNode(node)) {
                 return false;
             }
 
-            return isTypeOf(node, typeNode, {});
-        };
-
-        this.isTypeOfPath = function (node, typePath) {
-            if (!realNode(node)) {
-                return false;
-            }
-
-            return isTypeOfPath(node, typePath, {});
+            return isTypeOf(node, typeNodeOrPath, {});
         };
 
         this.isValidChildOf = function (node, parentNode) {
@@ -613,7 +576,7 @@ define([
                 i;
 
             for (i = 0; i < aspectMeta.length; i += 1) {
-                if (self.isTypeOfPath(node, aspectMeta[i])) {
+                if (self.isTypeOf(node, aspectMeta[i])) {
                     return true;
                 }
             }

--- a/test/common/core/metaquerycore.spec.js
+++ b/test/common/core/metaquerycore.spec.js
@@ -58,9 +58,9 @@ describe('meta query core', function () {
 
     after(function (done) {
         Q.allDone([
-                storage.closeDatabase(),
-                gmeAuth.unload()
-            ])
+            storage.closeDatabase(),
+            gmeAuth.unload()
+        ])
             .nodeify(done);
     });
 
@@ -184,6 +184,38 @@ describe('meta query core', function () {
             paths.push(core.getPath(validNodes[i]));
         }
         expect(paths).to.have.members(validPaths);
+    });
+
+    it.only('should return every valid meta child and ignore elements of rule outside of the meta', function () {
+        //model /367050797/1626677559
+        //actual port    /1924875415/1359805212
+        var validPaths = [
+                '/367050797/355480347',
+                '/367050797/625420143',
+                '/367050797/1626677559'
+            ],
+            parameters = {
+                node: baseNodes['/1924875415'],
+                multiplicity: true,
+                children: [
+                    baseNodes['/1924875415/1359805212']
+                ]
+            },
+            paths = [],
+            metaNodes = core.getAllMetaNodes(baseNodes['/1924875415/1359805212']),
+            i,
+            validNodes;
+
+        core.setChildMeta(metaNodes['/367050797/1626677559'], baseNodes['/1924875415/1359805212']);
+
+        validNodes = core.getValidChildrenMetaNodes(parameters);
+
+        for (i = 0; i < validNodes.length; i += 1) {
+            paths.push(core.getPath(validNodes[i]));
+        }
+        expect(paths).to.have.members(validPaths);
+
+        core.delChildMeta(metaNodes['/367050797/1626677559'], '/1924875415/1359805212');
     });
 
     it('should return every possible member type with basic check', function () {

--- a/test/common/core/metaquerycore.spec.js
+++ b/test/common/core/metaquerycore.spec.js
@@ -187,8 +187,6 @@ describe('meta query core', function () {
     });
 
     it('should return every valid meta child and ignore elements of rule outside of the meta', function () {
-        //model /367050797/1626677559
-        //actual port    /1924875415/1359805212
         var validPaths = [
                 '/367050797/355480347',
                 '/367050797/625420143',
@@ -201,8 +199,7 @@ describe('meta query core', function () {
                     baseNodes['/1924875415/1359805212'],
                     baseNodes['/1924875415/1544821790']
                 ],
-                sensitive: true,
-                multiplicity: true
+                sensitive: true
             },
             paths = [],
             metaNodes = core.getAllMetaNodes(baseNodes['/1924875415/1359805212']),

--- a/test/common/core/metaquerycore.spec.js
+++ b/test/common/core/metaquerycore.spec.js
@@ -186,7 +186,7 @@ describe('meta query core', function () {
         expect(paths).to.have.members(validPaths);
     });
 
-    it.only('should return every valid meta child and ignore elements of rule outside of the meta', function () {
+    it('should return every valid meta child and ignore elements of rule outside of the meta', function () {
         //model /367050797/1626677559
         //actual port    /1924875415/1359805212
         var validPaths = [
@@ -196,10 +196,13 @@ describe('meta query core', function () {
             ],
             parameters = {
                 node: baseNodes['/1924875415'],
-                multiplicity: true,
                 children: [
-                    baseNodes['/1924875415/1359805212']
-                ]
+                    baseNodes['/1924875415/1059131120'],
+                    baseNodes['/1924875415/1359805212'],
+                    baseNodes['/1924875415/1544821790']
+                ],
+                sensitive: true,
+                multiplicity: true
             },
             paths = [],
             metaNodes = core.getAllMetaNodes(baseNodes['/1924875415/1359805212']),
@@ -216,6 +219,41 @@ describe('meta query core', function () {
         expect(paths).to.have.members(validPaths);
 
         core.delChildMeta(metaNodes['/367050797/1626677559'], '/1924875415/1359805212');
+    });
+
+    it('should return every valid meta child and ignore elements of rule outside of the meta', function () {
+        //model /367050797/1626677559
+        //actual port    /1924875415/1359805212
+        var validPaths = [
+                '/367050797/355480347',
+                '/367050797/625420143',
+                '/367050797/1626677559'
+            ],
+            parameters = {
+                node: baseNodes['/1924875415'],
+                children: [
+                    baseNodes['/1924875415/1059131120'],
+                    baseNodes['/1924875415/1359805212'],
+                    baseNodes['/1924875415/1544821790']
+                ],
+                sensitive: true,
+                multiplicity: true,
+                aspect: 'oneAsp'
+            },
+            paths = [],
+            metaNodes = core.getAllMetaNodes(baseNodes['/1924875415/1359805212']),
+            i,
+            validNodes;
+
+        core.setChildMeta(metaNodes['/367050797/1626677559'], baseNodes['/1924875415/1359805212']);
+        core.setAspectMetaTarget(metaNodes['/367050797/1626677559'], 'oneAsp', baseNodes['/1924875415/1359805212']);
+
+        validNodes = core.getValidChildrenMetaNodes(parameters);
+
+        expect(validNodes).to.have.length(0);
+
+        core.delChildMeta(metaNodes['/367050797/1626677559'], '/1924875415/1359805212');
+        core.delAspectMeta(metaNodes['/367050797/1626677559'], 'oneAsp');
     });
 
     it('should return every possible member type with basic check', function () {


### PR DESCRIPTION
As out-of-meta nodes can be part of meta rules, these specific inquiry functions should be prepared for that scenario.
The function results remains the same, but it will work only with the paths of the rule related nodes instead of trying to get them from all the meta nodes.