### PR TITLE
webgme-engine v2.18.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "q": "1.5.0",
     "requirejs": "2.1.20",
     "require-uncached": "1.0.3",
-    "webgme-engine": "2.18.3",
+    "webgme-engine": "2.18.4",
     "webgme-user-management-page": "0.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Various bug-fixes see release notes for details.
https://github.com/webgme/webgme-engine/releases/tag/v2.18.4
