### PR TITLE
Fixes exception for tabs by ensuring active class is handled explicitly

### DIFF
--- a/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
+++ b/src/client/js/Dialogs/CreateProject/CreateProjectDialog.js
@@ -84,6 +84,12 @@ define(['js/Loader/LoaderCircles',
             self._btnDuplicate.removeClass('activated');
             self._btnCreateBlob.removeClass('activated');
 
+            self._dialog.find('li.tab').each(function () {
+                $(this).removeClass('active');
+            });
+
+            tabEl.addClass('active');
+
             if (tabEl.hasClass('snap-shot')) {
                 self._formSnapShot.addClass('activated');
                 self._btnCreateSnapShot.addClass('activated');
@@ -93,8 +99,6 @@ define(['js/Loader/LoaderCircles',
             } else if (tabEl.hasClass('blob')) {
                 self._formBlob.addClass('activated');
                 self._btnCreateBlob.addClass('activated');
-            } else {
-                return;
             }
         }
 

--- a/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
+++ b/src/client/js/Dialogs/DecoratorSVGExplorer/DecoratorSVGExplorerDialog.js
@@ -375,6 +375,12 @@ define([
                 groupClass;
             self._setSelected();
 
+            self._groupTabList.find('li.tab').each(function () {
+                $(this).removeClass('active');
+            });
+
+            el.addClass('active');
+
             groupClass = TAB_GROUP_PREFIX + el.data(DATA_TAB);
             self._modalBody.find('div.image-container').each(function () {
                 var divImg = $(this);

--- a/src/client/js/jquery.WebGME.js
+++ b/src/client/js/jquery.WebGME.js
@@ -268,8 +268,15 @@ define(['jquery'], function () {
 
             this.each(function () {
                 $(this).append(ul.clone(true));
+
                 $(this).on('click.groupedAlphabetTabs', 'li', function (event) {
                     var filter = $(this).data('filter');
+
+                    $(this).parent().find('li').each(function () {
+                        $(this).removeClass('active');
+                    });
+
+                    $(this).addClass('active');
 
                     if (params && params.onClick) {
                         params.onClick(filter);


### PR DESCRIPTION
When upgrading to jquery 3 (#1660), the bootstrap navigation tab click handling started throwing:
```
Syntax error, unrecognized expression: #
```
when clicking the tabs. The fix here bypasses the invalid selector (coming from `href=#`) by handling the `active` class explicitly on the `li`-elements.