### PR TITLE
Prevent new active object event when switching to new viz via node registery look-up

### DIFF
--- a/src/client/js/Constants.js
+++ b/src/client/js/Constants.js
@@ -83,6 +83,7 @@ define([
         ASSETS_DECORATOR_SVG_FOLDER: 'assets/DecoratorSVG/',
 
         /*WebGME state constants*/
+        STATE_TO_BE_ACTIVE_OBJECT: '_toBeActiveObject',
         STATE_ACTIVE_OBJECT: 'activeObject',
         STATE_ACTIVE_SELECTION: 'activeSelection',
         STATE_ACTIVE_ASPECT: 'activeAspect',

--- a/src/client/js/PanelBase/PanelBase.js
+++ b/src/client/js/PanelBase/PanelBase.js
@@ -73,6 +73,7 @@ define(['jquery', 'js/logger'], function (_jquery, Logger) {
     PanelBase.prototype.destroy = function () {
         this.clear();
         this.$el.remove();
+        this._destroyedInstance = true;
     };
 
     /* METHOD CALLED WHEN THE PARENT CONTAINER SIZE HAS CHANGED AND WIDGET SHOULD RESIZE ITSELF ACCORDINGLY */

--- a/src/client/js/PanelBase/PanelBaseWithHeader.js
+++ b/src/client/js/PanelBase/PanelBaseWithHeader.js
@@ -117,6 +117,7 @@ define(['js/PanelBase/PanelBase', 'css!./styles/PanelBaseWithHeader.css'], funct
     PanelBaseWithHeader.prototype.destroy = function () {
         this.clear();
         this.$_el.remove();
+        this._destroyedInstance = true;
     };
 
     PanelBaseWithHeader.prototype.setTitle = function (text) {

--- a/src/client/js/PanelManager/PanelManager.js
+++ b/src/client/js/PanelManager/PanelManager.js
@@ -17,7 +17,7 @@ define(['js/logger', 'js/Constants'], function (Logger, CONSTANTS) {
 
     PanelManager.prototype.setActivePanel = function (p) {
         if (this._activePanel !== p) {
-            if (this._activePanel) {
+            if (this._activePanel && !this._activePanel._destroyedInstance) {
                 //deactivate currently active panel
                 this._activePanel.setActive(false);
             }

--- a/src/client/js/Panels/Visualizer/VisualizerPanel.js
+++ b/src/client/js/Panels/Visualizer/VisualizerPanel.js
@@ -186,7 +186,7 @@ define(['js/logger',
             event.preventDefault();
         });
 
-        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_ACTIVE_OBJECT, function (model, activeObjectId, opts) {
+        WebGMEGlobal.State.on('change:' + CONSTANTS.STATE_TO_BE_ACTIVE_OBJECT, function (model, activeObjectId, opts) {
             if (opts.invoker !== self) {
                 self._onSelectedObjectChanged(activeObjectId, opts);
             }
@@ -378,9 +378,9 @@ define(['js/logger',
 
         // Only set the visualizer only if we were able to select some valid one.
         if (setActiveViz && visualizerToSet) {
-            setTimeout(function () {
-                self._setActiveVisualizer(visualizerToSet);
-            }, 0);
+            //setTimeout(function () {
+            self._setActiveVisualizer(visualizerToSet);
+            //}, 0);
         }
     };
 

--- a/src/client/js/Utils/StateManager.js
+++ b/src/client/js/Utils/StateManager.js
@@ -34,6 +34,7 @@ define([
                 objId = objId === 'root' ? '' : objId;
                 logger.debug('registerActiveObject, objId: ', objId);
                 opts = opts || {};
+                this.set(CONSTANTS.STATE_TO_BE_ACTIVE_OBJECT, objId, opts);
                 this.set(CONSTANTS.STATE_ACTIVE_OBJECT, objId, opts);
             },
 

--- a/src/client/js/Utils/StateManager.js
+++ b/src/client/js/Utils/StateManager.js
@@ -34,7 +34,6 @@ define([
                 objId = objId === 'root' ? '' : objId;
                 logger.debug('registerActiveObject, objId: ', objId);
                 opts = opts || {};
-                this.set(CONSTANTS.STATE_TO_BE_ACTIVE_OBJECT, objId, opts);
                 this.set(CONSTANTS.STATE_ACTIVE_OBJECT, objId, opts);
             },
 
@@ -173,6 +172,20 @@ define([
                 _WebGMEState.on('change', function (model, options) {
                     logger.debug('', model, options);
                 });
+
+                var orgSet = _WebGMEState.set.bind(_WebGMEState);
+
+                _WebGMEState.set = function (stateDesc, value, opts) {
+                    if (stateDesc === CONSTANTS.STATE_ACTIVE_OBJECT) {
+                        orgSet(CONSTANTS.STATE_TO_BE_ACTIVE_OBJECT, value, opts);
+                    } else if (stateDesc && typeof stateDesc === 'object' &&
+                        stateDesc.hasOwnProperty(CONSTANTS.STATE_ACTIVE_OBJECT)) {
+                        // Here value is the opts..
+                        orgSet(CONSTANTS.STATE_TO_BE_ACTIVE_OBJECT, stateDesc[CONSTANTS.STATE_ACTIVE_OBJECT], value);
+                    }
+
+                    orgSet(stateDesc, value, opts);
+                };
             }
 
             return _WebGMEState;


### PR DESCRIPTION
This way the to-be-destroyed visualizer does not receive and act on the new active object. This in turn makes for much cleaner visualizer switching when navigating the model. Additionally this mitigates risks of exceptions thrown from domain specific visualizers that require specific properties of the active-node.

This PR also ensure that destroyed visualizers do not get onDeactivate calls.