### PR TITLE
Create source map for client/dist/webgme....lib.build.js

### DIFF
--- a/utils/build/dist/build.js
+++ b/utils/build/dist/build.js
@@ -158,6 +158,7 @@ var requirejs = require('requirejs'),
             'isis-ui-components': 'client/bower_components/isis-ui-components/dist/isis-ui-components',
             'isis-ui-components-templates': 'client/bower_components/isis-ui-components/dist/isis-ui-components-templates',
         },
+        generateSourceMaps: true,
         include: [
             '../utils/build/dist/libIncludes',
         ],


### PR DESCRIPTION
It's useful for debugging plugins to have the source map for the dist/lib...js file.