### PR TITLE
Update fancy tree from v2.19.0 to v2.30.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,7 @@
     "jQuery-contextMenu": "swisnl/jQuery-contextMenu#2.6.4",
     "raven-js": "getsentry/raven-js#3.26.2",
     "clipboard": "zenorocha/clipboard.js#1.7.1",
-    "jquery.fancytree": "mar10/fancytree#2.19.0",
+    "jquery.fancytree": "mar10/fancytree#2.30.1",
     "font-awesome": "FortAwesome/Font-Awesome#4.7.0"
   }
 }

--- a/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
+++ b/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
@@ -12,7 +12,9 @@ define(['js/logger',
     'js/Constants',
     './TreeBrowserWidget.Keyboard',
     'js/DragDrop/DragSource',
-    'jquery-fancytree',
+    'jquery-fancytree/jquery.fancytree',
+    'jquery-fancytree/jquery.fancytree.edit',
+    'jquery-fancytree/jquery.fancytree.filter',
     'jquery-contextMenu',
     'css!./styles/TreeBrowserWidget.css'
 ], function (Logger, CONSTANTS, TreeBrowserWidgetKeyboard, dragSource) {
@@ -197,8 +199,15 @@ define(['js/logger',
             createNode: function (event, data) {
                 self._makeNodeDraggable(data.node);
             },
-            removeNode: function (event, data) {
-                self._destroyDraggable(data.node);
+            modifyChild: function (event, data) {
+                // This replaces
+                // removeNode: function (event, data) {
+                //     self._destroyDraggable(data.node);
+                // },
+                // Changed in https://github.com/mar10/fancytree/releases/tag/v2.20.0
+                if (data.operation === 'remove') {
+                    (data.node.children || []).forEach(self._destroyDraggable);
+                }
             },
 
             // Extensions

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -62,7 +62,7 @@ require.config({
         'jquery-dataTables': 'lib/jquery/jquery.dataTables.min',
         'jquery-dataTables-bootstrapped': 'lib/jquery/jquery.dataTables.bootstrapped',
         'jquery-spectrum': 'bower_components/spectrum/spectrum',
-        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/jquery.fancytree-all',
+        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/modules',
         'jquery-layout': 'lib/jquery/jquery.layout.min',
 
         'jquery-contextMenu': 'bower_components/jQuery-contextMenu/dist/jquery.contextMenu',

--- a/src/client/mainDEBUG.js
+++ b/src/client/mainDEBUG.js
@@ -36,7 +36,7 @@ require.config({
         'jquery-dataTables': 'lib/jquery/jquery.dataTables',
         'jquery-dataTables-bootstrapped': 'lib/jquery/jquery.dataTables.bootstrapped',
         'jquery-spectrum': 'bower_components/spectrum/spectrum',
-        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/modules/',
+        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/modules',
         'jquery-layout': 'lib/jquery/jquery.layout',
 
         'jquery-contextMenu': 'bower_components/jQuery-contextMenu/dist/jquery.contextMenu',

--- a/src/client/mainDEBUG.js
+++ b/src/client/mainDEBUG.js
@@ -36,7 +36,7 @@ require.config({
         'jquery-dataTables': 'lib/jquery/jquery.dataTables',
         'jquery-dataTables-bootstrapped': 'lib/jquery/jquery.dataTables.bootstrapped',
         'jquery-spectrum': 'bower_components/spectrum/spectrum',
-        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/jquery.fancytree-all',
+        'jquery-fancytree': 'bower_components/jquery.fancytree/dist/modules/',
         'jquery-layout': 'lib/jquery/jquery.layout',
 
         'jquery-contextMenu': 'bower_components/jQuery-contextMenu/dist/jquery.contextMenu',

--- a/utils/build/dist/build.js
+++ b/utils/build/dist/build.js
@@ -152,7 +152,7 @@ var requirejs = require('requirejs'),
             'jquery-ui-iPad': 'empty:',
             'jquery-spectrum': 'client/bower_components/spectrum/spectrum',
             'jquery-csszoom': 'empty:',
-            'jquery-fancytree': 'empty:',
+            'jquery-fancytree': 'client/bower_components/jquery.fancytree/dist/modules',
             'jquery-layout': 'empty:',
             'jquery-contextMenu': 'client/bower_components/jQuery-contextMenu/dist/jquery.contextMenu',
 

--- a/utils/build/dist/libIncludes.js
+++ b/utils/build/dist/libIncludes.js
@@ -10,6 +10,10 @@ define([
     'jquery-contextMenu',
     'jquery-spectrum',
 
+    'jquery-fancytree/jquery.fancytree',
+    'jquery-fancytree/jquery.fancytree.edit',
+    'jquery-fancytree/jquery.fancytree.filter',
+
     'bootstrap',
     'bootstrap-multiselect',
     'bootstrap-notify',


### PR DESCRIPTION
Since fancy tree is already loaded by the default object-browser there should not be a need to require it again. But for reference the requirejs path is now:
`'jquery-fancytree/jquery.fancytree'` rather than `'jquery-fancytree'`.

More importantly all plugins are not loaded by default anymore - only:
`'jquery-fancytree/jquery.fancytree.edit'`
`'jquery-fancytree/jquery.fancytree.filter'` 
Add a similar dependency statement if you need any more plugins. 

Actual breaking changes in fancy-tree is that the event `removeNode` no longer exists instead use `modifyChild`, see diff for details on how to switch.

For a full list of changes in fancy-tree see [the release notes](https://github.com/mar10/fancytree/releases).
