### PR TITLE
Bump webgme-engine to v2.19.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "q": "1.5.0",
     "require-uncached": "1.0.3",
     "requirejs": "2.1.20",
-    "webgme-engine": "2.19.3",
+    "webgme-engine": "2.19.4",
     "webgme-user-management-page": "0.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/webgme/webgme-engine/releases/tag/v2.19.4