### PR TITLE
Fixes #1545 RangeError in Connection Drawing

### DIFF
--- a/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
+++ b/src/client/js/Widgets/DiagramDesigner/AutoRouter.Worker.js
@@ -70,9 +70,10 @@ var startWorker = function() {
         AutoRouterWorker.prototype._handleMessage = function(msg) {
             var response,
                 action = msg[0],
+                lightResult,
                 result;
 
-            response = [action, msg[1].slice()];  // Copy the input args
+            response = [action, JSON.parse(JSON.stringify(msg[1]))];  // Copy the input args
 
             // If routing async, decorate the request
             if (action === 'routeAsync') {
@@ -87,8 +88,23 @@ var startWorker = function() {
                 worker.postMessage(['BugReplayList', this._getActionSequence()]);
             }
 
-            response.push(result);
+
             if (respondToAll || this.respondTo[action]) {
+                if (result) {
+                    if (action === 'addBox') {
+                        lightResult = {id: result.box.id};
+                        lightResult.ports = Object.keys(result.ports).map(function (key) {
+                            return {id: key};
+                        });
+                    }
+                }
+
+                if (lightResult) {
+                    response.push(lightResult);
+                } else {
+                    response.push(result);
+                }
+
                 this.logger.debug('Response:', response);
                 worker.postMessage(response);
             }

--- a/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager3.js
+++ b/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager3.js
@@ -585,7 +585,9 @@ define([
         for (j = boxObject.ports.length; j--;) {
             id = boxObject.ports[j].id;
             if (!newIds[id]) {
-                this._invokeAutoRouterMethod('removePort', [boxObject.ports[j]]);  // Not sure FIXME
+                // TODO: There is no API call in the AutoRouter/ActionApplier
+                // TODO: for removing port based on ids (this never worked)
+                //this._invokeAutoRouterMethod('removePort', [boxObject.ports[j]]);  // Not sure FIXME
             }
         }
     };


### PR DESCRIPTION
This is a temporary solution which works by trimming the communicated data. However we should move over to the new API of the auto-router once it supports all features (it, by design, only returns light objects mainly with ids).

Currently the new API does not support routing to a subset of connection areas for a specific path. (Example is the inheritance connection that is always drawn from top to bottom in meta editor.) 