### PR TITLE
Model Decorator supports set orientation of ports (S,N,W,E)

### DIFF
--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
@@ -54,9 +54,11 @@ define([
             $portsContainer: undefined,
             $portsContainerLeft: undefined,
             $portsContainerRight: undefined,
+            $portsContainerBottom: undefined,
             $portsContainerCenter: undefined,
             $ptr: undefined,
             $imgSVG: undefined,
+            $imgContainer: undefined,
             $replaceable: undefined
         };
 
@@ -94,6 +96,8 @@ define([
         this.skinParts.$portsContainer = this.$el.find('.ports');
         this.skinParts.$portsContainerLeft = this.skinParts.$portsContainer.find('.left');
         this.skinParts.$portsContainerRight = this.skinParts.$portsContainer.find('.right');
+        this.skinParts.$portsContainerBottom = this.$el.find('.bottom-ports');
+        this.skinParts.$imgContainer = this.$el.find('.img-container');
         this.skinParts.$portsContainerCenter = this.skinParts.$portsContainer.find('.center');
 
         this._update();
@@ -217,7 +221,11 @@ define([
             changed;
 
         //check if the port should be on the left or right-side
-        if (portPosition.x > 300) {
+        // FIXME: This should come from registry
+        if (portNode.getAttribute('name') === 'BottomInnerPort') {
+            portOrientation = 'S';
+            portContainer = this.skinParts.$portsContainerBottom;
+        } else if (portPosition.x > 300) {
             portOrientation = 'E';
             portContainer = this.skinParts.$portsContainerRight;
         }
@@ -439,7 +447,7 @@ define([
         if (svgURL) {
             if (!this.skinParts.$imgSVG) {
                 this.skinParts.$imgSVG = EMBEDDED_SVG_IMG_BASE.clone();
-                this.$el.append(this.skinParts.$imgSVG);
+                this.skinParts.$imgContainer.append(this.skinParts.$imgSVG);
             }
             if (this.skinParts.$imgSVG.attr('src') !== svgURL) {
                 this.skinParts.$imgSVG.on('load', function (/*event*/) {

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.Core.js
@@ -223,15 +223,7 @@ define([
             i,
             changed;
 
-        //check if the port should be on the left or right-side
-        // FIXME: This should come from registry
-
-        if (portNode.getAttribute('name') === 'BottomInnerPort') {
-            portOrientation = 'S';
-        } else if (portNode.getAttribute('name') === 'TopPort') {
-            portOrientation = 'N';
-        }
-
+        //check where along the border the port should be.
         switch (portOrientation) {
             case 'W':
                 portContainer = this.skinParts.$portsContainerLeft;
@@ -326,18 +318,28 @@ define([
     };
 
     ModelDecoratorCore.prototype._updatePortPosition = function (portId) {
-        var portNode = this._control._client.getNode(portId),
-            portPosition = portNode.getRegistry(REGISTRY_KEYS.POSITION) || {x: 0, y: 0};
+        var self = this,
+            portNode = this._control._client.getNode(portId),
+            portPosition = portNode.getRegistry(REGISTRY_KEYS.POSITION) || {x: 0, y: 0},
+            portOrientation = portNode.getRegistry(REGISTRY_KEYS.PORT_ORIENTATION);
 
-        //check if is has changed at all
-        if ((this.ports[portId].position.x !== portPosition.x) ||
-            (this.ports[portId].position.y !== portPosition.y)) {
+        function reattachPort() {
 
             //detach from DOM
-            this.ports[portId].$el.detach();
+            self.ports[portId].$el.detach();
 
             //reattach
-            this._addPortToContainer(portNode, this.ports[portId]);
+            self._addPortToContainer(portNode, self.ports[portId]);
+        }
+
+        if (portOrientation) {
+            if (this.ports[portId].orientation !== portOrientation) {
+                reattachPort();
+            }
+        } else if ((this.ports[portId].position.x !== portPosition.x) ||
+            (this.ports[portId].position.y !== portPosition.y)) {
+            // Position changed and it didn't have a set orientation.
+            reattachPort();
         }
     };
 

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
@@ -7,4 +7,8 @@
     </div>
     <div class='connector bottom'></div>
     <div class='connector top'></div>
+    <div class='img-container'>
+
+    </div>
+    <div class="bottom-ports"></div>
 </div>

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
@@ -1,4 +1,5 @@
 <div class="model-decorator">
+    <div class="top-ports"></div>
     <div class="name"></div>
     <div class="ports">
         <div class="left"></div>

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
@@ -1,5 +1,6 @@
 <div class="model-decorator">
     <div class="top-ports"></div>
+    <div class="connector top-left"></div>
     <div class="name"></div>
     <div class="ports">
         <div class="left"></div>

--- a/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
+++ b/src/client/decorators/ModelDecorator/Core/ModelDecorator.html
@@ -7,8 +7,6 @@
     </div>
     <div class='connector bottom'></div>
     <div class='connector top'></div>
-    <div class='img-container'>
-
-    </div>
+    <div class='img-container'></div>
     <div class="bottom-ports"></div>
 </div>

--- a/src/client/decorators/ModelDecorator/Core/Port.js
+++ b/src/client/decorators/ModelDecorator/Core/Port.js
@@ -61,7 +61,7 @@ define([
         .append(Port.prototype._DOMTitleWrapper.clone()).append(Port.prototype._DOMSVGIcon.clone())
         .append(Port.prototype._DOMDot.clone()).append(Port.prototype._DOMConnector.clone());
 
-    Port.prototype._DOMBaseBottomTemplate = Port.prototype._DOMPortBase.clone()
+    Port.prototype._DOMBaseTopBottomTemplate = Port.prototype._DOMPortBase.clone()
         .append(Port.prototype._DOMSVGIcon.clone())
         .append(Port.prototype._DOMDot.clone())
         .append(Port.prototype._DOMConnector.clone());
@@ -74,7 +74,8 @@ define([
                 concretePortTemplate = this._DOMBaseLeftTemplate;
                 break;
             case 'S':
-                concretePortTemplate = this._DOMBaseBottomTemplate;
+            case 'N':
+                concretePortTemplate = this._DOMBaseTopBottomTemplate;
                 break;
             default:
                 concretePortTemplate = this._DOMBaseRightTemplate;
@@ -199,7 +200,20 @@ define([
     Port.prototype.getConnectorArea = function () {
         var allPorts = this.$el.parent().children(),
             len = allPorts.length,
+            xShift,
             i;
+
+        if (this.orientation === 'N' || this.orientation === 'S') {
+            // Ports are centered in the middle so we need to determine the "shift" depending on how many
+            // ports there are.
+            // HEIGHT is width for N/S ports..
+            xShift = Math.floor(this.decorator.hostDesignerItem.getWidth() / 2);
+            if (len % 2 === 0) {
+                xShift -= (((len / 2) - 1) * PORT_DOM_HEIGHT + Math.floor(PORT_DOM_HEIGHT / 2));
+            } else {
+                xShift -= ((len - 1) / 2) * PORT_DOM_HEIGHT;
+            }
+        }
 
         for (i = 0; i < len; i += 1) {
             if (allPorts[i] === this.$el[0]) {
@@ -207,18 +221,48 @@ define([
             }
         }
 
-        this.connectionArea.x1 = this.orientation === 'W' ? 0 : this.decorator.hostDesignerItem.getWidth();
-        //fix the x coordinate for the dot/svg icon's width
-        if (this.icon) {
-            this.connectionArea.x1 += (this.orientation === 'W' ? -1 : 1) * (PORT_ICON_WIDTH - 1);
-        } else {
-            this.connectionArea.x1 += (this.orientation === 'W' ? -1 : 1) * (PORT_DOT_WIDTH - 1);
+        switch (this.orientation) {
+            case 'N':
+
+                this.connectionArea.y1 = this.connectionArea.y2 = - PORT_DOM_HEIGHT - 6;
+                this.connectionArea.x1 = this.connectionArea.x2 = xShift + i * PORT_DOM_HEIGHT;
+                this.connectionArea.angle1 = this.connectionArea.angle2 = 270;
+                break;
+            case 'S':
+                this.connectionArea.y1 = this.decorator.hostDesignerItem.getHeight() - PORT_DOM_HEIGHT;
+                this.connectionArea.y2 = this.connectionArea.y1;
+                this.connectionArea.x1 = this.connectionArea.x2 = xShift + i * PORT_DOM_HEIGHT;
+                this.connectionArea.angle1 = this.connectionArea.angle2 = 90;
+                break;
+            case 'W':
+                if (this.icon) {
+                    this.connectionArea.x1 = 1 - PORT_ICON_WIDTH;
+                } else {
+                    this.connectionArea.x1 = 1 - PORT_DOT_WIDTH;
+                }
+
+                this.connectionArea.y1 = i * PORT_DOM_HEIGHT + 9;
+
+                this.connectionArea.x2 = this.connectionArea.x1;
+                this.connectionArea.y2 = this.connectionArea.y1;
+
+                this.connectionArea.angle1 = this.connectionArea.angle2 = 180;
+                break;
+            default: // case E
+                if (this.icon) {
+                    this.connectionArea.x1 = this.decorator.hostDesignerItem.getWidth() + PORT_ICON_WIDTH  - 1;
+                } else {
+                    this.connectionArea.x1 = this.decorator.hostDesignerItem.getWidth() + PORT_DOT_WIDTH  - 1;
+                }
+
+                this.connectionArea.y1 = i * PORT_DOM_HEIGHT + 9;
+
+                this.connectionArea.x2 = this.connectionArea.x1;
+                this.connectionArea.y2 = this.connectionArea.y1;
+
+                this.connectionArea.angle1 = this.connectionArea.angle2 = 0;
+                break;
         }
-        this.connectionArea.x2 = this.connectionArea.x1;
-        this.connectionArea.y1 = i * PORT_DOM_HEIGHT + 9;
-        this.connectionArea.y2 = this.connectionArea.y1;
-        this.connectionArea.angle1 = this.orientation === 'W' ? 180 : 0;
-        this.connectionArea.angle2 = this.orientation === 'W' ? 180 : 0;
 
         return this.connectionArea;
     };

--- a/src/client/decorators/ModelDecorator/Core/Port.js
+++ b/src/client/decorators/ModelDecorator/Core/Port.js
@@ -61,8 +61,25 @@ define([
         .append(Port.prototype._DOMTitleWrapper.clone()).append(Port.prototype._DOMSVGIcon.clone())
         .append(Port.prototype._DOMDot.clone()).append(Port.prototype._DOMConnector.clone());
 
+    Port.prototype._DOMBaseBottomTemplate = Port.prototype._DOMPortBase.clone()
+        .append(Port.prototype._DOMSVGIcon.clone())
+        .append(Port.prototype._DOMDot.clone())
+        .append(Port.prototype._DOMConnector.clone());
+
     Port.prototype._initialize = function () {
-        var concretePortTemplate = this.orientation === 'W' ? this._DOMBaseLeftTemplate : this._DOMBaseRightTemplate;
+        var concretePortTemplate;
+
+        switch (this.orientation) {
+            case 'W':
+                concretePortTemplate = this._DOMBaseLeftTemplate;
+                break;
+            case 'S':
+                concretePortTemplate = this._DOMBaseBottomTemplate;
+                break;
+            default:
+                concretePortTemplate = this._DOMBaseRightTemplate;
+                break;
+        }
 
         this.$el = concretePortTemplate.clone();
         this.$el.attr({

--- a/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
+++ b/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
@@ -155,9 +155,36 @@ $abstract-class-name-color: #AAAAAA;
       height: 15px;
       width: 15px;
       margin-bottom: 2px;
-      border-radius: 5px;
+      border-radius: 2px;
 
-      &.inverse-on-hover:hover {
+      &:hover {
+        background-color: $ptr-hover-background-color;
+        -webkit-box-shadow: $ptr-hover-shadow;
+        -moz-box-shadow: $ptr-hover-shadow;
+        box-shadow: $ptr-hover-shadow;
+
+        [class^="icon-"]:not(.icon-white),
+        [class*=" icon-"]:not(.icon-white) {
+          background-image: url("../../../img/glyphicons-halflings-white.png");
+        }
+      }
+
+      [class^="icon-"],
+      [class*=" icon-"] {
+        margin-top: -2px;
+      }
+    }
+
+    .replaceable {
+      position: absolute;
+      bottom: 0;
+      left: 2px;
+      height: 15px;
+      width: 15px;
+      margin-bottom: 2px;
+      border-radius: 2px;
+
+      &:hover {
         background-color: $ptr-hover-background-color;
         -webkit-box-shadow: $ptr-hover-shadow;
         -moz-box-shadow: $ptr-hover-shadow;

--- a/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
+++ b/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
@@ -59,7 +59,7 @@ $abstract-class-name-color: #AAAAAA;
 
     .ports {
       font-size: 10px;
-      min-height: 1px;
+      min-height: 16px;
       width: $ports-width * 2 + $ports-separator-width + $padding * 2;
       position: relative;
 

--- a/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
+++ b/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
@@ -84,7 +84,22 @@ $abstract-class-name-color: #AAAAAA;
         min-height: 1px;
       }
 
-      @include port($ports-width, $padding);
+      @include port($ports-width, $padding, false);
+    }
+
+    .bottom-ports {
+      width: 100%;
+      left: 0;
+      height: 5px;
+      position: absolute;
+      align-items: center;
+      justify-content: center;
+      display: flex;
+      //background-color: #0D3349;
+      //opacity: 0.1;
+
+
+      @include port(10px, $padding, true);
     }
 
     .progress-bar {

--- a/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
+++ b/src/client/decorators/ModelDecorator/Core/_ModelDecorator.scss
@@ -84,22 +84,29 @@ $abstract-class-name-color: #AAAAAA;
         min-height: 1px;
       }
 
-      @include port($ports-width, $padding, false);
+      @include port($ports-width, $padding, 'WE');
+    }
+
+    .top-ports {
+      width: 100%;
+      left: 0;
+      height: 0;
+      position: absolute;
+      align-items: center;
+      justify-content: center;
+      display: flex;
+      @include port(10px, $padding, 'N');
     }
 
     .bottom-ports {
       width: 100%;
       left: 0;
-      height: 5px;
+      height: 0;
       position: absolute;
       align-items: center;
       justify-content: center;
       display: flex;
-      //background-color: #0D3349;
-      //opacity: 0.1;
-
-
-      @include port(10px, $padding, true);
+      @include port(10px, $padding, 'S');
     }
 
     .progress-bar {

--- a/src/client/decorators/ModelDecorator/Core/_Port.scss
+++ b/src/client/decorators/ModelDecorator/Core/_Port.scss
@@ -102,7 +102,7 @@ $svg-icon-width: 5px;
       }
 
       span.dot {
-        left: - $padding - $dot-width;
+        left: - $padding - $dot-width - 1;
         border-top-left-radius: $dot-radius;
         border-bottom-left-radius: $dot-radius;
       }

--- a/src/client/decorators/ModelDecorator/Core/_Port.scss
+++ b/src/client/decorators/ModelDecorator/Core/_Port.scss
@@ -12,12 +12,16 @@ $icon-padding: 2px;
 $svg-icon-height: 11px;
 $svg-icon-width: 5px;
 
-@mixin port($ports-width, $padding) {
+@mixin port($ports-width, $padding, $isBottom) {
   .port {
     white-space: nowrap;
     position: relative;
     height: $port-height;
     line-height: $port-height;
+    @if($isBottom) {
+      display: inline;
+      height: $svg-icon-height;
+    }
 
     &:hover {
       cursor: pointer;
@@ -31,21 +35,43 @@ $svg-icon-width: 5px;
     }
 
     img.svg-icon {
-      height: $svg-icon-height;
-      width: $svg-icon-width;
-      position: absolute;
       display: inline-block;
-      top: 2px;
+
+      @if($isBottom) {
+        position: relative;
+        top: 1px;
+        margin-left: 2px;
+        margin-right: 2px;
+        width: $svg-icon-height;
+        height: $svg-icon-width;
+      } @else {
+        position: absolute;
+        height: $svg-icon-height;
+        width: $svg-icon-width;
+        top: 2px;
+      }
     }
 
     span.dot {
-      position: absolute;
       display: inline-block;
       background: $dot-color;
       border: $dot-border-width solid $dot-color;
-      width: $dot-width;
-      height: $dot-height;
-      top: ($port-height - $dot-height)/2;
+
+      @if($isBottom) {
+        position: relative;
+        top: 0;
+        margin-left: 4px;
+        margin-right: 4px;
+        width: $dot-height;
+        height: $dot-width + 1;
+        border-bottom-left-radius: $dot-radius;
+        border-bottom-right-radius: $dot-radius;
+      } @else {
+        position: absolute;
+        width: $dot-width;
+        height: $dot-height;
+        top: ($port-height - $dot-height)/2;
+      }
     }
 
     &.w-icon {

--- a/src/client/decorators/ModelDecorator/Core/_Port.scss
+++ b/src/client/decorators/ModelDecorator/Core/_Port.scss
@@ -12,13 +12,13 @@ $icon-padding: 2px;
 $svg-icon-height: 11px;
 $svg-icon-width: 5px;
 
-@mixin port($ports-width, $padding, $isBottom) {
+@mixin port($ports-width, $padding, $orientation) {
   .port {
     white-space: nowrap;
     position: relative;
     height: $port-height;
     line-height: $port-height;
-    @if($isBottom) {
+    @if($orientation == 'N' or $orientation == 'S') {
       display: inline;
       height: $svg-icon-height;
     }
@@ -37,18 +37,22 @@ $svg-icon-width: 5px;
     img.svg-icon {
       display: inline-block;
 
-      @if($isBottom) {
+      @if($orientation == 'N' or $orientation == 'S') {
         position: relative;
-        top: 1px;
         margin-left: 2px;
         margin-right: 2px;
         width: $svg-icon-height;
         height: $svg-icon-width;
+        @if($orientation == 'S') {
+          top: 3px;
+        } @else {
+          top: -8px;
+        }
       } @else {
         position: absolute;
+        top: 2px;
         height: $svg-icon-height;
         width: $svg-icon-width;
-        top: 2px;
       }
     }
 
@@ -57,15 +61,21 @@ $svg-icon-width: 5px;
       background: $dot-color;
       border: $dot-border-width solid $dot-color;
 
-      @if($isBottom) {
+      @if($orientation == 'N' or $orientation == 'S') {
         position: relative;
-        top: 0;
         margin-left: 4px;
         margin-right: 4px;
         width: $dot-height;
         height: $dot-width + 1;
-        border-bottom-left-radius: $dot-radius;
-        border-bottom-right-radius: $dot-radius;
+        @if($orientation == 'S') {
+          top: 1px;
+          border-bottom-left-radius: $dot-radius;
+          border-bottom-right-radius: $dot-radius;
+        } @else {
+          top: -9px;
+          border-top-left-radius: $dot-radius;
+          border-top-right-radius: $dot-radius;
+        }
       } @else {
         position: absolute;
         width: $dot-width;

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -262,17 +262,36 @@
     height: 15px;
     width: 15px;
     margin-bottom: 2px;
-    border-radius: 5px; }
-    .model-decorator .set.inverse-on-hover:hover {
+    border-radius: 2px; }
+    .model-decorator .set:hover {
       background-color: rgba(82, 168, 236, 0.8);
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
-      .model-decorator .set.inverse-on-hover:hover [class^="icon-"]:not(.icon-white),
-      .model-decorator .set.inverse-on-hover:hover [class*=" icon-"]:not(.icon-white) {
+      .model-decorator .set:hover [class^="icon-"]:not(.icon-white),
+      .model-decorator .set:hover [class*=" icon-"]:not(.icon-white) {
         background-image: url("../../../img/glyphicons-halflings-white.png"); }
     .model-decorator .set [class^="icon-"],
     .model-decorator .set [class*=" icon-"] {
+      margin-top: -2px; }
+  .model-decorator .replaceable {
+    position: absolute;
+    bottom: 0;
+    left: 2px;
+    height: 15px;
+    width: 15px;
+    margin-bottom: 2px;
+    border-radius: 2px; }
+    .model-decorator .replaceable:hover {
+      background-color: rgba(82, 168, 236, 0.8);
+      -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+      .model-decorator .replaceable:hover [class^="icon-"]:not(.icon-white),
+      .model-decorator .replaceable:hover [class*=" icon-"]:not(.icon-white) {
+        background-image: url("../../../img/glyphicons-halflings-white.png"); }
+    .model-decorator .replaceable [class^="icon-"],
+    .model-decorator .replaceable [class*=" icon-"] {
       margin-top: -2px; }
   .model-decorator.abstract .name {
     font-style: italic;

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -84,7 +84,7 @@
     .model-decorator .ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .ports .right .port .title-wrapper {
@@ -149,7 +149,7 @@
     .model-decorator .top-ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .top-ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .top-ports .right .port .title-wrapper {
@@ -214,7 +214,7 @@
     .model-decorator .bottom-ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .bottom-ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .bottom-ports .right .port .title-wrapper {
@@ -326,6 +326,9 @@
       top: -16px; }
     .model-decorator .connector:hover.bottom {
       bottom: -16px; }
+  .model-decorator .connector.top-left {
+    top: 2px;
+    left: 9px; }
   .model-decorator .connector.top {
     top: -10px; }
   .model-decorator .connector.bottom {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -33,7 +33,7 @@
     color: #AAAAAA; }
   .model-decorator .ports {
     font-size: 10px;
-    min-height: 1px;
+    min-height: 16px;
     width: 121px;
     position: relative; }
     .model-decorator .ports .left {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -64,16 +64,16 @@
         overflow: hidden;
         text-overflow: ellipsis; }
       .model-decorator .ports .port img.svg-icon {
+        display: inline-block;
+        position: absolute;
         height: 11px;
         width: 5px;
-        position: absolute;
-        display: inline-block;
         top: 2px; }
       .model-decorator .ports .port span.dot {
-        position: absolute;
         display: inline-block;
         background: #666666;
         border: 1px solid #666666;
+        position: absolute;
         width: 3px;
         height: 7px;
         top: 4px; }
@@ -98,6 +98,71 @@
       transform: scaleX(-1); }
     .model-decorator .ports .right .port span.dot {
       left: 54px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px; }
+  .model-decorator .bottom-ports {
+    width: 100%;
+    left: 0;
+    height: 5px;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    display: flex; }
+    .model-decorator .bottom-ports .port {
+      white-space: nowrap;
+      position: relative;
+      height: 15px;
+      line-height: 15px;
+      display: inline;
+      height: 11px; }
+      .model-decorator .bottom-ports .port:hover {
+        cursor: pointer; }
+      .model-decorator .bottom-ports .port .title-wrapper {
+        display: inline-block;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+      .model-decorator .bottom-ports .port img.svg-icon {
+        display: inline-block;
+        position: relative;
+        top: 1px;
+        margin-left: 2px;
+        margin-right: 2px;
+        width: 11px;
+        height: 5px; }
+      .model-decorator .bottom-ports .port span.dot {
+        display: inline-block;
+        background: #666666;
+        border: 1px solid #666666;
+        position: relative;
+        top: 0;
+        margin-left: 4px;
+        margin-right: 4px;
+        width: 7px;
+        height: 4px;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px; }
+      .model-decorator .bottom-ports .port.w-icon span.dot {
+        display: none; }
+    .model-decorator .bottom-ports .left .port .title-wrapper {
+      text-align: left; }
+    .model-decorator .bottom-ports .left .port img.svg-icon {
+      left: -8px; }
+    .model-decorator .bottom-ports .left .port span.dot {
+      left: -6px;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px; }
+    .model-decorator .bottom-ports .right .port .title-wrapper {
+      text-align: right; }
+    .model-decorator .bottom-ports .right .port img.svg-icon {
+      right: -8px;
+      -webkit-transform: scaleX(-1);
+      -moz-transform: scaleX(-1);
+      -ms-transform: scaleX(-1);
+      -o-transform: scaleX(-1);
+      transform: scaleX(-1); }
+    .model-decorator .bottom-ports .right .port span.dot {
+      left: 14px;
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px; }
   .model-decorator .progress-bar .loader-progressbar {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -66,9 +66,9 @@
       .model-decorator .ports .port img.svg-icon {
         display: inline-block;
         position: absolute;
+        top: 2px;
         height: 11px;
-        width: 5px;
-        top: 2px; }
+        width: 5px; }
       .model-decorator .ports .port span.dot {
         display: inline-block;
         background: #666666;
@@ -100,10 +100,75 @@
       left: 54px;
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px; }
+  .model-decorator .top-ports {
+    width: 100%;
+    left: 0;
+    height: 0;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    display: flex; }
+    .model-decorator .top-ports .port {
+      white-space: nowrap;
+      position: relative;
+      height: 15px;
+      line-height: 15px;
+      display: inline;
+      height: 11px; }
+      .model-decorator .top-ports .port:hover {
+        cursor: pointer; }
+      .model-decorator .top-ports .port .title-wrapper {
+        display: inline-block;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+      .model-decorator .top-ports .port img.svg-icon {
+        display: inline-block;
+        position: relative;
+        margin-left: 2px;
+        margin-right: 2px;
+        width: 11px;
+        height: 5px;
+        top: -8px; }
+      .model-decorator .top-ports .port span.dot {
+        display: inline-block;
+        background: #666666;
+        border: 1px solid #666666;
+        position: relative;
+        margin-left: 4px;
+        margin-right: 4px;
+        width: 7px;
+        height: 4px;
+        top: -9px;
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px; }
+      .model-decorator .top-ports .port.w-icon span.dot {
+        display: none; }
+    .model-decorator .top-ports .left .port .title-wrapper {
+      text-align: left; }
+    .model-decorator .top-ports .left .port img.svg-icon {
+      left: -8px; }
+    .model-decorator .top-ports .left .port span.dot {
+      left: -6px;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px; }
+    .model-decorator .top-ports .right .port .title-wrapper {
+      text-align: right; }
+    .model-decorator .top-ports .right .port img.svg-icon {
+      right: -8px;
+      -webkit-transform: scaleX(-1);
+      -moz-transform: scaleX(-1);
+      -ms-transform: scaleX(-1);
+      -o-transform: scaleX(-1);
+      transform: scaleX(-1); }
+    .model-decorator .top-ports .right .port span.dot {
+      left: 14px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px; }
   .model-decorator .bottom-ports {
     width: 100%;
     left: 0;
-    height: 5px;
+    height: 0;
     position: absolute;
     align-items: center;
     justify-content: center;
@@ -125,21 +190,21 @@
       .model-decorator .bottom-ports .port img.svg-icon {
         display: inline-block;
         position: relative;
-        top: 1px;
         margin-left: 2px;
         margin-right: 2px;
         width: 11px;
-        height: 5px; }
+        height: 5px;
+        top: 3px; }
       .model-decorator .bottom-ports .port span.dot {
         display: inline-block;
         background: #666666;
         border: 1px solid #666666;
         position: relative;
-        top: 0;
         margin-left: 4px;
         margin-right: 4px;
         width: 7px;
         height: 4px;
+        top: 1px;
         border-bottom-left-radius: 5px;
         border-bottom-right-radius: 5px; }
       .model-decorator .bottom-ports .port.w-icon span.dot {
@@ -246,8 +311,8 @@
     top: -10px; }
   .model-decorator .connector.bottom {
     bottom: -9px; }
-    .model-decorator .connector.bottom.has-bottom-ports {
-      visibility: hidden; }
+  .model-decorator .connector.has-ports {
+    visibility: hidden; }
 .model-decorator .ports .port div.connector {
   top: 0.5px; }
   .model-decorator .ports .port div.connector:hover {
@@ -262,7 +327,9 @@
   .model-decorator .ports .right .port .connector:hover {
     left: 62px; }
 .model-decorator .bottom-ports div.connector {
-  top: 4px; }
+  top: 6px; }
+.model-decorator .top-ports div.connector {
+  top: -9px; }
 .model-decorator.accept-droppable {
   background-color: #00FF00 !important;
   cursor: alias; }

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.css
@@ -246,6 +246,8 @@
     top: -10px; }
   .model-decorator .connector.bottom {
     bottom: -9px; }
+    .model-decorator .connector.bottom.has-bottom-ports {
+      visibility: hidden; }
 .model-decorator .ports .port div.connector {
   top: 0.5px; }
   .model-decorator .ports .port div.connector:hover {
@@ -259,6 +261,8 @@
   left: 60px; }
   .model-decorator .ports .right .port .connector:hover {
     left: 62px; }
+.model-decorator .bottom-ports div.connector {
+  top: 4px; }
 .model-decorator.accept-droppable {
   background-color: #00FF00 !important;
   cursor: alias; }

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
@@ -154,23 +154,12 @@ define([
                 len: LEN
             });
 
-            //South side
-            result.push({
-                id: 'S',
-                x1: edge,
-                y1: this.hostDesignerItem.getHeight(),
-                x2: this.hostDesignerItem.getWidth() - edge,
-                y2: this.hostDesignerItem.getHeight(),
-                angle1: 90,
-                angle2: 90,
-                len: LEN
-            });
-
-            //check east and west
+            //check east and west and south
             //if there is port on the side, it's disabled for drawing connections
             //otherwise enabled
             var eastEnabled = true;
             var westEnabled = true;
+            var southEnabled = true;
             for (var pId in this.ports) {
                 if (this.ports.hasOwnProperty(pId)) {
                     if (this.ports[pId].orientation === 'E') {
@@ -179,10 +168,30 @@ define([
                     if (this.ports[pId].orientation === 'W') {
                         westEnabled = false;
                     }
+                    if (this.ports[pId].orientation === 'S') {
+                        southEnabled = false;
+                    }
                 }
-                if (!eastEnabled && !westEnabled) {
+                if (!eastEnabled && !westEnabled && !southEnabled) {
                     break;
                 }
+            }
+
+            //South side
+            if (southEnabled) {
+                result.push({
+                    id: 'S',
+                    x1: edge,
+                    y1: this.hostDesignerItem.getHeight(),
+                    x2: this.hostDesignerItem.getWidth() - edge,
+                    y2: this.hostDesignerItem.getHeight(),
+                    angle1: 90,
+                    angle2: 90,
+                    len: LEN
+                });
+                this.$el.find('.connector.bottom').removeClass('has-bottom-ports');
+            } else {
+                this.$el.find('.connector.bottom').addClass('has-bottom-ports');
             }
 
             if (eastEnabled) {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
@@ -198,6 +198,26 @@ define([
                 this.$el.find('.connector.top').addClass('has-ports');
             }
 
+            // If both north and south are disabled we need a spare connector in the top left corner.
+            if (northEnabled === false && southEnabled === false) {
+                this.$el.find('.connector.top-left').removeClass('has-ports');
+                // If east and west are also disabled we need a connection area in the same corner.
+                if (eastEnabled === false && westEnabled === false) {
+                    result.push({
+                        id: 'NW',
+                        x1: 0,
+                        y1: edge,
+                        x2: 0,
+                        y2: edge,
+                        angle1: 180,
+                        angle2: 180,
+                        len: LEN
+                    });
+                }
+            } else {
+                this.$el.find('.connector.top-left').addClass('has-ports');
+            }
+
             if (eastEnabled) {
                 result.push({
                     id: 'E',

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.js
@@ -142,42 +142,30 @@ define([
         //by default return the bounding box edges midpoints
 
         if (id === undefined || id === this.hostDesignerItem.id) {
-            //North side
-            result.push({
-                id: 'N',
-                x1: edge,
-                y1: 0,
-                x2: this.hostDesignerItem.getWidth() - edge,
-                y2: 0,
-                angle1: 270,
-                angle2: 270,
-                len: LEN
-            });
-
-            //check east and west and south
             //if there is port on the side, it's disabled for drawing connections
             //otherwise enabled
             var eastEnabled = true;
             var westEnabled = true;
             var southEnabled = true;
+            var northEnabled = true;
             for (var pId in this.ports) {
                 if (this.ports.hasOwnProperty(pId)) {
                     if (this.ports[pId].orientation === 'E') {
                         eastEnabled = false;
-                    }
-                    if (this.ports[pId].orientation === 'W') {
+                    } else if (this.ports[pId].orientation === 'W') {
                         westEnabled = false;
-                    }
-                    if (this.ports[pId].orientation === 'S') {
+                    } else if (this.ports[pId].orientation === 'S') {
                         southEnabled = false;
+                    } else if (this.ports[pId].orientation === 'N') {
+                        northEnabled = false;
                     }
                 }
-                if (!eastEnabled && !westEnabled && !southEnabled) {
+
+                if (!eastEnabled && !westEnabled && !southEnabled && !northEnabled) {
                     break;
                 }
             }
 
-            //South side
             if (southEnabled) {
                 result.push({
                     id: 'S',
@@ -189,9 +177,25 @@ define([
                     angle2: 90,
                     len: LEN
                 });
-                this.$el.find('.connector.bottom').removeClass('has-bottom-ports');
+                this.$el.find('.connector.bottom').removeClass('has-ports');
             } else {
-                this.$el.find('.connector.bottom').addClass('has-bottom-ports');
+                this.$el.find('.connector.bottom').addClass('has-ports');
+            }
+
+            if (northEnabled) {
+                result.push({
+                    id: 'N',
+                    x1: edge,
+                    y1: 0,
+                    x2: this.hostDesignerItem.getWidth() - edge,
+                    y2: 0,
+                    angle1: 270,
+                    angle2: 270,
+                    len: LEN
+                });
+                this.$el.find('.connector.top').removeClass('has-ports');
+            } else {
+                this.$el.find('.connector.top').addClass('has-ports');
             }
 
             if (eastEnabled) {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
@@ -38,9 +38,10 @@
 
     &.bottom {
       bottom: -9px;
-      &.has-bottom-ports {
-        visibility: hidden;
-      }
+    }
+
+    &.has-ports {
+      visibility: hidden;
     }
   }
 
@@ -80,7 +81,13 @@
 
   .bottom-ports {
     div.connector {
-      top: 4px;
+      top: 6px;
+    }
+  }
+
+  .top-ports {
+    div.connector {
+      top: -9px;
     }
   }
   &.accept-droppable {

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
@@ -32,6 +32,11 @@
       }
     }
 
+    &.top-left {
+      top: 2px;
+      left: 9px;
+    }
+
     &.top {
       top: -10px;
     }

--- a/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
+++ b/src/client/decorators/ModelDecorator/DiagramDesigner/ModelDecorator.DiagramDesignerWidget.scss
@@ -38,6 +38,9 @@
 
     &.bottom {
       bottom: -9px;
+      &.has-bottom-ports {
+        visibility: hidden;
+      }
     }
   }
 
@@ -75,6 +78,11 @@
     }
   }
 
+  .bottom-ports {
+    div.connector {
+      top: 4px;
+    }
+  }
   &.accept-droppable {
     background-color: $accept-droppable-background-color;
     cursor: alias;

--- a/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
+++ b/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
@@ -262,17 +262,36 @@
     height: 15px;
     width: 15px;
     margin-bottom: 2px;
-    border-radius: 5px; }
-    .model-decorator .set.inverse-on-hover:hover {
+    border-radius: 2px; }
+    .model-decorator .set:hover {
       background-color: rgba(82, 168, 236, 0.8);
       -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
-      .model-decorator .set.inverse-on-hover:hover [class^="icon-"]:not(.icon-white),
-      .model-decorator .set.inverse-on-hover:hover [class*=" icon-"]:not(.icon-white) {
+      .model-decorator .set:hover [class^="icon-"]:not(.icon-white),
+      .model-decorator .set:hover [class*=" icon-"]:not(.icon-white) {
         background-image: url("../../../img/glyphicons-halflings-white.png"); }
     .model-decorator .set [class^="icon-"],
     .model-decorator .set [class*=" icon-"] {
+      margin-top: -2px; }
+  .model-decorator .replaceable {
+    position: absolute;
+    bottom: 0;
+    left: 2px;
+    height: 15px;
+    width: 15px;
+    margin-bottom: 2px;
+    border-radius: 2px; }
+    .model-decorator .replaceable:hover {
+      background-color: rgba(82, 168, 236, 0.8);
+      -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6); }
+      .model-decorator .replaceable:hover [class^="icon-"]:not(.icon-white),
+      .model-decorator .replaceable:hover [class*=" icon-"]:not(.icon-white) {
+        background-image: url("../../../img/glyphicons-halflings-white.png"); }
+    .model-decorator .replaceable [class^="icon-"],
+    .model-decorator .replaceable [class*=" icon-"] {
       margin-top: -2px; }
   .model-decorator.abstract .name {
     font-style: italic;

--- a/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
+++ b/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
@@ -33,7 +33,7 @@
     color: #AAAAAA; }
   .model-decorator .ports {
     font-size: 10px;
-    min-height: 1px;
+    min-height: 16px;
     width: 121px;
     position: relative; }
     .model-decorator .ports .left {

--- a/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
+++ b/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
@@ -84,7 +84,7 @@
     .model-decorator .ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .ports .right .port .title-wrapper {
@@ -149,7 +149,7 @@
     .model-decorator .top-ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .top-ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .top-ports .right .port .title-wrapper {
@@ -214,7 +214,7 @@
     .model-decorator .bottom-ports .left .port img.svg-icon {
       left: -8px; }
     .model-decorator .bottom-ports .left .port span.dot {
-      left: -6px;
+      left: -7px;
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px; }
     .model-decorator .bottom-ports .right .port .title-wrapper {

--- a/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
+++ b/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
@@ -64,16 +64,16 @@
         overflow: hidden;
         text-overflow: ellipsis; }
       .model-decorator .ports .port img.svg-icon {
+        display: inline-block;
+        position: absolute;
         height: 11px;
         width: 5px;
-        position: absolute;
-        display: inline-block;
         top: 2px; }
       .model-decorator .ports .port span.dot {
-        position: absolute;
         display: inline-block;
         background: #666666;
         border: 1px solid #666666;
+        position: absolute;
         width: 3px;
         height: 7px;
         top: 4px; }
@@ -98,6 +98,71 @@
       transform: scaleX(-1); }
     .model-decorator .ports .right .port span.dot {
       left: 54px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px; }
+  .model-decorator .bottom-ports {
+    width: 100%;
+    left: 0;
+    height: 5px;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    display: flex; }
+    .model-decorator .bottom-ports .port {
+      white-space: nowrap;
+      position: relative;
+      height: 15px;
+      line-height: 15px;
+      display: inline;
+      height: 11px; }
+      .model-decorator .bottom-ports .port:hover {
+        cursor: pointer; }
+      .model-decorator .bottom-ports .port .title-wrapper {
+        display: inline-block;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+      .model-decorator .bottom-ports .port img.svg-icon {
+        display: inline-block;
+        position: relative;
+        top: 1px;
+        margin-left: 2px;
+        margin-right: 2px;
+        width: 11px;
+        height: 5px; }
+      .model-decorator .bottom-ports .port span.dot {
+        display: inline-block;
+        background: #666666;
+        border: 1px solid #666666;
+        position: relative;
+        top: 0;
+        margin-left: 4px;
+        margin-right: 4px;
+        width: 7px;
+        height: 4px;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px; }
+      .model-decorator .bottom-ports .port.w-icon span.dot {
+        display: none; }
+    .model-decorator .bottom-ports .left .port .title-wrapper {
+      text-align: left; }
+    .model-decorator .bottom-ports .left .port img.svg-icon {
+      left: -8px; }
+    .model-decorator .bottom-ports .left .port span.dot {
+      left: -6px;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px; }
+    .model-decorator .bottom-ports .right .port .title-wrapper {
+      text-align: right; }
+    .model-decorator .bottom-ports .right .port img.svg-icon {
+      right: -8px;
+      -webkit-transform: scaleX(-1);
+      -moz-transform: scaleX(-1);
+      -ms-transform: scaleX(-1);
+      -o-transform: scaleX(-1);
+      transform: scaleX(-1); }
+    .model-decorator .bottom-ports .right .port span.dot {
+      left: 14px;
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px; }
   .model-decorator .progress-bar .loader-progressbar {

--- a/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
+++ b/src/client/decorators/ModelDecorator/PartBrowser/ModelDecorator.PartBrowserWidget.css
@@ -66,9 +66,9 @@
       .model-decorator .ports .port img.svg-icon {
         display: inline-block;
         position: absolute;
+        top: 2px;
         height: 11px;
-        width: 5px;
-        top: 2px; }
+        width: 5px; }
       .model-decorator .ports .port span.dot {
         display: inline-block;
         background: #666666;
@@ -100,10 +100,75 @@
       left: 54px;
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px; }
+  .model-decorator .top-ports {
+    width: 100%;
+    left: 0;
+    height: 0;
+    position: absolute;
+    align-items: center;
+    justify-content: center;
+    display: flex; }
+    .model-decorator .top-ports .port {
+      white-space: nowrap;
+      position: relative;
+      height: 15px;
+      line-height: 15px;
+      display: inline;
+      height: 11px; }
+      .model-decorator .top-ports .port:hover {
+        cursor: pointer; }
+      .model-decorator .top-ports .port .title-wrapper {
+        display: inline-block;
+        width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis; }
+      .model-decorator .top-ports .port img.svg-icon {
+        display: inline-block;
+        position: relative;
+        margin-left: 2px;
+        margin-right: 2px;
+        width: 11px;
+        height: 5px;
+        top: -8px; }
+      .model-decorator .top-ports .port span.dot {
+        display: inline-block;
+        background: #666666;
+        border: 1px solid #666666;
+        position: relative;
+        margin-left: 4px;
+        margin-right: 4px;
+        width: 7px;
+        height: 4px;
+        top: -9px;
+        border-top-left-radius: 5px;
+        border-top-right-radius: 5px; }
+      .model-decorator .top-ports .port.w-icon span.dot {
+        display: none; }
+    .model-decorator .top-ports .left .port .title-wrapper {
+      text-align: left; }
+    .model-decorator .top-ports .left .port img.svg-icon {
+      left: -8px; }
+    .model-decorator .top-ports .left .port span.dot {
+      left: -6px;
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px; }
+    .model-decorator .top-ports .right .port .title-wrapper {
+      text-align: right; }
+    .model-decorator .top-ports .right .port img.svg-icon {
+      right: -8px;
+      -webkit-transform: scaleX(-1);
+      -moz-transform: scaleX(-1);
+      -ms-transform: scaleX(-1);
+      -o-transform: scaleX(-1);
+      transform: scaleX(-1); }
+    .model-decorator .top-ports .right .port span.dot {
+      left: 14px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px; }
   .model-decorator .bottom-ports {
     width: 100%;
     left: 0;
-    height: 5px;
+    height: 0;
     position: absolute;
     align-items: center;
     justify-content: center;
@@ -125,21 +190,21 @@
       .model-decorator .bottom-ports .port img.svg-icon {
         display: inline-block;
         position: relative;
-        top: 1px;
         margin-left: 2px;
         margin-right: 2px;
         width: 11px;
-        height: 5px; }
+        height: 5px;
+        top: 3px; }
       .model-decorator .bottom-ports .port span.dot {
         display: inline-block;
         background: #666666;
         border: 1px solid #666666;
         position: relative;
-        top: 0;
         margin-left: 4px;
         margin-right: 4px;
         width: 7px;
         height: 4px;
+        top: 1px;
         border-bottom-left-radius: 5px;
         border-bottom-right-radius: 5px; }
       .model-decorator .bottom-ports .port.w-icon span.dot {

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -54,6 +54,7 @@ define(['js/logger',
             REGISTRY_KEYS.TREE_ITEM_EXPANDED_ICON,
             REGISTRY_KEYS.SVG_ICON,
             REGISTRY_KEYS.PORT_SVG_ICON,
+            REGISTRY_KEYS.PORT_ORIENTATION,
             REGISTRY_KEYS.COLOR,
             REGISTRY_KEYS.TEXT_COLOR,
             REGISTRY_KEYS.BORDER_COLOR,
@@ -540,6 +541,18 @@ define(['js/logger',
                             dst[repKey].useDisplayedValue = WebGMEGlobal.SvgManager.isSvg;
                         }
                         dst[repKey].clipboard = true;
+                    } else if (key === REGISTRY_KEYS.PORT_ORIENTATION) {
+                        dst[ICON_SUB_GROUP] = {
+                            name: ICON_SUB_GROUP,
+                            text: ICON_SUB_GROUP,
+                            value: undefined,
+                            isFolder: true
+                        };
+                        repKey = ICON_SUB_GROUP + '.' + key;
+                        dst[repKey] = dst[extKey];
+                        delete dst[extKey];
+                        dst[repKey].value = typeof dst[repKey].value !== 'string' ? '' : dst[repKey].value;
+                        dst[repKey].valueItems = ['E', 'W', 'S', 'N'];
                     } else if (key === REGISTRY_KEYS.COLOR || key === REGISTRY_KEYS.BORDER_COLOR ||
                         key === REGISTRY_KEYS.TEXT_COLOR) {
                         dst[COLOR_SUB_GROUP] = {

--- a/src/client/js/RegistryKeys.js
+++ b/src/client/js/RegistryKeys.js
@@ -42,6 +42,7 @@ define([], function () {
         DISPLAY_FORMAT: 'DisplayFormat',
         SVG_ICON: 'SVGIcon',
         PORT_SVG_ICON: 'PortSVGIcon',
+        PORT_ORIENTATION: 'PortOrientation',
         TREE_ITEM_COLLAPSED_ICON: 'TreeItemCollapsedIcon',
         TREE_ITEM_EXPANDED_ICON: 'TreeItemExpandedIcon',
 


### PR DESCRIPTION
The orientation can now also be set to N (North) and S (South). Since the area is limited the name of these ports are not displayed until hovered (see picture below).
![image](https://user-images.githubusercontent.com/6518904/48022172-1302cb80-e100-11e8-9e09-1b4ad7ac0902.png)

When all borders are populated with ports the connector for the box itself is the one in the top-left corner. This place is also where the connection area is placed (that is where connection connect to the box).

![image](https://user-images.githubusercontent.com/6518904/48022139-fe263800-e0ff-11e8-877b-233f559d957a.png)

Set the PortOrientation registry (see below) to the border it should be placed (E = East, W = West, etc.). If the registry isn't set the behavior is the same as before - that is the port will be placed East if it's x-position is > 300.

![image](https://user-images.githubusercontent.com/6518904/48022888-f071b200-e101-11e8-90f4-49480e900cb9.png)



A currently unresolved discrepancy is how the "horizontally placed" ports span outside of the border when ever more than 9 are present. 
