### PR TITLE
Bump webgme-engine to 2.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webgme",
-  "version": "2.20.1-beta1",
+  "version": "2.20.1-beta2",
   "description": "Web-based Generic Modeling Environment",
   "engines": {
     "node": ">=4.0.0"
@@ -27,7 +27,7 @@
     "q": "1.5.0",
     "require-uncached": "1.0.3",
     "requirejs": "2.1.20",
-    "webgme-engine": "github:webgme/webgme-engine#ot-attribute-editing",
+    "webgme-engine": "2.19.1",
     "webgme-user-management-page": "0.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Various improvements, bug fixes and back-end support for operational transformations.
https://github.com/webgme/webgme-engine/releases/tag/v2.19.0
https://github.com/webgme/webgme-engine/releases/tag/v2.19.1