### PR TITLE
Fixes #1663 meta-editor conn update exception by ensuring connection present on current sheet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
   - TEST_BROWSER=true
   - TEST_FOLDER=test RECURSIVE=true
 
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+#before_script:
+#  - export DISPLAY=:99.0
+#  - sh -e /etc/init.d/xvfb start
 
 script: ./test/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
 
     packages:
       - mongodb-org-server
-      - xvfb
 
 cache:
   directories:
@@ -33,7 +32,6 @@ env:
   - TEST_FOLDER=test RECURSIVE=true
 
 before_script:
-  - xvfb :99
-  - export DISPLAY=:99.0
+  - Xvfb :99 & export DISPLAY=:99
 
 script: ./test/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 
     packages:
       - mongodb-org-server
+      - xvfb
 
 cache:
   directories:
@@ -31,8 +32,8 @@ env:
   - TEST_BROWSER=true
   - TEST_FOLDER=test RECURSIVE=true
 
-#before_script:
-#  - export DISPLAY=:99.0
-#  - sh -e /etc/init.d/xvfb start
+before_script:
+  - xvfb :99
+  - export DISPLAY=:99.0
 
 script: ./test/travis.sh

--- a/src/client/js/Panels/MetaEditor/MetaEditorControl.js
+++ b/src/client/js/Panels/MetaEditor/MetaEditorControl.js
@@ -867,10 +867,23 @@ define(['js/logger',
     MetaEditorControl.prototype._updateConnectionText = function (gmeSrcId, gmeDstId, connType, connTexts) {
         var connectionID,
             idx,
-            len = this._connectionListBySrcGMEID[gmeSrcId][gmeDstId][connType].length,
+            len,
             pointerOrSetName = connTexts.name,
             found = false,
+            connectionPresent = false,
             connDesc;
+
+        if (this._connectionListBySrcGMEID[gmeSrcId] &&
+            this._connectionListBySrcGMEID[gmeSrcId][gmeDstId] &&
+            this._connectionListBySrcGMEID[gmeSrcId][gmeDstId][connType]) {
+            connectionPresent = true;
+        }
+
+        if (!connectionPresent) {
+            return;
+        }
+
+        len = this._connectionListBySrcGMEID[gmeSrcId][gmeDstId][connType].length;
 
         while (len--) {
             connectionID = this._connectionListBySrcGMEID[gmeSrcId][gmeDstId][connType][len];
@@ -1002,11 +1015,12 @@ define(['js/logger',
 
         //compute updated and added connections
         children.items.forEach(function (target, idx) {
-            if (self._nodeMetaContainment[gmeID].items.indexOf(target) > -1) {
+            var prevIdx = self._nodeMetaContainment[gmeID].items.indexOf(target);
+            if (prevIdx > -1) {
                 sameCnt += 1;
                 // Potential Update
-                if (self._nodeMetaContainment[gmeID].minItems[idx] !== children.minItems[idx] ||
-                    self._nodeMetaContainment[gmeID].maxItems[idx] !== children.maxItems[idx]) {
+                if (self._nodeMetaContainment[gmeID].minItems[prevIdx] !== children.minItems[idx] ||
+                    self._nodeMetaContainment[gmeID].maxItems[prevIdx] !== children.maxItems[idx]) {
                     self._updateConnectionText(gmeID, target, MetaRelations.META_RELATIONS.CONTAINMENT, {
                         dstText: getMultiplicityText(children.minItems[idx], children.maxItems[idx]),
                         dstTextEdit: true
@@ -1099,13 +1113,14 @@ define(['js/logger',
                     if (isOneToOnePointer(newPtrDesc) === isOneToOnePointer(oldPtrDesc)) {
                         sameTargetCnt = 0;
                         newPtrDesc.items.forEach(function (target, idx) {
-                            if (oldPtrDesc.items.indexOf(target) > -1) {
+                            var prevIdx = oldPtrDesc.items.indexOf(target);
+                            if (prevIdx > -1) {
                                 sameTargetCnt += 1;
 
                                 // Potential text update for set
                                 if (isOneToOnePointer(newPtrDesc) === false &&
-                                    (oldPtrDesc.minItems[idx] !== newPtrDesc.minItems[idx] ||
-                                    oldPtrDesc.maxItems[idx] !== newPtrDesc.maxItems[idx])) {
+                                    (oldPtrDesc.minItems[prevIdx] !== newPtrDesc.minItems[idx] ||
+                                    oldPtrDesc.maxItems[prevIdx] !== newPtrDesc.maxItems[idx])) {
                                     self._updateConnectionText(gmeID, target, MetaRelations.META_RELATIONS.SET, {
                                         name: ptrName,
                                         dstText: getMultiplicityText(newPtrDesc.minItems[idx],


### PR DESCRIPTION
Also fixes faulty updated cardinalities.

Second part was introduced by #1655 (which happened to trigger more updates on meta-relations not present on the canvas).