### PR TITLE
Fixes #1665 do not trigger orTabsSorted when no change and crosscut tab ordering

### DIFF
--- a/src/client/js/Panels/Crosscut/CrosscutController.js
+++ b/src/client/js/Panels/Crosscut/CrosscutController.js
@@ -248,7 +248,8 @@ define(['js/logger',
                 title: crosscutsRegistry[len].title,
                 filterInfo: crosscutsRegistry[len].filter || {},
                 enableDeleteTab: true,
-                enableRenameTab: true
+                enableRenameTab: true,
+                order: crosscutsRegistry[len].order
             });
         }
 
@@ -266,7 +267,7 @@ define(['js/logger',
     CrosscutController.prototype.getMemberListSetsRegistryKey = function () {
         return REGISTRY_KEYS.CROSSCUTS;
     };
-    
+
     CrosscutController.prototype.getMemberListSetsRegistry = GMEConcepts.getCrosscuts;
 
     CrosscutController.prototype.getNewSetNamePrefixDesc = function () {

--- a/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
+++ b/src/client/js/Widgets/DiagramDesigner/DiagramDesignerWidget.Tabs.js
@@ -321,6 +321,7 @@ define([
 
     DiagramDesignerWidgetTabs.prototype._onTabsSortStop = function () {
         var ul = this.$ulTabTab,
+            orderChanged = false,
             allLi = ul.find('li'),
             i,
             li,
@@ -331,7 +332,14 @@ define([
             order.push(li.data(TAB_ID));
         }
 
-        if (order.length > 0) {
+        for (i = 0; i < order.length; i += 1) {
+            if (i + '' !== order[i]) {
+                orderChanged = true;
+                break;
+            }
+        }
+
+        if (orderChanged) {
             this.onTabsSorted(order);
         }
     };


### PR DESCRIPTION
This also fixes a bug in cross-cut editor where tab order was messed up