### PR TITLE
Property editor multiselect issues and various improvements fixes to it

### DIFF
--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanel.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanel.js
@@ -69,8 +69,6 @@ define(['js/PanelBase/PanelBaseWithHeader',
         this.propertyGrids.push(propertyGrid);
         this.$el.find('div#attributes').html(propertyGrid.$el);
 
-        // FIXME: This approach of multiple controllers can be very inefficient when selecting many nodes.
-
         //attach control to the PropertyGrid for PROPERTY_GROUP_ATTRIBUTES
         p = new PropertyEditorPanelController(this._client, propertyGrid, CONSTANTS.PROPERTY_GROUP_ATTRIBUTES);
         p.setReadOnly = function (isReadOnly) {

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -7,24 +7,22 @@
  */
 
 define(['js/logger',
-    'js/util',
     'js/NodePropertyNames',
     'js/RegistryKeys',
     'js/Constants',
     'assets/line/lineSvgs',
-    'js/Utils/GMEConcepts',
     'js/Utils/DisplayFormat',
+    './PropertyEditorPanelControllerHelpers',
     'js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog',
     'js/Dialogs/ValidVisualizers/ValidVisualizersDialog',
     'js/Controls/PropertyGrid/PropertyGridWidgets'
 ], function (Logger,
-             util,
              nodePropertyNames,
              REGISTRY_KEYS,
              CONSTANTS,
              LINE_SVG_DIRECTORY,
-             GMEConcepts,
              displayFormat,
+             PropertyEditorPanelControllerHelpers,
              DecoratorSVGExplorerDialog,
              ValidVisualizersDialog,
              PROPERTY_GRID_WIDGETS) {
@@ -80,6 +78,7 @@ define(['js/logger',
     PropertyEditorController = function (client, propertyGrid, type) {
         this._client = client;
         this._propertyGrid = propertyGrid;
+        this.NON_INVALID_PTRS = NON_INVALID_PTRS;
         this._type = type || null; // CONSTANTS.PROPERTY_GROUP_ATTRIBUTES ...
         this._logger = Logger.create('gme:Panels:PropertyEditor:PropertyEditorController',
             WebGMEGlobal.gmeConfig.client.log);
@@ -93,6 +92,10 @@ define(['js/logger',
 
         this._logger.debug('Created');
     };
+
+    // Prototypical inheritance from PluginBase.
+    PropertyEditorController.prototype = Object.create(PropertyEditorPanelControllerHelpers.prototype);
+    PropertyEditorController.prototype.constructor = PropertyEditorController;
 
     PropertyEditorController.prototype._initEventHandlers = function () {
         var self = this;
@@ -646,253 +649,6 @@ define(['js/logger',
                 delete dst[extKey];
             }
         }
-    };
-
-    PropertyEditorController.prototype._getNodeAttributeValues = function (node) {
-        var result = {},
-            attrNames = _.union(node.getAttributeNames() || [], node.getValidAttributeNames() || []),
-            len = attrNames.length;
-
-        while (--len >= 0) {
-            result[attrNames[len]] = node.getAttribute(attrNames[len]);
-        }
-
-        return util.flattenObject(result);
-    };
-
-    PropertyEditorController.prototype._getNodeRegistryValues = function (node, registryNames) {
-        var result = {},
-            len = registryNames.length;
-
-        while (--len >= 0) {
-            result[registryNames[len]] = node.getRegistry(registryNames[len]);
-        }
-
-        return util.flattenObject(result);
-    };
-
-    PropertyEditorController.prototype._getPointerInfo = function (node) {
-        var result = {},
-            availablePointers = _.union(node.getValidPointerNames() || [], node.getPointerNames() || []),
-            len = availablePointers.length,
-            ptrTo;
-
-        while (len--) {
-            if (availablePointers[len] === CONSTANTS.POINTER_BASE) {
-                ptrTo = node.getBaseId();
-            } else {
-                ptrTo = node.getPointerId(availablePointers[len]);
-            }
-
-            ptrTo = ptrTo === null ? CONSTANTS.CORE.NULLPTR_RELID : ptrTo;
-            result[availablePointers[len]] = ptrTo || '';
-        }
-
-        return util.flattenObject(result);
-    };
-
-    PropertyEditorController.prototype._isInvalidAttribute = function (selectedNodes, attrName) {
-        var i = selectedNodes.length,
-            node,
-            validNames;
-
-        while (i--) {
-            node = selectedNodes[i];
-            validNames = selectedNodes[i].getValidAttributeNames();
-            if (validNames.indexOf(attrName) !== -1) {
-                return false;
-            }
-        }
-
-        return true;
-    };
-
-    PropertyEditorController.prototype._isInvalidAttributeValue = function (selectedNodes, attrName) {
-        var result = false,
-            attrValue,
-            node;
-
-        if (selectedNodes.length === 1) {
-            node = selectedNodes[0];
-            if (node) {
-                attrValue = node.getAttribute(attrName);
-
-                // We should not complain when there is no value at all.
-                if (typeof attrValue === 'undefined') {
-                    return false;
-                }
-
-                try {
-                    result = !node.isValidAttributeValueOf(attrName, attrValue);
-                } catch (e) {
-                    if (e.message.indexOf('Invalid regular expression') > -1) {
-                        this._logger.error('Invalid regular expression defined in the meta model for attribute "' +
-                            attrName + '"');
-                        result = true;
-                    } else {
-                        throw e;
-                    }
-                }
-            }
-        }
-
-        return result;
-    };
-
-    PropertyEditorController.prototype._getAttributeRange = function (selectedNodes, attrName) {
-        var i = selectedNodes.length,
-            range = {},
-            nodeObj,
-            schema;
-
-        while (i--) {
-            nodeObj = selectedNodes[i];
-            schema = nodeObj.getAttributeMeta(attrName) || {};
-            if (schema.hasOwnProperty('min')) {
-                if (range.hasOwnProperty('min')) {
-                    range.min = schema.min > range.min ? schema.min : range.min;
-                } else {
-                    range.min = schema.min;
-                }
-            }
-
-            if (schema.hasOwnProperty('max')) {
-                if (range.hasOwnProperty('max')) {
-                    range.max = schema.max < range.max ? schema.max : range.max;
-                } else {
-                    range.max = schema.max;
-                }
-            }
-        }
-
-        return range;
-    };
-
-    PropertyEditorController.prototype._isInvalidPointer = function (selectedNodes, pointerName) {
-        var i = selectedNodes.length,
-            node,
-            validNames;
-
-        while (i--) {
-            node = selectedNodes[i];
-            if (node) {
-                validNames = node.getValidPointerNames();
-
-                if (validNames.indexOf(pointerName) !== -1 || NON_INVALID_PTRS.indexOf(pointerName) !== -1) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    };
-
-    PropertyEditorController.prototype._isResettableRegistry = function (selectedNodes, regName) {
-        var i = selectedNodes.length,
-            ownRegistryNames,
-            node;
-
-        while (i--) {
-            node = selectedNodes[i];
-
-            if (node) {
-                ownRegistryNames = node.getOwnRegistryNames();
-
-                if (node.getOwnRegistryNames().indexOf(regName) === -1) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    };
-
-    PropertyEditorController.prototype._isResettableAttribute = function (selectedNodes, attrName) {
-        var i = selectedNodes.length,
-            ownAttrNames,
-            validNames,
-            baseValidNames,
-            node,
-            baseNode;
-
-        while (i--) {
-            node = selectedNodes[i];
-
-            if (node) {
-                baseNode = this._client.getNode(node.getBaseId());
-                validNames = node.getValidAttributeNames();
-                baseValidNames = baseNode === null ? [] : baseNode.getValidAttributeNames();
-                ownAttrNames = node.getOwnAttributeNames();
-
-                if (ownAttrNames.indexOf(attrName) === -1) {
-                    return false;
-                }
-
-                if (baseValidNames.indexOf(attrName) === -1 && validNames.indexOf(attrName) !== -1) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    };
-
-    PropertyEditorController.prototype._isReadonlyAttribute = function (selectedNodes, attrName) {
-        var i;
-
-        for (i = 0; i < selectedNodes.length; i += 1) {
-            if ((selectedNodes[i].getAttributeMeta(attrName) || {}).readonly &&
-                selectedNodes[i].isMetaNode() !== true) {
-                return true;
-            }
-        }
-
-        return false;
-    };
-
-    PropertyEditorController.prototype._isResettablePointer = function (selectedNodes, pointerName) {
-        var i = selectedNodes.length,
-            ownPointerNames,
-            node,
-            validNames,
-            baseValidNames,
-            baseNode;
-
-        while (i--) {
-            node = selectedNodes[i];
-
-            if (node) {
-                baseNode = this._client.getNode(node.getBaseId());
-                ownPointerNames = node.getOwnPointerNames();
-                validNames = node.getValidPointerNames();
-                baseValidNames = baseNode === null ? [] : baseNode.getValidPointerNames();
-
-                if (ownPointerNames.indexOf(pointerName) === -1) {
-                    return false;
-                }
-
-                if (baseValidNames.indexOf(pointerName) === -1 && validNames.indexOf(pointerName) !== -1) {
-                    return false;
-                }
-
-            }
-        }
-
-        return true;
-    };
-
-    PropertyEditorController.prototype._canBeReplaceable = function (selectedNodes) {
-        var i = selectedNodes.length;
-
-        while (i--) {
-            if (GMEConcepts.canBeReplaceable(selectedNodes[i].getId())) {
-                // continue
-            } else {
-                return false;
-            }
-        }
-
-        return true;
     };
 
     PropertyEditorController.prototype._filterCommon = function (commonAttrMeta, result, other, initPhase) {

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -93,10 +93,11 @@ define(['js/logger',
         this._logger.debug('Created');
     };
 
-    // Prototypical inheritance from PluginBase.
+    // Prototypical inheritance from PropertyEditorPanelControllerHelpers.
     PropertyEditorController.prototype = Object.create(PropertyEditorPanelControllerHelpers.prototype);
     PropertyEditorController.prototype.constructor = PropertyEditorController;
 
+    // Event handling and update triggering
     PropertyEditorController.prototype._initEventHandlers = function () {
         var self = this;
 
@@ -233,6 +234,7 @@ define(['js/logger',
 
                 flattenedPointers = self._getPointerInfo(cNode);
                 this._filterCommon(commonAttrMeta, commonPointers, flattenedPointers, isFirstNode);
+                isFirstNode = false;
             }
         }
 

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -233,17 +233,17 @@ define(['js/logger',
             }
         }
 
-        if (selectedObjIDs.length === 1) {
+        if (selectedNodes.length === 1) {
+            cNode = selectedNodes[0];
             propList[' ID/Path'] = {
                 name: 'ID',
-                value: selectedObjIDs[0],
+                value: cNode.getId(),
                 valueType: 'string',
                 isCommon: true,
                 readOnly: true,
                 clipboard: true
             };
 
-            cNode = self._client.getNode(selectedObjIDs[0]);
             if (cNode) {
                 propList[' GUID'] = {
                     name: 'GUID',

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelControllerHelpers.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelControllerHelpers.js
@@ -1,0 +1,269 @@
+/*globals define, _*/
+/*jshint browser: true*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+
+define([
+    'js/util',
+    'js/Constants',
+    'js/Utils/GMEConcepts'
+], function (util,
+             CONSTANTS,
+             GMEConcepts) {
+    'use strict';
+
+    function PropertyEditorControllerHelpers() {
+
+    }
+
+    PropertyEditorControllerHelpers.prototype._getNodeAttributeValues = function (node) {
+        var result = {},
+            attrNames = _.union(node.getAttributeNames() || [], node.getValidAttributeNames() || []),
+            len = attrNames.length;
+
+        while (--len >= 0) {
+            result[attrNames[len]] = node.getAttribute(attrNames[len]);
+        }
+
+        return util.flattenObject(result);
+    };
+
+    PropertyEditorControllerHelpers.prototype._getNodeRegistryValues = function (node, registryNames) {
+        var result = {},
+            len = registryNames.length;
+
+        while (--len >= 0) {
+            result[registryNames[len]] = node.getRegistry(registryNames[len]);
+        }
+
+        return util.flattenObject(result);
+    };
+
+    PropertyEditorControllerHelpers.prototype._getPointerInfo = function (node) {
+        var result = {},
+            availablePointers = _.union(node.getValidPointerNames() || [], node.getPointerNames() || []),
+            len = availablePointers.length,
+            ptrTo;
+
+        while (len--) {
+            if (availablePointers[len] === CONSTANTS.POINTER_BASE) {
+                ptrTo = node.getBaseId();
+            } else {
+                ptrTo = node.getPointerId(availablePointers[len]);
+            }
+
+            ptrTo = ptrTo === null ? CONSTANTS.CORE.NULLPTR_RELID : ptrTo;
+            result[availablePointers[len]] = ptrTo || '';
+        }
+
+        return util.flattenObject(result);
+    };
+
+    PropertyEditorControllerHelpers.prototype._isInvalidAttribute = function (selectedNodes, attrName) {
+        var i = selectedNodes.length,
+            node,
+            validNames;
+
+        while (i--) {
+            node = selectedNodes[i];
+            validNames = selectedNodes[i].getValidAttributeNames();
+            if (validNames.indexOf(attrName) !== -1) {
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isInvalidAttributeValue = function (selectedNodes, attrName) {
+        var result = false,
+            attrValue,
+            node;
+
+        if (selectedNodes.length === 1) {
+            node = selectedNodes[0];
+            if (node) {
+                attrValue = node.getAttribute(attrName);
+
+                // We should not complain when there is no value at all.
+                if (typeof attrValue === 'undefined') {
+                    return false;
+                }
+
+                try {
+                    result = !node.isValidAttributeValueOf(attrName, attrValue);
+                } catch (e) {
+                    if (e.message.indexOf('Invalid regular expression') > -1) {
+                        this._logger.error('Invalid regular expression defined in the meta model for attribute "' +
+                            attrName + '"');
+                        result = true;
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+        }
+
+        return result;
+    };
+
+    PropertyEditorControllerHelpers.prototype._getAttributeRange = function (selectedNodes, attrName) {
+        var i = selectedNodes.length,
+            range = {},
+            nodeObj,
+            schema;
+
+        while (i--) {
+            nodeObj = selectedNodes[i];
+            schema = nodeObj.getAttributeMeta(attrName) || {};
+            if (schema.hasOwnProperty('min')) {
+                if (range.hasOwnProperty('min')) {
+                    range.min = schema.min > range.min ? schema.min : range.min;
+                } else {
+                    range.min = schema.min;
+                }
+            }
+
+            if (schema.hasOwnProperty('max')) {
+                if (range.hasOwnProperty('max')) {
+                    range.max = schema.max < range.max ? schema.max : range.max;
+                } else {
+                    range.max = schema.max;
+                }
+            }
+        }
+
+        return range;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isInvalidPointer = function (selectedNodes, pointerName) {
+        var i = selectedNodes.length,
+            node,
+            validNames;
+
+        while (i--) {
+            node = selectedNodes[i];
+            if (node) {
+                validNames = node.getValidPointerNames();
+
+                if (validNames.indexOf(pointerName) !== -1 || this.NON_INVALID_PTRS.indexOf(pointerName) !== -1) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isResettableRegistry = function (selectedNodes, regName) {
+        var i = selectedNodes.length,
+            ownRegistryNames,
+            node;
+
+        while (i--) {
+            node = selectedNodes[i];
+
+            if (node) {
+                ownRegistryNames = node.getOwnRegistryNames();
+
+                if (node.getOwnRegistryNames().indexOf(regName) === -1) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isResettableAttribute = function (selectedNodes, attrName) {
+        var i = selectedNodes.length,
+            ownAttrNames,
+            validNames,
+            baseValidNames,
+            node,
+            baseNode;
+
+        while (i--) {
+            node = selectedNodes[i];
+
+            if (node) {
+                baseNode = this._client.getNode(node.getBaseId());
+                validNames = node.getValidAttributeNames();
+                baseValidNames = baseNode === null ? [] : baseNode.getValidAttributeNames();
+                ownAttrNames = node.getOwnAttributeNames();
+
+                if (ownAttrNames.indexOf(attrName) === -1) {
+                    return false;
+                }
+
+                if (baseValidNames.indexOf(attrName) === -1 && validNames.indexOf(attrName) !== -1) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isReadonlyAttribute = function (selectedNodes, attrName) {
+        var i;
+
+        for (i = 0; i < selectedNodes.length; i += 1) {
+            if ((selectedNodes[i].getAttributeMeta(attrName) || {}).readonly &&
+                selectedNodes[i].isMetaNode() !== true) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    PropertyEditorControllerHelpers.prototype._isResettablePointer = function (selectedNodes, pointerName) {
+        var i = selectedNodes.length,
+            ownPointerNames,
+            node,
+            validNames,
+            baseValidNames,
+            baseNode;
+
+        while (i--) {
+            node = selectedNodes[i];
+
+            if (node) {
+                baseNode = this._client.getNode(node.getBaseId());
+                ownPointerNames = node.getOwnPointerNames();
+                validNames = node.getValidPointerNames();
+                baseValidNames = baseNode === null ? [] : baseNode.getValidPointerNames();
+
+                if (ownPointerNames.indexOf(pointerName) === -1) {
+                    return false;
+                }
+
+                if (baseValidNames.indexOf(pointerName) === -1 && validNames.indexOf(pointerName) !== -1) {
+                    return false;
+                }
+
+            }
+        }
+
+        return true;
+    };
+
+    PropertyEditorControllerHelpers.prototype._canBeReplaceable = function (selectedNodes) {
+        var i = selectedNodes.length;
+
+        while (i--) {
+            if (GMEConcepts.canBeReplaceable(selectedNodes[i].getId())) {
+                // continue
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    };
+
+    return PropertyEditorControllerHelpers;
+});

--- a/src/client/js/Utils/StateManager.js
+++ b/src/client/js/Utils/StateManager.js
@@ -51,7 +51,7 @@ define([
             registerActiveSelection: function (objIdList, opts) {
                 ASSERT(_.isArray(objIdList));
                 opts = opts || {};
-                this.set(CONSTANTS.STATE_ACTIVE_SELECTION, objIdList, opts);
+                this.set(CONSTANTS.STATE_ACTIVE_SELECTION, objIdList.slice(), opts);
             },
 
             getActiveSelection: function () {


### PR DESCRIPTION
Fixes #1515 
Fixes #1518 

- Fix display ID/GUID issue when only one node in selection was a valid one.
- Do not compute unneeded values for the different types. (All properties/attributes etc were requested four times.)
- Make proper CANON comparison between attribute meta descriptions.
- Copy the activeSelection array in the state to avoid mutation issues when not handled carefully.
- Break down the huge class.
