### PR TITLE
Fixes #1642 Handle connection-segment-points during move/copy/create instance

### DIFF
--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -750,6 +750,15 @@ define(['js/logger',
                 var srcNode = nodeObj.getNode(nodeObj.getPointerId('src')),
                     dstNode = nodeObj.getNode(nodeObj.getPointerId('dst'));
 
+                // Maybe src/dst are ports - check if their parents where selected..
+                if (srcNode && !result[srcNode.getId()]) {
+                    srcNode = nodeObj.getNode(srcNode.getParentId());
+                }
+
+                if (dstNode && !result[dstNode.getId()]) {
+                    dstNode = nodeObj.getNode(dstNode.getParentId());
+                }
+
                 if (srcNode && result[srcNode.getId()] && dstNode && result[dstNode.getId()]) {
                     var srcPos = srcNode.getRegistry('position'),
                         dstPos = dstNode.getRegistry('position'),
@@ -758,8 +767,6 @@ define(['js/logger',
                     if (srcPos && dstPos) {
                         delta.x = ( result[srcNode.getId()].x - srcPos.x + result[dstNode.getId()].x - dstPos.x ) / 2;
                         delta.y = ( result[srcNode.getId()].y - srcPos.y + result[dstNode.getId()].y - dstPos.y ) / 2;
-
-                        console.log('delta[', delta.x, ',', delta.y, ']');
 
                         linePoints.forEach(function (point) {
                             point[0] += delta.x;

--- a/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager2.js
+++ b/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager2.js
@@ -350,8 +350,9 @@ define(['js/logger'], function (Logger) {
             }
         }
 
-        //when no segment points are defined route with horizontal and vertical lines
-        if (segmentPoints.length === 0) {
+        // if (segmentPoints.length === 0) { when no segment points are defined route with horizontal and vertical lines
+        // # Not true anymore - still apply square routing when seg points are there.
+        if (true) {
             //no segment points
             if (srcObjId === dstObjId && srcSubCompId === dstSubCompId) {
                 //self connection

--- a/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager2.js
+++ b/src/client/js/Widgets/DiagramDesigner/ConnectionRouteManager2.js
@@ -350,9 +350,8 @@ define(['js/logger'], function (Logger) {
             }
         }
 
-        // if (segmentPoints.length === 0) { when no segment points are defined route with horizontal and vertical lines
-        // # Not true anymore - still apply square routing when seg points are there.
-        if (true) {
+        //when no segment points are defined route with horizontal and vertical lines
+        if (segmentPoints.length === 0) {
             //no segment points
             if (srcObjId === dstObjId && srcSubCompId === dstSubCompId) {
                 //self connection


### PR DESCRIPTION
When performing either of the actions in the title and a connection is among the selected nodes. Any segment point will be translated based on the new positions of the `src` and `dst`. The translation will only take place if both the `src` and `dst` are among the moved/copied/created nodes. (If the `src` and `dst` are ports the parents act as reference points.)

