### PR TITLE
Fixes copy paste from key board inside root node

### DIFF
--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.DiagramDesignerWidgetEventHandlers.js
@@ -1214,7 +1214,7 @@ define(['js/logger',
             childrenIDs = [],
             aspect = this._selectedAspect;
 
-        if (parentID) {
+        if (typeof parentID === 'string') {
             try {
                 data = JSON.parse(data);
             } catch (e) {


### PR DESCRIPTION
The current check won't allow copying inside the root-node (with path `''`).