### PR TITLE
Disable the caching of distribution files

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html manifest="webgme.dist.<%=webgmeVersion%>.appcache">
+<!--<html manifest="webgme.dist.<%=webgmeVersion%>.appcache">-->
 <head>
     <title><%=pageTitle%></title>
     <!-- Load main.js with RequireJS and launch the app from there -->


### PR DESCRIPTION
With guest account disabled and without token the index path is never taken at load and redirect to login is triggered from requirejs loads.