### PR TITLE
Hiding header breadcrumb of the node navigation

### DIFF
--- a/config/componentsGenericUIDefaults.json
+++ b/config/componentsGenericUIDefaults.json
@@ -1,6 +1,7 @@
 {
   "GenericUIProjectNavigatorController": {
     "disableProjectActions": false,
+    "disableNodeMenu": false,
     "rootMenuClass": "gme-root",
     "rootDisplayName": "GME",
     "projectMenuClass": "",

--- a/src/client/js/Panels/Header/ProjectNavigatorController.js
+++ b/src/client/js/Panels/Header/ProjectNavigatorController.js
@@ -1139,7 +1139,7 @@ define([
             }
         }
 
-        if (typeof nodeId !== 'string' || !this.gmeClient.getNode(nodeId)) {
+        if (typeof nodeId !== 'string' || !this.gmeClient.getNode(nodeId) || self.config.disableNodeMenu === true) {
             this.$scope.navigator.items.length = this.navIdBranch + 1;
             return;
         }
@@ -1318,6 +1318,7 @@ define([
     ProjectNavigatorController.getDefaultConfig = function () {
         return {
             disableProjectActions: false,
+            disableNodeMenu: false,
             rootMenuClass: 'gme-root',
             rootDisplayName: 'GME',
             projectMenuClass: '',


### PR DESCRIPTION
A new component option is added to the GenericUIProjectNavigatorController's options. The 'disableNodeMenu' - when set to true - hides the last portion of the header breadcrumbs that offers navigation to the containers of the current node context.

Closes #1680.
