### PR TITLE
Enable copying and manually editing/pasting blob-hashes in asset widget

### DIFF
--- a/src/client/js/Controls/PropertyGrid/PropertyGridWidgetManager.js
+++ b/src/client/js/Controls/PropertyGrid/PropertyGridWidgetManager.js
@@ -61,7 +61,7 @@ define([
         if (propDesc.multiline) {
             SpecificWidget = PROPERTY_GRID_WIDGETS.MULTILINE;
         }
-        if (readOnly && type !== 'boolean') {
+        if (readOnly && type !== 'boolean' && type !== 'asset') {
             widget = new LabelWidget(propDesc);
         } else if (SpecificWidget) {
             switch (SpecificWidget) {

--- a/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
@@ -28,6 +28,11 @@ define([
     AssetWidget = function (propertyDesc) {
         WidgetBase.call(this, propertyDesc);
         var self = this;
+
+        if (propertyDesc.readOnly) {
+            this._alwaysReadOnly = true;
+        }
+
         this._logger = Logger.create('gme:js:Controls:PropertyGrid:Widgets:AssetWidget',
             WebGMEGlobal.gmeConfig.client.log);
 

--- a/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/AssetWidget.js
@@ -8,10 +8,12 @@ define([
     'js/Controls/PropertyGrid/Widgets/WidgetBase',
     'blob/BlobClient',
     'js/logger',
+    'common/regexp',
     'css!./styles/AssetWidget.css'
 ], function (WidgetBase,
              BlobClient,
-             Logger) {
+             Logger,
+             RegExp) {
 
     'use strict';
 
@@ -25,6 +27,7 @@ define([
 
     AssetWidget = function (propertyDesc) {
         WidgetBase.call(this, propertyDesc);
+        var self = this;
         this._logger = Logger.create('gme:js:Controls:PropertyGrid:Widgets:AssetWidget',
             WebGMEGlobal.gmeConfig.client.log);
 
@@ -37,6 +40,9 @@ define([
 
         this.__assetLink = ASSET_LINK.clone();
         this.__el.append(this.__assetLink);
+
+        this.__editArea = $('<div>', {class: 'edit-area'});
+        this.__el.append(this.__editArea);
 
         this.__fileDropTarget = this.__el;
 
@@ -52,6 +58,36 @@ define([
         this._attachFileDropHandlers();
 
         this.updateDisplay();
+
+        this.__el.on('dblclick', function () {
+            if (self._isReadOnly || self.__progressBar.is(':visible')) {
+                return;
+            }
+
+            self.__btnAttach.hide();
+            self.__assetLink.hide();
+
+            self.__editArea.editInPlace({
+                class: 'in-place-edit',
+                value: self.propertyValue,
+                enableEmpty: true,
+                css: {
+                    'font-size': '11px'
+                },
+                onChange: function (oldValue, newValue) {
+                    if (RegExp.BLOB_HASH.test(newValue) || newValue === '') {
+                        self.setValue(newValue);
+                        self.fireFinishChange();
+                    }
+                },
+                onFinish: function () {
+                    // Wait for the new value to be accepted..
+                    self.__btnAttach.show();
+                    self.__assetLink.show();
+                }
+            });
+
+        });
     };
 
     AssetWidget.prototype = Object.create(WidgetBase.prototype);
@@ -293,6 +329,7 @@ define([
 
     AssetWidget.prototype.destroy = function () {
         this._detachFileDropHandlers();
+        this.__el.off('dblclick');
         clearTimeout(this.__timeoutId);
         WidgetBase.prototype.destroy.call(this);
     };

--- a/src/client/js/Controls/PropertyGrid/Widgets/iCheckBoxWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/iCheckBoxWidget.js
@@ -19,6 +19,10 @@ define([
 
         WidgetBase.call(this, propertyDesc);
 
+        if (propertyDesc.readOnly) {
+            this._alwaysReadOnly = true;
+        }
+
         this.__checkbox = new ICheckBox({
             checkedText: 'TRUE',
             uncheckedText: 'FALSE',

--- a/src/client/js/Controls/PropertyGrid/Widgets/styles/AssetWidget.css
+++ b/src/client/js/Controls/PropertyGrid/Widgets/styles/AssetWidget.css
@@ -12,6 +12,8 @@ div.asset-widget {
   position: relative;
   background-color: rgba(0, 0, 0, 0.025);
   border: 1px dashed #aaaaaa; }
+  div.asset-widget .edit-area {
+    height: 92%; }
   div.asset-widget .btn-dialog-open {
     position: absolute;
     right: 0;

--- a/src/client/js/Controls/PropertyGrid/Widgets/styles/AssetWidget.scss
+++ b/src/client/js/Controls/PropertyGrid/Widgets/styles/AssetWidget.scss
@@ -14,6 +14,10 @@ div.asset-widget {
   background-color: rgba(0, 0, 0, 0.025);
   border: 1px dashed #aaaaaa;
 
+  .edit-area {
+    height: 92%;
+  }
+
   .btn-dialog-open {
     position: absolute;
     right: 0;

--- a/src/client/js/jquery.WebGME.js
+++ b/src/client/js/jquery.WebGME.js
@@ -67,13 +67,6 @@ define(['jquery'], function () {
                     inputCtrl.addClass(editClass);
                 }
 
-                //add any custom css specified 
-                keys = Object.keys(extraCss);
-
-                for (i = keys.length - 1; i >= 0; i--) {
-                    inputCtrl.css(keys[i], extraCss[keys[i]]);
-                }
-
                 //set css properties to fix Bootstrap's modification
                 h = Math.max(h, minHeight);
                 inputCtrl.outerWidth(w).outerHeight(h);
@@ -83,6 +76,13 @@ define(['jquery'], function () {
                     'line-height': h + 'px',
                     'font-size':   h - fontSizeAdjust
                 });
+
+                //add any custom css specified
+                keys = Object.keys(extraCss);
+
+                for (i = keys.length - 1; i >= 0; i--) {
+                    inputCtrl.css(keys[i], extraCss[keys[i]]);
+                }
 
 
                 el.html(inputCtrl);
@@ -94,6 +94,10 @@ define(['jquery'], function () {
 
                 //finally put the control in focus
                 inputCtrl.focus();
+
+                inputCtrl.on('click', function (event) {
+                    event.stopPropagation();
+                });
 
                 //hook up event handlers to 'save' and 'cancel'
                 inputCtrl.keydown(


### PR DESCRIPTION
This PR also fixes the boolean widget in property editor so that it respects read-only attributes.