### PR TITLE
Fixes #1523 Changing the name when adding new attribute prompts user to propagate change

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Aspects.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.Aspects.js
@@ -184,13 +184,13 @@ define([
         }
 
         desc = {
-            'name': cName,
-            'items': [],
-            'validChildrenTypes': this._getAspectDescriptorValidChildrenTypes()
+            name: cName,
+            items: [],
+            validChildrenTypes: this._getAspectDescriptorValidChildrenTypes()
         };
 
         dialog.show(desc, aspectNames, function (cDesc) {
-            self.saveAspectDescriptor(cName, cDesc);
+            self.saveAspectDescriptor(cDesc.name, cDesc);
         });
     };
 
@@ -207,8 +207,8 @@ define([
         i = validChildrenTypeIDs.length;
         while (i--) {
             typeInfo = {
-                'id': validChildrenTypeIDs[i],
-                'name': validChildrenTypeIDs[i]
+                id: validChildrenTypeIDs[i],
+                name: validChildrenTypeIDs[i]
             };
 
             nodeObj = client.getNode(validChildrenTypeIDs[i]);

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
@@ -519,7 +519,7 @@ define([
         };
 
         dialog.show(desc, attrNames, function (attrDesc) {
-            self.saveAttributeDescriptor(attrName, attrDesc);
+            self.saveAttributeDescriptor(attrDesc.name, attrDesc);
         });
     };
 


### PR DESCRIPTION
When creating a new attribute, the name given in the in-place text box should not matter, but only the one given in the dialog.