### PR TITLE
Make sure to check defined src/dst ptrs at isConnection check

### DIFF
--- a/src/client/js/Utils/GMEConcepts.js
+++ b/src/client/js/Utils/GMEConcepts.js
@@ -60,15 +60,10 @@ define(['jquery',
      */
     function isConnectionType(objID) {
         var valid = false,
-            obj = client.getNode(objID),
-            ptrNames;
+            obj = client.getNode(objID);
 
         if (obj) {
-            ptrNames = obj.getPointerNames();
-            if (ptrNames.indexOf(CONSTANTS.POINTER_SOURCE) !== -1 &&
-                ptrNames.indexOf(CONSTANTS.POINTER_TARGET) !== -1) {
-                valid = true;
-            }
+            return obj.isConnection();
         }
 
         return valid;


### PR DESCRIPTION
Otherwise the mixin pointer definitions of src/dst are not handled correctly for the connection-type. Specifically a node that does not define or inherits the src/dst pointers, but only mixes in the rules from a node will not be detected as a connection in the ModelEditor.



This PR mitigates the consequences of:
https://github.com/webgme/webgme-engine/issues/11