### PR TITLE
Navigation title

### DIFF
--- a/config/componentsGenericUIDefaults.json
+++ b/config/componentsGenericUIDefaults.json
@@ -60,6 +60,19 @@
       "topNode": {}
     }
   },
+  "GenericUIModelEditorPanel": {
+    "navigationTitle": {
+      "enabled": false,
+      "attribute": "name",
+      "depth": 2
+    },
+    "byProjectKind": {
+      "navigationTitle": {}
+    },
+    "byProjectId": {
+      "navigationTitle": {}
+    }
+  },
   "GenericUICrosscutController": {
     "autoCreateCrosscut": false
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
     },
     "agentkeepalive": {
       "version": "3.4.1",
-      "resolved": "http://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.4.1.tgz",
       "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
       "requires": {
         "humanize-ms": "^1.2.1"
@@ -276,7 +276,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -347,7 +347,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -506,7 +506,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -607,7 +607,7 @@
     },
     "browser-pack": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -628,7 +628,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
@@ -712,7 +712,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -746,7 +746,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -897,7 +897,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camelcase": {
@@ -907,7 +907,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1034,7 +1034,7 @@
     },
     "cli-color": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
       "integrity": "sha1-3hiM3Ekp2DtnrqBBEPvtQP2/Z3U=",
       "requires": {
         "ansi-regex": "2",
@@ -1080,7 +1080,7 @@
     },
     "color": {
       "version": "0.8.0",
-      "resolved": "http://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
       "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
       "requires": {
         "color-convert": "^0.5.0",
@@ -1089,7 +1089,7 @@
       "dependencies": {
         "color-convert": {
           "version": "0.5.3",
-          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
         }
       }
@@ -1109,7 +1109,7 @@
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
         "color-name": "^1.0.0"
@@ -1122,7 +1122,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "colorspace": {
@@ -1164,7 +1164,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "comment-parser": {
@@ -1353,7 +1353,7 @@
     },
     "convert-source-map": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "cookie": {
@@ -1428,7 +1428,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1440,7 +1440,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1510,7 +1510,7 @@
     },
     "d": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "requires": {
         "es5-ext": "~0.10.2"
@@ -1670,7 +1670,7 @@
     },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -1727,7 +1727,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1745,7 +1745,7 @@
       "dependencies": {
         "utility": {
           "version": "0.1.11",
-          "resolved": "http://registry.npmjs.org/utility/-/utility-0.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/utility/-/utility-0.1.11.tgz",
           "integrity": "sha1-/eYM+bTkdRlHoM9dEEzik2ciZxU=",
           "requires": {
             "address": ">=0.0.1"
@@ -1776,7 +1776,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
@@ -1788,7 +1788,7 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
@@ -1882,7 +1882,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -1916,7 +1916,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -1991,7 +1991,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
             "es5-ext": "^0.10.9"
@@ -2001,7 +2001,7 @@
     },
     "es6-promise": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "es6-symbol": {
@@ -2015,7 +2015,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
             "es5-ext": "^0.10.9"
@@ -2098,7 +2098,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
             "es5-ext": "^0.10.9"
@@ -2114,7 +2114,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
@@ -2186,7 +2186,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
@@ -2554,7 +2554,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -2568,7 +2568,7 @@
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "optional": true,
@@ -3126,7 +3126,7 @@
     },
     "got": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/got/-/got-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-2.4.0.tgz",
       "integrity": "sha1-5Ah6LNWbXSDy0WnchdIWntnon1Y=",
       "requires": {
         "duplexify": "^3.2.0",
@@ -3356,7 +3356,7 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "htmlparser2": {
@@ -3567,7 +3567,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3760,7 +3760,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -3910,7 +3910,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3923,7 +3923,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -3951,7 +3951,7 @@
         },
         "entities": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
           "dev": true
         },
@@ -3976,7 +3976,7 @@
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
@@ -4006,7 +4006,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -4018,7 +4018,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4048,7 +4048,7 @@
         },
         "xmlbuilder": {
           "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
           "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
           "dev": true,
           "requires": {
@@ -4094,12 +4094,12 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         }
       }
@@ -4115,7 +4115,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -4161,13 +4161,13 @@
         },
         "entities": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
           "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
           "dev": true
         },
         "htmlparser2": {
           "version": "3.8.3",
-          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
           "dev": true,
           "requires": {
@@ -4186,7 +4186,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4261,7 +4261,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "optional": true,
@@ -4844,7 +4844,7 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true,
       "optional": true
@@ -4867,7 +4867,7 @@
     },
     "kuler": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
       "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
       "requires": {
         "colornames": "0.0.2"
@@ -4875,7 +4875,7 @@
     },
     "labeled-stream-splicer": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
       "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "requires": {
         "inherits": "^2.0.1",
@@ -4918,7 +4918,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -5101,7 +5101,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memoizee": {
@@ -5120,14 +5120,14 @@
       "dependencies": {
         "next-tick": {
           "version": "0.2.2",
-          "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
           "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
         }
       }
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -5246,7 +5246,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimize": {
@@ -5265,7 +5265,7 @@
       "dependencies": {
         "async": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "requires": {
             "lodash": "^4.8.0"
@@ -5273,7 +5273,7 @@
         },
         "htmlparser2": {
           "version": "3.9.2",
-          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "requires": {
             "domelementtype": "^1.3.0",
@@ -5312,7 +5312,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -5320,7 +5320,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -5403,7 +5403,7 @@
     },
     "mongodb": {
       "version": "2.2.35",
-      "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
       "integrity": "sha512-3HGLucDg/8EeYMin3k+nFWChTA85hcYDCw1lPsWR6yV9A6RgKb24BkLiZ9ySZR+S0nfBjWoIUS7cyV6ceGx5Gg==",
       "requires": {
         "es6-promise": "3.2.1",
@@ -5442,7 +5442,7 @@
     },
     "mongodb-core": {
       "version": "2.1.19",
-      "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz",
       "integrity": "sha512-Jt4AtWUkpuW03kRdYGxga4O65O1UHlFfvvInslEfLlGi+zDMxbBe3J2NVmN9qPJ957Mn6Iz0UpMtV80cmxCVxw==",
       "requires": {
         "bson": "~1.0.4",
@@ -5526,7 +5526,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "negotiator": {
@@ -5536,7 +5536,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nomnom": {
@@ -5557,7 +5557,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -5568,7 +5568,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         },
@@ -5627,7 +5627,7 @@
     },
     "nunjucks": {
       "version": "2.4.3",
-      "resolved": "http://registry.npmjs.org/nunjucks/-/nunjucks-2.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.4.3.tgz",
       "integrity": "sha1-lhzLDzGABI7ptpzLboLBy5ReXs0=",
       "requires": {
         "asap": "^2.0.3",
@@ -5757,7 +5757,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -5790,7 +5790,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -5798,7 +5798,7 @@
     },
     "os-name": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
       "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
       "requires": {
         "osx-release": "^1.0.0",
@@ -5807,7 +5807,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -5913,7 +5913,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
@@ -6013,7 +6013,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -6121,7 +6121,7 @@
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true,
       "optional": true
@@ -6141,19 +6141,19 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         },
         "colors": {
           "version": "0.6.2",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "winston": {
           "version": "0.8.3",
-          "resolved": "http://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
           "dev": true,
           "requires": {
@@ -6273,7 +6273,7 @@
     },
     "raml2html": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/raml2html/-/raml2html-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/raml2html/-/raml2html-3.0.1.tgz",
       "integrity": "sha1-aqeaoJg+o8SgfwF3UceBOCmmUhg=",
       "requires": {
         "commander": "2.9.x",
@@ -6287,7 +6287,7 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -6295,14 +6295,14 @@
         },
         "marked": {
           "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
         }
       }
     },
     "raml2obj": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/raml2obj/-/raml2obj-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/raml2obj/-/raml2obj-3.0.0.tgz",
       "integrity": "sha1-9w9XPGci4osw1C/bdUOkhoWR678=",
       "requires": {
         "raml-parser": "0.8.x"
@@ -6820,7 +6820,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "^0.1.0",
@@ -6869,7 +6869,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
         }
       }
@@ -6940,7 +6940,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -6970,7 +6970,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
@@ -7062,7 +7062,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -7071,7 +7071,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "requires": {
         "json-stable-stringify": "~0.0.0",
@@ -7091,7 +7091,7 @@
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
@@ -7257,7 +7257,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
@@ -7478,7 +7478,7 @@
     },
     "stream-splicer": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "requires": {
         "inherits": "^2.0.1",
@@ -7499,7 +7499,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -7517,7 +7517,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -7581,7 +7581,7 @@
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "requires": {
         "acorn-node": "^1.2.0"
@@ -7620,7 +7620,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -7639,7 +7639,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "requires": {
         "process": "~0.11.0"
@@ -7878,7 +7878,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
         }
       }
@@ -8013,7 +8013,7 @@
     },
     "urllib": {
       "version": "2.11.1",
-      "resolved": "http://registry.npmjs.org/urllib/-/urllib-2.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/urllib/-/urllib-2.11.1.tgz",
       "integrity": "sha1-5F1Xnxu+Qsn64hzf9yVo88jIyUU=",
       "requires": {
         "any-promise": "^1.2.0",
@@ -8094,13 +8094,13 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         },
         "ncp": {
           "version": "0.4.2",
-          "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
           "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
           "dev": true
         }
@@ -8108,7 +8108,7 @@
     },
     "utility": {
       "version": "1.7.1",
-      "resolved": "http://registry.npmjs.org/utility/-/utility-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/utility/-/utility-1.7.1.tgz",
       "integrity": "sha1-+3TN3IFqQRJ2ym6MqZMkfyPusKc=",
       "requires": {
         "copy-to": "~2.0.1",
@@ -8188,7 +8188,7 @@
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
           "dev": true
         }
@@ -8327,7 +8327,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
@@ -8340,7 +8340,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -8373,7 +8373,7 @@
     },
     "xmlbuilder": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
         "lodash": "^4.0.0"
@@ -8407,7 +8407,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
+++ b/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
@@ -131,3 +131,5 @@
 
 .txt-project-name {
   width: 50%; }
+
+/*# sourceMappingURL=ProjectsDialog.css.map */

--- a/src/client/js/PanelBase/PanelBaseWithHeader.js
+++ b/src/client/js/PanelBase/PanelBaseWithHeader.js
@@ -79,6 +79,9 @@ define([
         this.$panelHeader = $('<div/>', {
             class: 'panel-header no-print'
         });
+        this.$panelHeaderTitle = $('<div/>', {
+            class: 'panel-header-title'
+        });
 
         //Create Panel's BODY
         //set $el to panel-body for subclass use
@@ -99,13 +102,8 @@ define([
             this.$_el.append(this.$panelHeader);
             this.$_el.append(this.$panelBody);
             this.$panelHeader.append(this.$panelReadOnlyIndicator);
-            this.$panelHeaderTitle = $('<div/>', {
-                class: 'panel-header-title'
-            });
             this.$panelHeader.append(this.$panelHeaderTitle);
-            this.$panelHeaderTitle.on('click', function (event) {
-                console.log('titleclick');
-            });
+
         } else if (options[PanelBaseWithHeader.OPTIONS.FLOATING_TITLE] === true) {
             this.$_el.append(this.$panelBody);
             this.$_el.append(this.$panelHeader);
@@ -113,25 +111,23 @@ define([
             this.$floatingTitle = $('<div/>', {
                 class: 'floating-title no-print'
             });
-            this.$panelHeaderTitle = $('<div/>', {
-                class: 'panel-header-title'
-            });
             this.$floatingTitle.append(this.$panelReadOnlyIndicator);
             this.$floatingTitle.append(this.$panelHeaderTitle);
             this.$_el.append(this.$floatingTitle);
-            this.$panelHeaderTitle.on('click', function (event) {
-                console.log('floatingtitleclick');
-            });
+
         } else {
             this.$_el.append(this.$panelBody);
             this.$_el.append(this.$panelReadOnlyIndicator);
         }
+
+        this._configNavigationTitle(options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE]);
 
         //Navigator title - if used, title will not be set, but client event will be followed
         if (options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].enabled === true) {
             this._client = options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].client;
             if (this._client) {
                 this._navigatorTitleInUse = true;
+                this._navigationTitleConfig = options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE];
                 this._attachClientEventListener();
                 if (typeof options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].attribute === 'string') {
                     this._navigatorAttribute = options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].attribute;
@@ -199,7 +195,36 @@ define([
         this._destroyedInstance = true;
     };
 
-    PanelBaseWithHeader.prototype.setTitle = function (text) {
+    PanelBaseWithHeader.prototype._configNavigationTitle = function (navigationTitleConfig) {
+        // We save it in case the navigation title config would change between projects.
+        this._navigationTitleConfig = navigationTitleConfig;
+        this.$panelHeaderTitle.empty();
+
+        //Navigator title - if used, title will not be set, but client event will be followed
+        if (this._navigationTitleConfig.enabled === true) {
+            this._client = this._navigationTitleConfig.client;
+            if (this._client) {
+                this._navigatorTitleInUse = true;
+                this._attachClientEventListener();
+                if (typeof this._navigationTitleConfig.attribute === 'string') {
+                    this._navigatorAttribute = this._navigationTitleConfig.attribute;
+
+                } else {
+                    this._navigatorAttribute = null;
+                }
+                this._navigatorTitleDepth = this._navigationTitleConfig.depth || 1;
+            }
+        } else {
+            this._navigatorTitleInUse = false;
+            this._detachClientEventListener();
+        }
+    };
+
+    PanelBaseWithHeader.prototype.setTitle = function (text, navigationTitleConfig) {
+
+        if (navigationTitleConfig && !_.isEqual(navigationTitleConfig, this._navigationTitleConfig)) {
+            this._configNavigationTitle(navigationTitleConfig);
+        }
         if (this.$panelHeaderTitle && !this._navigatorTitleInUse) {
             this.$panelHeaderTitle.text(text);
         }

--- a/src/client/js/PanelBase/PanelBaseWithHeader.js
+++ b/src/client/js/PanelBase/PanelBaseWithHeader.js
@@ -116,12 +116,6 @@ define([
             this.$_el.append(this.$panelReadOnlyIndicator);
         }
 
-
-        //Navigator title - if used, title will not be set, but client event will be followed
-        this._navigationTitleConfig = null;
-        if (this._client) {
-            this._configNavigationTitle(this._getCurrentNavigationConfig());
-        }
         this._attachClientEventListener();
     };
 
@@ -143,7 +137,6 @@ define([
     };
 
     PanelBaseWithHeader.prototype._refreshNavigationTitle = function () {
-        console.log(WebGMEGlobal.State.getActiveObject());
         var self = this,
             navigationItems = [],
             config = self._getCurrentNavigationConfig(),
@@ -224,24 +217,6 @@ define([
         this.clear();
         this.$_el.remove();
         this._destroyedInstance = true;
-    };
-
-    PanelBaseWithHeader.prototype._configNavigationTitle = function (config) {
-        this.$panelHeaderTitle.empty();
-
-        //Navigator title - if used, title will not be set, but client event will be followed
-        if (config.enabled === true) {
-            if (this._client) {
-                this._attachClientEventListener();
-                if (typeof this._navigationTitleConfig.attribute === 'string') {
-                    this._navigationAttribute = this._navigationTitleConfig.attribute;
-
-                } else {
-                    this._navigationAttribute = null;
-                }
-                this._navigationTitleDepth = this._navigationTitleConfig.depth || 1;
-            }
-        }
     };
 
     PanelBaseWithHeader.prototype.setTitle = function (text) {

--- a/src/client/js/PanelBase/PanelBaseWithHeader.js
+++ b/src/client/js/PanelBase/PanelBaseWithHeader.js
@@ -187,7 +187,9 @@ define([
     };
 
     PanelBaseWithHeader.prototype._navigatorTitleClicked = function (event) {
-        console.log(event);
+        var settings = {};
+        settings[CONSTANTS.STATE_ACTIVE_OBJECT] = $(event.target).data('webgme-id');
+        WebGMEGlobal.State.set(settings);
     };
 
     PanelBaseWithHeader.prototype.destroy = function () {

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
@@ -1,6 +1,9 @@
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
  */
+.panel-header-title-navigation-item {
+  cursor: pointer; }
+
 .panel-base-wh {
   box-sizing: border-box; }
   .panel-base-wh .ro-icon {
@@ -10,7 +13,7 @@
     top: 2px;
     left: 2px; }
   .panel-base-wh .panel-header {
-    background-color: #efefef;
+    background-color: #EFEFEF;
     border-bottom: 3px solid rgba(0, 0, 0, 0);
     white-space: nowrap; }
     .panel-base-wh .panel-header .panel-header-title {
@@ -50,7 +53,7 @@
       left: 0; }
   .panel-base-wh .panel-body {
     position: relative;
-    background-color: white; }
+    background-color: #FFFFFF; }
   .panel-base-wh .floating-title {
     position: absolute;
     top: 0;
@@ -58,7 +61,7 @@
     box-shadow: 0;
     text-shadow: 1.5px 1.5px 0 rgba(0, 0, 0, 0.15);
     opacity: .65;
-    color: #555555; }
+    color: #555; }
     .panel-base-wh .floating-title .ro-icon {
       position: relative;
       top: -1px;
@@ -78,12 +81,12 @@
   .panel-base-wh.read-only .ro-icon {
     display: inline-block; }
   .panel-base-wh.read-only .panel-body {
-    background-color: #fbfbfb; }
+    background-color: #FBFBFB; }
   .panel-base-wh .absolute-header {
     border: 1px solid #d3d8df; }
   .panel-base-wh.active-panel .panel-header {
     border-bottom-color: #00235b;
-    background: white; }
+    background: #fff; }
   .panel-base-wh.active-panel .floating-title {
     opacity: 0.85;
     color: #00235b; }
@@ -91,10 +94,10 @@
     border: 1px solid #00235b; }
   .panel-base-wh.w-tabs .floating-title {
     top: 30px; }
-.panel-base-scroll {}
-  .panel-base-scroll .panel-body {
-    overflow: auto;
-  }
+
+.panel-base-scroll .panel-body {
+  overflow: auto; }
+
 .side-panel .panel-base-wh {
   position: relative;
   padding: 0;
@@ -103,11 +106,11 @@
   -webkit-border-radius: 0;
   -moz-border-radius: 0;
   border-radius: 0;
-  background-color: whitesmoke; }
+  background-color: #F5F5F5; }
   .side-panel .panel-base-wh .panel-header {
     padding: 0 3px;
     font-size: 0.85em;
-    background-color: whitesmoke;
+    background-color: #F5F5F5;
     border-bottom: 3px solid rgba(0, 0, 0, 0); }
     .side-panel .panel-base-wh .panel-header .ro-icon {
       position: relative;
@@ -123,9 +126,11 @@
     .side-panel .panel-base-wh .panel-header .panel-header-toolbar {
       display: block; }
   .side-panel .panel-base-wh .panel-body {
-    background-color: whitesmoke;
+    background-color: #F5F5F5;
     padding: 0; }
   .side-panel .panel-base-wh.read-only .panel-body {
-    background-color: #fbfbfb; }
+    background-color: #FBFBFB; }
   .side-panel .panel-base-wh.active-panel .panel-header {
     border-bottom-color: #00235b; }
+
+/*# sourceMappingURL=PanelBaseWithHeader.css.map */

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.css
@@ -2,7 +2,10 @@
  * @author rkereskenyi / https://github.com/rkereskenyi
  */
 .panel-header-title-navigation-item {
-  cursor: pointer; }
+  cursor: pointer;
+  min-width: 50px; }
+  .panel-header-title-navigation-item:hover {
+    opacity: 0.5; }
 
 .panel-base-wh {
   box-sizing: border-box; }

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
@@ -44,6 +44,10 @@ $panel-header-title-font-size: 0.85em;
 
 .panel-header-title-navigation-item {
   cursor: pointer;
+  min-width: 50px;
+  &:hover {
+    opacity: 0.5;
+  }
 }
 
 .panel-base-wh {

--- a/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
+++ b/src/client/js/PanelBase/styles/PanelBaseWithHeader.scss
@@ -42,6 +42,10 @@ $panel-header-title-font-size: 0.85em;
   margin-top: 8px;
 }
 
+.panel-header-title-navigation-item {
+  cursor: pointer;
+}
+
 .panel-base-wh {
   box-sizing: border-box;
 
@@ -193,6 +197,7 @@ $panel-header-title-font-size: 0.85em;
     overflow: auto;
   }
 }
+
 .side-panel {
 
   .panel-base-wh {

--- a/src/client/js/Panels/ModelEditor/ModelEditorControl.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorControl.js
@@ -82,7 +82,7 @@ define(['js/logger',
         //attach all the event handlers for event's coming from DesignerCanvas
         this.attachDiagramDesignerWidgetEventHandlers();
 
-        //this._updateTopNode();
+        this._updateTopNode();
         this.logger.debug('ModelEditorControl ctor finished');
     };
 
@@ -1054,7 +1054,7 @@ define(['js/logger',
     };
 
     ModelEditorControl.prototype._activeProjectChanged = function (/*model, activeProjectId*/) {
-        //this._updateTopNode();
+        this._updateTopNode();
     };
 
     ModelEditorControl.prototype._updateTopNode = function () {

--- a/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
@@ -7,11 +7,13 @@
 define(['js/PanelBase/PanelBaseWithHeader',
     'js/PanelManager/IActivePanel',
     'js/Widgets/ModelEditor/ModelEditorWidget',
-    './ModelEditorControl'
+    './ModelEditorControl',
+    'js/Utils/ComponentSettings'
 ], function (PanelBaseWithHeader,
              IActivePanel,
              ModelEditorWidget,
-             ModelEditorControl) {
+             ModelEditorControl,
+             ComponentSettings) {
 
     'use strict';
 
@@ -19,17 +21,20 @@ define(['js/PanelBase/PanelBaseWithHeader',
 
     ModelEditorPanel = function (layoutManager, params) {
         var options = {};
+
+        //set properties from component settings
+        this._config = ModelEditorPanel.getDefaultConfig();
+        ComponentSettings.resolveWithWebGMEGlobal(this._config, ModelEditorPanel.getComponentId());
+
+        //TODO - this has to be controlled from the components configuration
+        options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE] = this._config.navigationTitle || {enabled: false};
+        if (options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].enabled) {
+            options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].client = params.client;
+        }
+
         //set properties from options
         options[PanelBaseWithHeader.OPTIONS.LOGGER_INSTANCE_NAME] = 'ModelEditorPanel';
         options[PanelBaseWithHeader.OPTIONS.FLOATING_TITLE] = true;
-
-        //TODO - this has to be controlled from the components configuration
-        options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE] = {
-            enabled: true,
-            client: params.client,
-            depth: 2,
-            attribute: 'name'
-        };
 
         //call parent's constructor
         PanelBaseWithHeader.apply(this, [options, layoutManager]);
@@ -113,6 +118,26 @@ define(['js/PanelBase/PanelBaseWithHeader',
 
     ModelEditorPanel.prototype.getNodeID = function () {
         return this.control.getNodeID();
+    };
+
+    ModelEditorPanel.getDefaultConfig = function () {
+        return {
+            navigatorTitle: {
+                enabled: false,
+                attribute: 'name',
+                depth: 2
+            },
+            byProjectKind: {
+                navigatorTitle: {}
+            },
+            byProjectId: {
+                navigatorTitle: {}
+            }
+        };
+    };
+
+    ModelEditorPanel.getComponentId = function () {
+        return 'GenericUIModelEditorPanel';
     };
 
     return ModelEditorPanel;

--- a/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
@@ -23,6 +23,14 @@ define(['js/PanelBase/PanelBaseWithHeader',
         options[PanelBaseWithHeader.OPTIONS.LOGGER_INSTANCE_NAME] = 'ModelEditorPanel';
         options[PanelBaseWithHeader.OPTIONS.FLOATING_TITLE] = true;
 
+        //TODO - this has to be controlled from the components configuration
+        options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE] = {
+            enabled: true,
+            client: params.client,
+            depth: 2,
+            attribute: 'name'
+        };
+
         //call parent's constructor
         PanelBaseWithHeader.apply(this, [options, layoutManager]);
 

--- a/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
+++ b/src/client/js/Panels/ModelEditor/ModelEditorPanel.js
@@ -26,12 +26,6 @@ define(['js/PanelBase/PanelBaseWithHeader',
         this._config = ModelEditorPanel.getDefaultConfig();
         ComponentSettings.resolveWithWebGMEGlobal(this._config, ModelEditorPanel.getComponentId());
 
-        //TODO - this has to be controlled from the components configuration
-        options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE] = this._config.navigationTitle || {enabled: false};
-        if (options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].enabled) {
-            options[PanelBaseWithHeader.OPTIONS.NAVIGATION_TITLE].client = params.client;
-        }
-
         //set properties from options
         options[PanelBaseWithHeader.OPTIONS.LOGGER_INSTANCE_NAME] = 'ModelEditorPanel';
         options[PanelBaseWithHeader.OPTIONS.FLOATING_TITLE] = true;
@@ -40,6 +34,7 @@ define(['js/PanelBase/PanelBaseWithHeader',
         PanelBaseWithHeader.apply(this, [options, layoutManager]);
 
         this._client = params.client;
+
 
         //initialize UI
         this._initialize();
@@ -122,16 +117,16 @@ define(['js/PanelBase/PanelBaseWithHeader',
 
     ModelEditorPanel.getDefaultConfig = function () {
         return {
-            navigatorTitle: {
+            navigationTitle: {
                 enabled: false,
                 attribute: 'name',
                 depth: 2
             },
             byProjectKind: {
-                navigatorTitle: {}
+                navigationTitle: {}
             },
             byProjectId: {
-                navigatorTitle: {}
+                navigationTitle: {}
             }
         };
     };


### PR DESCRIPTION
As an additional way to quickly navigate towards the root node of the project, we added the Navigation Title feature.
If allowed (currently only in the Composition visualizer, but can be easily adapted to any visualizer using the PanelBaseWithHeader) the title will be a clickable breadcrumbs line (navigation reacts to double click!) instead of a plain, static label.
The feature has to be configured with components config.
The following is an example on how to allow for every project on a given deployment:
```
"GenericUIModelEditorPanel": {
    "navigationTitle": {
      "enabled": true,
      "attribute": "name",
      "depth": 4
    },
    "byProjectKind": {
      "navigationTitle": {}
    },
    "byProjectId": {
      "navigationTitle": {}
    }
  }
```

About the options:
- if attribute is not given, the id of the node will be shown on the screen
- the depth can be any number and controlls how many container (starting from the root), will be visualized and clickable for a quick navigation

This resolves #1677.