### PR TITLE
Introduce hidden property in plugin-config option

### DIFF
--- a/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
+++ b/src/client/js/Dialogs/PluginConfig/PluginConfigDialog.js
@@ -221,6 +221,9 @@ define([
 
             // Make sure not modify the global metadata.
             pluginConfigEntry = JSON.parse(JSON.stringify(pluginConfigEntry));
+            if (pluginConfigEntry.hidden === true) {
+                return;
+            }
 
             if (prevConfig && prevConfig.hasOwnProperty(pluginConfigEntry.name)) {
                 pluginConfigEntry.value = prevConfig[pluginConfigEntry.name];


### PR DESCRIPTION
Below, the `species` option would not be displayed for the user in the plugin config dialog.
```
{
  "id": "MyPlugin",
  ...
  "configStructure": [
    {
      "name": "species",
      "displayName": "Animal Species",
      "regex": "^[a-zA-Z]+$",
      "regexMessage": "Name can only contain English characters!",
      "description": "Which species does the animal belong to.",
      "value": "Horse",
      "valueType": "string",
      "hidden": true
    }]
```