### PR TITLE
Fixes #1501 Add method on IActivePanel to give visualizer control of inner toolbar

### DIFF
--- a/src/client/js/PanelManager/IActivePanel.js
+++ b/src/client/js/PanelManager/IActivePanel.js
@@ -1,4 +1,4 @@
-/*globals define*/
+/*globals define, $*/
 /*jshint browser: true*/
 
 /**
@@ -36,6 +36,14 @@ define([], function () {
     IActivePanel.prototype.getNodeID = function () {
         this.logger.warn('IActivePanel.prototype.getNodeID IS NOT IMPLEMENTED!!!');
         return undefined;
+    };
+
+    /**
+     * 
+     * @returns {jQuery|HTMLElement}
+     */
+    IActivePanel.prototype.getSplitPanelToolbarEl = function () {
+        return $('<div class="split-panel-toolbar"></div>');
     };
 
     return IActivePanel;

--- a/src/client/js/PanelManager/IActivePanel.js
+++ b/src/client/js/PanelManager/IActivePanel.js
@@ -39,8 +39,10 @@ define([], function () {
     };
 
     /**
-     * 
-     * @returns {jQuery|HTMLElement}
+     * Toolbar handled by split-panel. It adds maximize btns to it.
+     * If no toolbar should be displayed - overwrite and return null.
+     *
+     * @returns {jQuery|null}
      */
     IActivePanel.prototype.getSplitPanelToolbarEl = function () {
         return $('<div class="split-panel-toolbar"></div>');

--- a/src/client/js/Panels/GraphViz/GraphVizPanel.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanel.js
@@ -1,4 +1,4 @@
-/*globals define, _, WebGMEGlobal*/
+/*globals define, _, WebGMEGlobal, $*/
 /*jshint browser: true*/
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
@@ -55,6 +55,33 @@ define(['js/PanelBase/PanelBaseWithHeader',
         });
 
         this.onActivate();
+    };
+
+    GraphVizPanel.prototype.getSplitPanelToolbarEl = function () {
+        this._splitPanelToolbarEl = IActivePanel.prototype.getSplitPanelToolbarEl.call(this);
+
+        // Set the size bigger than 40 x 40 and add some padding for the scroll-bar.
+        this._splitPanelToolbarEl.css({
+            width: '100px',
+            height: '100px',
+            'padding-right': '10px'
+        });
+
+        this.control._addSplitPanelToolbarBtns(this._splitPanelToolbarEl);
+
+        return this._splitPanelToolbarEl;
+    };
+
+    GraphVizPanel.prototype.afterAppend = function () {
+        PanelBaseWithHeader.prototype.afterAppend.call(this);
+        // At this point the split-panel has added its buttons (the maximize)
+        // and we can modify the look of all btns.
+
+        this._splitPanelToolbarEl.children().each(function () {
+            $(this).css({
+                'font-size': '16px'
+            });
+        });
     };
 
     /* OVERRIDE FROM WIDGET-WITH-HEADER */

--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -1,4 +1,4 @@
-/*globals define, _, WebGMEGlobal*/
+/*globals define, _, WebGMEGlobal, $*/
 /*jshint browser: true*/
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
@@ -306,28 +306,55 @@ define(['js/logger',
     };
 
     GraphVizControl.prototype._initializeToolbar = function () {
-        var toolBar = WebGMEGlobal.Toolbar,
-            self = this;
+        var toolBar = WebGMEGlobal.Toolbar;
 
         this._toolbarItems = [];
 
         this._toolbarItems.push(toolBar.addSeparator());
         /************** MODEL / CONNECTION filter *******************/
-
-        this.$cbShowConnection = toolBar.addCheckBox({
-            title: 'Show connection',
-            icon: 'gme icon-gme_diagonal-arrow',
-            checkChangedFn: function (data, checked) {
-                self._displayModelsOnly = !checked;
-                self._generateData();
-            }
-        });
-
-        this._toolbarItems.push(this.$cbShowConnection);
+        //
+        // this.$cbShowConnection = toolBar.addCheckBox({
+        //     title: 'Show connection',
+        //     icon: 'gme icon-gme_diagonal-arrow',
+        //     checkChangedFn: function (data, checked) {
+        //         self._displayModelsOnly = !checked;
+        //         self._generateData();
+        //     }
+        // });
+        //
+        // this._toolbarItems.push(this.$cbShowConnection);
         /************** END OF - MODEL / CONNECTION filter *******************/
 
         this._toolbarInitialized = true;
     };
+
+    GraphVizControl.prototype._addSplitPanelToolbarBtns = function (toolbarEl) {
+        var self = this,
+            connBtn = $('<span class="split-panel-toolbar-btn no-print glyphicon glyphicon-filter"></span>');
+
+        connBtn.on('click', function () {
+            self._displayModelsOnly = !self._displayModelsOnly;
+            if (self._displayModelsOnly) {
+                connBtn.attr('title', 'Show connections');
+            } else {
+                connBtn.attr('title', 'Hide connections');
+            }
+            self._generateData();
+        });
+
+        if (self._displayModelsOnly) {
+            connBtn.attr('title', 'Show connections');
+        } else {
+            connBtn.attr('title', 'Hide connections');
+        }
+
+        toolbarEl.append(connBtn);
+
+        connBtn.hide();
+
+        return toolbarEl;
+    };
+
 
     return GraphVizControl;
 });

--- a/src/client/js/Panels/SplitPanel/SplitMaximizeButton.js
+++ b/src/client/js/Panels/SplitPanel/SplitMaximizeButton.js
@@ -7,19 +7,21 @@
 define([], function () {
     'use strict';
 
-    function SplitMaximizeButton(id, splitPanelManager, container) {
+    function SplitMaximizeButton(id, splitPanelManager, container, toolbarEl) {
         this._id = id;
         this._manager = splitPanelManager;
-        this.$el = $('<div class="toolbar"></div>');
-        this._button = $('<span class="maximize-btn no-print glyphicon glyphicon-resize-full"></span>');
+        this._toolbarEl = toolbarEl;
+        this._button = $('<span class="split-panel-toolbar-btn maximize-btn no-print glyphicon glyphicon-resize-full">' +
+            '</span>');
 
-        this.$el.append(this._button);
+        // Since float it right this should come first (i.e. top right corner).
+        toolbarEl.prepend(this._button);
 
         this._button.hide();
 
         this._initialize();
 
-        container.append(this.$el);
+        container.append(toolbarEl);
     }
 
     SplitMaximizeButton.prototype._initialize = function () {
@@ -43,7 +45,8 @@ define([], function () {
             }
         });
 
-        this.$el.on('mouseenter', function () {
+        this._toolbarEl.on('mouseenter', function () {
+            self._toolbarEl.children().show();
             if (self._manager._maximized === false && Object.keys(self._manager._panels).length > 1 ||
                 self._manager._maximized) {
                 if (self._manager._maximized) {
@@ -55,12 +58,13 @@ define([], function () {
                     self._button.addClass('glyphicon-resize-full');
                     self._button.attr('title', 'Maximize panel');
                 }
-                self._button.show();
+            } else {
+                self._button.hide();
             }
         });
 
-        this.$el.on('mouseleave', function () {
-            self._button.hide();
+        this._toolbarEl.on('mouseleave', function () {
+            self._toolbarEl.children().hide();
         });
     };
 

--- a/src/client/js/Panels/SplitPanel/SplitPanel.js
+++ b/src/client/js/Panels/SplitPanel/SplitPanel.js
@@ -118,7 +118,7 @@ define([
             panelContainer: panelContainer,
             instance: null,
             eventHandler: self._attachActivateHandler(panelContainer),
-            maximizeButton: new SplitMaximizeButton(this._activePanelId, this, panelContainer),
+            maximizeButton: null,
             splitters: {
                 top: null,
                 right: null,
@@ -156,11 +156,26 @@ define([
     };
 
     SplitPanel.prototype.updateActivePanel = function (panel) {
-        var activePanel = this._panels[this._activePanelId];
+        var self = this,
+            activePanel = this._panels[this._activePanelId],
+            toolbar;
 
         // activePanel.panelContainer.empty();
         activePanel.instance = panel;
         activePanel.panelContainer.append(panel.$pEl);
+
+        if (activePanel.toolbar) {
+            activePanel.toolbar.remove();
+            delete activePanel.toolbar;
+        }
+
+        toolbar = panel.getSplitPanelToolbarEl();
+
+        if (toolbar) {
+            (new SplitMaximizeButton(this._activePanelId, self, activePanel.panelContainer, toolbar));
+            activePanel.toolbar = toolbar;
+        }
+
         panel.afterAppend();
 
         WebGMEGlobal.PanelManager.setActivePanel(panel);
@@ -188,7 +203,7 @@ define([
             panelContainer: panelContainer,
             instance: null,
             eventHandler: self._attachActivateHandler(panelContainer),
-            maximizeButton: new SplitMaximizeButton(newPanelId, self, panelContainer),
+            maximizeButton: null,
             splitters: {
                 // Initially set splitters to same as panel splitting from.
                 top: this._panels[this._activePanelId].splitters.top,

--- a/src/client/js/Panels/SplitPanel/SplitPanel.js
+++ b/src/client/js/Panels/SplitPanel/SplitPanel.js
@@ -118,7 +118,7 @@ define([
             panelContainer: panelContainer,
             instance: null,
             eventHandler: self._attachActivateHandler(panelContainer),
-            maximizeButton: null,
+            toolbar: null,
             splitters: {
                 top: null,
                 right: null,
@@ -203,7 +203,7 @@ define([
             panelContainer: panelContainer,
             instance: null,
             eventHandler: self._attachActivateHandler(panelContainer),
-            maximizeButton: null,
+            toolbar: null,
             splitters: {
                 // Initially set splitters to same as panel splitting from.
                 top: this._panels[this._activePanelId].splitters.top,

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
@@ -27,8 +27,8 @@ ul.split-panel-dropdown-list {
       width: 40px;
       height: 40px;
       z-index: 999999;
-      padding-top: 3px;
-      padding-right: 10px; }
+      padding-top: 2px;
+      padding-right: 3px; }
       .split-panel .split-panel-panel-container .split-panel-toolbar .split-panel-toolbar-btn {
         position: relative;
         float: right;

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.css
@@ -20,25 +20,26 @@ ul.split-panel-dropdown-list {
   .split-panel .split-panel-panel-container {
     position: absolute;
     overflow: hidden; }
-    .split-panel .split-panel-panel-container .toolbar {
+    .split-panel .split-panel-panel-container .split-panel-toolbar {
       position: absolute;
-      right: 0px;
-      top: 0px;
+      right: 0;
+      top: 0;
       width: 40px;
       height: 40px;
-      z-index: 999999; }
-    .split-panel .split-panel-panel-container .maximize-btn {
-      position: absolute;
-      top: 3px;
-      right: 2px;
-      border-radius: 50%;
-      color: #00235b;
-      background-color: #fff;
-      border: 6px solid #fff;
-      opacity: 0.75;
-      cursor: pointer; }
-      .split-panel .split-panel-panel-container .maximize-btn:hover {
-        opacity: 1; }
+      z-index: 999999;
+      padding-top: 3px;
+      padding-right: 10px; }
+      .split-panel .split-panel-panel-container .split-panel-toolbar .split-panel-toolbar-btn {
+        position: relative;
+        float: right;
+        border-radius: 50%;
+        color: #00235b;
+        background-color: #fff;
+        border: 6px solid #fff;
+        opacity: 0.75;
+        cursor: pointer; }
+        .split-panel .split-panel-panel-container .split-panel-toolbar .split-panel-toolbar-btn:hover {
+          opacity: 1; }
   .split-panel .splitter {
     z-index: 1000;
     position: absolute;

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
@@ -33,8 +33,8 @@ ul.split-panel-dropdown-list {
       width: 40px;
       height: 40px;
       z-index: 999999;
-      padding-top: 3px;
-      padding-right: 10px;
+      padding-top: 2px;
+      padding-right: 3px;
 
       .split-panel-toolbar-btn {
         position: relative;

--- a/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
+++ b/src/client/js/Panels/SplitPanel/styles/SplitPanel.scss
@@ -26,28 +26,29 @@ ul.split-panel-dropdown-list {
     position: absolute;
     overflow: hidden;
 
-    .toolbar {
+    .split-panel-toolbar {
       position: absolute;
-      right: 0px;
-      top: 0px;
+      right: 0;
+      top: 0;
       width: 40px;
       height: 40px;
       z-index: 999999;
+      padding-top: 3px;
+      padding-right: 10px;
 
-    }
-    .maximize-btn {
-      position: absolute;
-      top: 3px;
-      right: 2px;
-      border-radius: 50%;
-      color: #00235b;
-      background-color: #fff;
-      border: 6px solid #fff;
-      opacity: 0.75;
-      cursor: pointer;
-      //text-shadow: -1px 0 #9ecaed, 0 1px #9ecaed, 1px 0 #9ecaed, 0 -1px #9ecaed;
-      &:hover {
-        opacity: 1;
+      .split-panel-toolbar-btn {
+        position: relative;
+        float: right;
+        border-radius: 50%;
+        color: #00235b;
+        background-color: #fff;
+        border: 6px solid #fff;
+        opacity: 0.75;
+        cursor: pointer;
+        //text-shadow: -1px 0 #9ecaed, 0 1px #9ecaed, 1px 0 #9ecaed, 0 -1px #9ecaed;
+        &:hover {
+          opacity: 1;
+        }
       }
     }
   }

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -114,6 +114,19 @@ define(['js/logger',
                 self._toolbarBtn.clear();
 
                 self._toolbarBtn.addButton({
+                    text: maximized ? 'Exit maximize' : 'Maximize active panel',
+                    title: maximized ? 'Shows all split panels' : 'Maximizes the active panel',
+                    icon: 'split-panel-dropdown-icon glyphicon ' +
+                    (maximized ? 'glyphicon-resize-small' : 'glyphicon-resize-full'),
+                    disabled: self._splitPanel.getNumberOfPanels() === 1,
+                    clickFn: function () {
+                        self._splitPanel.maximize(!maximized, self._splitPanel._activePanelId);
+                    }
+                });
+
+                self._toolbarBtn.addDivider();
+
+                self._toolbarBtn.addButton({
                     text: 'Split vertically',
                     title: 'Splits the active panel vertically',
                     icon: 'fa fa-columns split-panel-dropdown-icon',

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
@@ -15,7 +15,7 @@ define([
         TABS_CONTAINER = 'diagram-designer-tabs-container',
         ADD_TAB_CONTAINER_CLASS = 'add-tab-container',
         TAB_LIST_CONTAINER_CLASS = 'tab-list-container',
-        //TAB_SCROLL = 200,
+        TAB_SCROLL = 200,
         TAB_ID = 'TAB_ID',
         TAB_RENAME = 'TAB_RENAME',
         WITH_TABS_CLASS = 'w-tabs',
@@ -60,23 +60,23 @@ define([
         });
         this.$divAddTab.append(this.$ddlTabsList.el);
 
-        // this.$btnScrollLeft = new ToolbarButton({
-        //     title: 'Scroll left',
-        //     icon: 'glyphicon glyphicon-chevron-left',
-        //     clickFn: function (/*data*/) {
-        //         self._tabsScrollLeft();
-        //     }
-        // });
-        // this.$divAddTab.append(this.$btnScrollLeft.el);
-        //
-        // this.$btnScrollRight = new ToolbarButton({
-        //     title: 'Scroll right',
-        //     icon: 'glyphicon glyphicon-chevron-right',
-        //     clickFn: function (/*data*/) {
-        //         self._tabsScrollRight();
-        //     }
-        // });
-        // this.$divAddTab.append(this.$btnScrollRight.el);
+        this.$btnScrollLeft = new ToolbarButton({
+            title: 'Scroll left',
+            icon: 'glyphicon glyphicon-chevron-left',
+            clickFn: function (/*data*/) {
+                self._tabsScrollLeft();
+            }
+        });
+        this.$divAddTab.append(this.$btnScrollLeft.el);
+
+        this.$btnScrollRight = new ToolbarButton({
+            title: 'Scroll right',
+            icon: 'glyphicon glyphicon-chevron-right',
+            clickFn: function (/*data*/) {
+                self._tabsScrollRight();
+            }
+        });
+        this.$divAddTab.append(this.$btnScrollRight.el);
 
 
         this.$divTabList = $('<div/>', {class: TAB_LIST_CONTAINER_CLASS});
@@ -88,7 +88,7 @@ define([
         this.$tabsContainer.append(this.$divAddTab);
         this.$tabsContainer.append(this.$divTabList);
 
-        // this._tabScrollValue = 0;
+        this._tabScrollValue = 0;
 
         //hook up tab rename
         // set title editable on double-click
@@ -140,7 +140,7 @@ define([
         this.$ddlTabsList.clear();
         this._tabCounter = 0;
         this._selectedTab = undefined;
-        //this._scrollTabListBy(0 - this._tabScrollValue);
+        this._scrollTabListBy(0 - this._tabScrollValue);
     };
 
     DiagramDesignerWidgetTabs.prototype._makeTabsSortable = function () {
@@ -199,7 +199,7 @@ define([
         });
 
         if (this._addingMultipleTabs !== true) {
-            //this._refreshTabScrollButtons();
+            this._refreshTabScrollButtons();
         }
 
         return li.data(TAB_ID);
@@ -214,33 +214,33 @@ define([
     DiagramDesignerWidgetTabs.prototype.addMultipleTabsEnd = function () {
         this.$ulTabTab.show();
 
-        //this._refreshTabScrollButtons();
+        this._refreshTabScrollButtons();
 
         this._addingMultipleTabs = false;
     };
 
-    // DiagramDesignerWidgetTabs.prototype._tabsScrollLeft = function () {
-    //     if (this._tabScrollValue < 0) {
-    //         this._scrollTabListBy(Math.min(Math.abs(this._tabScrollValue), TAB_SCROLL));
-    //     }
-    // };
-    //
-    // DiagramDesignerWidgetTabs.prototype._tabsScrollRight = function () {
-    //     var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
-    //         this._tabScrollValue;
-    //
-    //     if (overflowRightBy > 0) {
-    //         overflowRightBy = Math.min(overflowRightBy, TAB_SCROLL);
-    //         this._scrollTabListBy(-overflowRightBy);
-    //     }
-    // };
-    //
-    // DiagramDesignerWidgetTabs.prototype._scrollTabListBy = function (value) {
-    //     this._tabScrollValue += value;
-    //     this.$ulTabTab.css('left', this._tabScrollValue);
-    //
-    //     this._refreshTabScrollButtons();
-    // };
+    DiagramDesignerWidgetTabs.prototype._tabsScrollLeft = function () {
+        if (this._tabScrollValue < 0) {
+            this._scrollTabListBy(Math.min(Math.abs(this._tabScrollValue), TAB_SCROLL));
+        }
+    };
+
+    DiagramDesignerWidgetTabs.prototype._tabsScrollRight = function () {
+        var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
+            this._tabScrollValue;
+
+        if (overflowRightBy > 0) {
+            overflowRightBy = Math.min(overflowRightBy, TAB_SCROLL);
+            this._scrollTabListBy(-overflowRightBy);
+        }
+    };
+
+    DiagramDesignerWidgetTabs.prototype._scrollTabListBy = function (value) {
+        this._tabScrollValue += value;
+        this.$ulTabTab.css('left', this._tabScrollValue);
+
+        this._refreshTabScrollButtons();
+    };
 
     DiagramDesignerWidgetTabs.prototype.selectTab = function (tabID) {
         var liToSelect,
@@ -288,36 +288,36 @@ define([
                 liToSelect.find('a').prepend(DDL_SELECTED_TAB_ICON_BASE.clone());
             }
 
-            //this._scrollSelectedTabIntoView();
+            this._scrollSelectedTabIntoView();
 
             //fire event...
             this.onSelectedTabChanged(this._selectedTab);
         }
     };
 
-    // DiagramDesignerWidgetTabs.prototype._scrollSelectedTabIntoView = function () {
-    //     //scroll selected tab's tab into view
-    //     var li = this.$ulTabTab.find('li.active').first();
-    //     var liPos = li.position();
-    //     var visibleWidth = this.$tabsContainer.width() - this.$divAddTab.outerWidth(true);
-    //     var visibleMin = -this._tabScrollValue;
-    //     var visibleMax = -this._tabScrollValue + visibleWidth;
-    //     if (liPos) {
-    //         if (liPos.left < visibleMin) {
-    //             this._scrollTabListBy(visibleMin - liPos.left);
-    //         } else if (liPos.left + li.width() > visibleMax) {
-    //             this._scrollTabListBy(visibleMax - (liPos.left + li.width()));
-    //         }
-    //     }
-    // };
-    //
-    // DiagramDesignerWidgetTabs.prototype._refreshTabScrollButtons = function () {
-    //     var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
-    //         this._tabScrollValue;
-    //
-    //     this.$btnScrollLeft.enabled(this._tabScrollValue < 0);
-    //     this.$btnScrollRight.enabled(overflowRightBy > 0);
-    // };
+    DiagramDesignerWidgetTabs.prototype._scrollSelectedTabIntoView = function () {
+        //scroll selected tab's tab into view
+        var li = this.$ulTabTab.find('li.active').first();
+        var liPos = li.position();
+        var visibleWidth = this.$tabsContainer.width() - this.$divAddTab.outerWidth(true);
+        var visibleMin = -this._tabScrollValue;
+        var visibleMax = -this._tabScrollValue + visibleWidth;
+        if (liPos) {
+            if (liPos.left < visibleMin) {
+                this._scrollTabListBy(visibleMin - liPos.left);
+            } else if (liPos.left + li.width() > visibleMax) {
+                this._scrollTabListBy(visibleMax - (liPos.left + li.width()));
+            }
+        }
+    };
+
+    DiagramDesignerWidgetTabs.prototype._refreshTabScrollButtons = function () {
+        var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
+            this._tabScrollValue;
+
+        this.$btnScrollLeft.enabled(this._tabScrollValue < 0);
+        this.$btnScrollRight.enabled(overflowRightBy > 0);
+    };
 
     DiagramDesignerWidgetTabs.prototype._onTabsSortStop = function () {
         var ul = this.$ulTabTab,
@@ -336,19 +336,19 @@ define([
         }
     };
 
-    // DiagramDesignerWidgetTabs.prototype._refreshTabTabsScrollOnResize = function () {
-    //     if (this._tabsEnabled === true) {
-    //         var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() +
-    //             this.$divAddTab.outerWidth(true) + this._tabScrollValue;
-    //
-    //         if (overflowRightBy < 0) {
-    //             this._scrollTabListBy(-overflowRightBy);
-    //         }
-    //
-    //         this._scrollSelectedTabIntoView();
-    //         this._refreshTabScrollButtons();
-    //     }
-    // };
+    DiagramDesignerWidgetTabs.prototype._refreshTabTabsScrollOnResize = function () {
+        if (this._tabsEnabled === true) {
+            var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() +
+                this.$divAddTab.outerWidth(true) + this._tabScrollValue;
+
+            if (overflowRightBy < 0) {
+                this._scrollTabListBy(-overflowRightBy);
+            }
+
+            this._scrollSelectedTabIntoView();
+            this._refreshTabScrollButtons();
+        }
+    };
 
     DiagramDesignerWidgetTabs.prototype.onTabDeleteClicked = function (tabID) {
         this.logger.warn('onTabDeleteClicked not implemented: "' + tabID + '"');

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
@@ -15,7 +15,7 @@ define([
         TABS_CONTAINER = 'diagram-designer-tabs-container',
         ADD_TAB_CONTAINER_CLASS = 'add-tab-container',
         TAB_LIST_CONTAINER_CLASS = 'tab-list-container',
-        TAB_SCROLL = 200,
+        //TAB_SCROLL = 200,
         TAB_ID = 'TAB_ID',
         TAB_RENAME = 'TAB_RENAME',
         WITH_TABS_CLASS = 'w-tabs',
@@ -60,23 +60,23 @@ define([
         });
         this.$divAddTab.append(this.$ddlTabsList.el);
 
-        this.$btnScrollLeft = new ToolbarButton({
-            title: 'Scroll left',
-            icon: 'glyphicon glyphicon-chevron-left',
-            clickFn: function (/*data*/) {
-                self._tabsScrollLeft();
-            }
-        });
-        this.$divAddTab.append(this.$btnScrollLeft.el);
-
-        this.$btnScrollRight = new ToolbarButton({
-            title: 'Scroll right',
-            icon: 'glyphicon glyphicon-chevron-right',
-            clickFn: function (/*data*/) {
-                self._tabsScrollRight();
-            }
-        });
-        this.$divAddTab.append(this.$btnScrollRight.el);
+        // this.$btnScrollLeft = new ToolbarButton({
+        //     title: 'Scroll left',
+        //     icon: 'glyphicon glyphicon-chevron-left',
+        //     clickFn: function (/*data*/) {
+        //         self._tabsScrollLeft();
+        //     }
+        // });
+        // this.$divAddTab.append(this.$btnScrollLeft.el);
+        //
+        // this.$btnScrollRight = new ToolbarButton({
+        //     title: 'Scroll right',
+        //     icon: 'glyphicon glyphicon-chevron-right',
+        //     clickFn: function (/*data*/) {
+        //         self._tabsScrollRight();
+        //     }
+        // });
+        // this.$divAddTab.append(this.$btnScrollRight.el);
 
 
         this.$divTabList = $('<div/>', {class: TAB_LIST_CONTAINER_CLASS});
@@ -88,7 +88,7 @@ define([
         this.$tabsContainer.append(this.$divAddTab);
         this.$tabsContainer.append(this.$divTabList);
 
-        this._tabScrollValue = 0;
+        // this._tabScrollValue = 0;
 
         //hook up tab rename
         // set title editable on double-click
@@ -140,7 +140,7 @@ define([
         this.$ddlTabsList.clear();
         this._tabCounter = 0;
         this._selectedTab = undefined;
-        this._scrollTabListBy(0 - this._tabScrollValue);
+        //this._scrollTabListBy(0 - this._tabScrollValue);
     };
 
     DiagramDesignerWidgetTabs.prototype._makeTabsSortable = function () {
@@ -199,7 +199,7 @@ define([
         });
 
         if (this._addingMultipleTabs !== true) {
-            this._refreshTabScrollButtons();
+            //this._refreshTabScrollButtons();
         }
 
         return li.data(TAB_ID);
@@ -214,33 +214,33 @@ define([
     DiagramDesignerWidgetTabs.prototype.addMultipleTabsEnd = function () {
         this.$ulTabTab.show();
 
-        this._refreshTabScrollButtons();
+        //this._refreshTabScrollButtons();
 
         this._addingMultipleTabs = false;
     };
 
-    DiagramDesignerWidgetTabs.prototype._tabsScrollLeft = function () {
-        if (this._tabScrollValue < 0) {
-            this._scrollTabListBy(Math.min(Math.abs(this._tabScrollValue), TAB_SCROLL));
-        }
-    };
-
-    DiagramDesignerWidgetTabs.prototype._tabsScrollRight = function () {
-        var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
-            this._tabScrollValue;
-
-        if (overflowRightBy > 0) {
-            overflowRightBy = Math.min(overflowRightBy, TAB_SCROLL);
-            this._scrollTabListBy(-overflowRightBy);
-        }
-    };
-
-    DiagramDesignerWidgetTabs.prototype._scrollTabListBy = function (value) {
-        this._tabScrollValue += value;
-        this.$ulTabTab.css('left', this._tabScrollValue);
-
-        this._refreshTabScrollButtons();
-    };
+    // DiagramDesignerWidgetTabs.prototype._tabsScrollLeft = function () {
+    //     if (this._tabScrollValue < 0) {
+    //         this._scrollTabListBy(Math.min(Math.abs(this._tabScrollValue), TAB_SCROLL));
+    //     }
+    // };
+    //
+    // DiagramDesignerWidgetTabs.prototype._tabsScrollRight = function () {
+    //     var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
+    //         this._tabScrollValue;
+    //
+    //     if (overflowRightBy > 0) {
+    //         overflowRightBy = Math.min(overflowRightBy, TAB_SCROLL);
+    //         this._scrollTabListBy(-overflowRightBy);
+    //     }
+    // };
+    //
+    // DiagramDesignerWidgetTabs.prototype._scrollTabListBy = function (value) {
+    //     this._tabScrollValue += value;
+    //     this.$ulTabTab.css('left', this._tabScrollValue);
+    //
+    //     this._refreshTabScrollButtons();
+    // };
 
     DiagramDesignerWidgetTabs.prototype.selectTab = function (tabID) {
         var liToSelect,
@@ -288,36 +288,36 @@ define([
                 liToSelect.find('a').prepend(DDL_SELECTED_TAB_ICON_BASE.clone());
             }
 
-            this._scrollSelectedTabIntoView();
+            //this._scrollSelectedTabIntoView();
 
             //fire event...
             this.onSelectedTabChanged(this._selectedTab);
         }
     };
 
-    DiagramDesignerWidgetTabs.prototype._scrollSelectedTabIntoView = function () {
-        //scroll selected tab's tab into view
-        var li = this.$ulTabTab.find('li.active').first();
-        var liPos = li.position();
-        var visibleWidth = this.$tabsContainer.width() - this.$divAddTab.outerWidth(true);
-        var visibleMin = -this._tabScrollValue;
-        var visibleMax = -this._tabScrollValue + visibleWidth;
-        if (liPos) {
-            if (liPos.left < visibleMin) {
-                this._scrollTabListBy(visibleMin - liPos.left);
-            } else if (liPos.left + li.width() > visibleMax) {
-                this._scrollTabListBy(visibleMax - (liPos.left + li.width()));
-            }
-        }
-    };
-
-    DiagramDesignerWidgetTabs.prototype._refreshTabScrollButtons = function () {
-        var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
-            this._tabScrollValue;
-
-        this.$btnScrollLeft.enabled(this._tabScrollValue < 0);
-        this.$btnScrollRight.enabled(overflowRightBy > 0);
-    };
+    // DiagramDesignerWidgetTabs.prototype._scrollSelectedTabIntoView = function () {
+    //     //scroll selected tab's tab into view
+    //     var li = this.$ulTabTab.find('li.active').first();
+    //     var liPos = li.position();
+    //     var visibleWidth = this.$tabsContainer.width() - this.$divAddTab.outerWidth(true);
+    //     var visibleMin = -this._tabScrollValue;
+    //     var visibleMax = -this._tabScrollValue + visibleWidth;
+    //     if (liPos) {
+    //         if (liPos.left < visibleMin) {
+    //             this._scrollTabListBy(visibleMin - liPos.left);
+    //         } else if (liPos.left + li.width() > visibleMax) {
+    //             this._scrollTabListBy(visibleMax - (liPos.left + li.width()));
+    //         }
+    //     }
+    // };
+    //
+    // DiagramDesignerWidgetTabs.prototype._refreshTabScrollButtons = function () {
+    //     var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() + this.$divAddTab.outerWidth(true) +
+    //         this._tabScrollValue;
+    //
+    //     this.$btnScrollLeft.enabled(this._tabScrollValue < 0);
+    //     this.$btnScrollRight.enabled(overflowRightBy > 0);
+    // };
 
     DiagramDesignerWidgetTabs.prototype._onTabsSortStop = function () {
         var ul = this.$ulTabTab,
@@ -336,19 +336,19 @@ define([
         }
     };
 
-    DiagramDesignerWidgetTabs.prototype._refreshTabTabsScrollOnResize = function () {
-        if (this._tabsEnabled === true) {
-            var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() +
-                this.$divAddTab.outerWidth(true) + this._tabScrollValue;
-
-            if (overflowRightBy < 0) {
-                this._scrollTabListBy(-overflowRightBy);
-            }
-
-            this._scrollSelectedTabIntoView();
-            this._refreshTabScrollButtons();
-        }
-    };
+    // DiagramDesignerWidgetTabs.prototype._refreshTabTabsScrollOnResize = function () {
+    //     if (this._tabsEnabled === true) {
+    //         var overflowRightBy = this.$ulTabTab.width() - this.$tabsContainer.width() +
+    //             this.$divAddTab.outerWidth(true) + this._tabScrollValue;
+    //
+    //         if (overflowRightBy < 0) {
+    //             this._scrollTabListBy(-overflowRightBy);
+    //         }
+    //
+    //         this._scrollSelectedTabIntoView();
+    //         this._refreshTabScrollButtons();
+    //     }
+    // };
 
     DiagramDesignerWidgetTabs.prototype.onTabDeleteClicked = function (tabID) {
         this.logger.warn('onTabDeleteClicked not implemented: "' + tabID + '"');

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -393,7 +393,10 @@ define([
         //call our own resize handler
         this._resizeItemContainer();
 
-        this._refreshTabTabsScrollOnResize();
+        if (this.$ulTabTab.width() !== 0) {
+            // Do not refresh the tabs if they aren't shown.
+            this._refreshTabTabsScrollOnResize();
+        }
     };
 
     DiagramDesignerWidget.prototype.destroy = function () {

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -393,7 +393,7 @@ define([
         //call our own resize handler
         this._resizeItemContainer();
 
-        this._refreshTabTabsScrollOnResize();
+        // this._refreshTabTabsScrollOnResize();
     };
 
     DiagramDesignerWidget.prototype.destroy = function () {

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.js
@@ -393,7 +393,7 @@ define([
         //call our own resize handler
         this._resizeItemContainer();
 
-        // this._refreshTabTabsScrollOnResize();
+        this._refreshTabTabsScrollOnResize();
     };
 
     DiagramDesignerWidget.prototype.destroy = function () {


### PR DESCRIPTION
See graphviz panel for example of how to add own btns and overwrite look of toolbar and buttons.

The dropdown menu now also contains maximize/exit maximize allowing the visualizer to completely disabled the potentially blocking toolbar. Simply overwrite:
```
MyVizPanel.prototype.getSplitPanelToolbarEl = function () {
    return null;
};
```