### PR TITLE
Password - attribute

### DIFF
--- a/src/client/decorators/MetaDecorator/DiagramDesigner/AttributeDetailsDialog.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/AttributeDetailsDialog.js
@@ -88,13 +88,19 @@ define([
         }
 
         function enumSelectionChanged(checked) {
-            var multiChecked = self._cbMultiline.is(':checked');
+            var multiChecked = self._cbMultiline.is(':checked'),
+                passwordChecked = self._cbPassword.is(':checked');
 
             if (checked) {
                 if (multiChecked) {
-                    self._cbMultiline.attr('checked', false);
+                    self._cbMultiline.prop('checked', false);
                     multiLineSelectionChanged(false);
                 }
+                if (passwordChecked) {
+                    self._cbPassword.prop('checked', false);
+                    passwordSelectionChanged(false);
+                }
+
                 self._pEnumValues.show();
                 self._pRange.hide();
                 self._pRangeMax.val('');
@@ -114,12 +120,17 @@ define([
         }
 
         function multiLineSelectionChanged(checked, value) {
-            var enumChecked = self._cbEnum.is(':checked');
+            var enumChecked = self._cbEnum.is(':checked'),
+                passwordChecked = self._cbPassword.is(':checked');
 
             if (checked) {
                 if (enumChecked) {
-                    self._cbEnum.attr('checked', false);
+                    self._cbEnum.prop('checked', false);
                     enumSelectionChanged(false);
+                }
+                if (passwordChecked) {
+                    self._cbPassword.prop('checked', false);
+                    passwordSelectionChanged(false);
                 }
 
                 if (typeof value === 'string') {
@@ -143,6 +154,23 @@ define([
                 self._pMultilineSubTypes.hide();
                 self._pDefaultValueMultiline.hide();
                 self._pDefaultValue.show();
+            }
+        }
+
+        function passwordSelectionChanged(checked) {
+            var enumChecked = self._cbEnum.is(':checked'),
+                multiChecked = self._cbMultiline.is(':checked');
+
+            if (checked) {
+                if (enumChecked) {
+                    self._cbEnum.prop('checked', false);
+                    enumSelectionChanged(false);
+                }
+
+                if (multiChecked) {
+                    self._cbMultiline.prop('checked', false);
+                    multiLineSelectionChanged(false);
+                }
             }
         }
 
@@ -211,6 +239,10 @@ define([
                         attrDesc.multilineType = self._multilineType.val();
                     }
                 }
+
+                if(self._cbPassword.is(':checked')){
+                    attrDesc.isPassword = true;
+                }
             }
 
             self._dialog.modal('hide');
@@ -243,6 +275,8 @@ define([
                 self._pMultilineSubTypes.hide();
             }
 
+            self._pPassword.hide();
+
             switch (newType) {
                 case 'integer':
                     self._pRegExp.hide();
@@ -271,6 +305,7 @@ define([
                     self._pRegExp.show();
                     self._pRange.hide();
                     self._pMultiline.show();
+                    self._pPassword.show();
                     if (self._cbMultiline.is(':checked')) {
                         self._pDefaultValue.hide();
                         self._pDefaultValueMultiline.show();
@@ -287,6 +322,7 @@ define([
         this._cbEnum = this._el.find('#cbEnum').first();
         this._pEnum = this._el.find('#pEnum').first();
         this._cbMultiline = this._el.find('#cbMultiline').first();
+        this._cbPassword = this._el.find('#cbPassword').first();
 
         this._pMultiline = this._el.find('#pMultiline').first();
         this._pMultiline.hide();
@@ -302,6 +338,9 @@ define([
 
         this._pEnumValues = this._el.find('#pEnumValues').first();
         this._pEnumValues.hide();
+
+        this._pPassword = this._el.find('#pPassword').first();
+        this._pPassword.hide();
 
         this._btnSave = this._dialog.find('.btn-save').first();
         this._btnDelete = this._dialog.find('.btn-delete').first();
@@ -386,6 +425,9 @@ define([
             multiLineSelectionChanged($(this).is(':checked'));
         });
 
+        this._cbPassword.on('change', null, function () {
+            passwordSelectionChanged($(this).is(':checked'));
+        });
         //'type' checkbox check change
         this._inputType.on('change', null, function () {
             selectedTypeChanged(self._inputType.val());
@@ -456,6 +498,7 @@ define([
                 this._pRange.hide();
                 this._pRegExp.show();
                 this._pMultiline.show();
+                this._pPassword.show();
                 if (attributeDesc.regexp) {
                     this._pRegExpValue.val(attributeDesc.regexp);
                 }
@@ -477,6 +520,12 @@ define([
                     }
 
                     multiLineSelectionChanged(true, attributeDesc.defaultValue);
+                }
+
+                if (attributeDesc.isPassword){
+                    this._pPassword.show();
+                    this._cbPassword.prop('checked', true);
+                    passwordSelectionChanged(true);
                 }
             } else {
                 this._pRange.show();

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/MetaDecorator.DiagramDesignerWidget.js
@@ -153,7 +153,8 @@ define([
                     max: attrMeta.max,
                     regexp: attrMeta.regexp,
                     readonly: attrMeta.readonly,
-                    hidden: attrMeta.hidden
+                    hidden: attrMeta.hidden,
+                    isPassword: attrMeta.isPassword,
                 });
 
                 //we will not let 'name' attribute to be modified as that is used UI-wise
@@ -587,6 +588,11 @@ define([
 
         if (attrDesc.isEnum) {
             attrSchema.enum = attrDesc.enumValues;
+        }
+
+        attrSchema.isPassword = false;
+        if(attrDesc.isPassword) {
+            attrSchema.isPassword = true;
         }
 
         this.logger.debug('saveAttributeDescriptor: ' + attrName + ', attrDesc: ' + JSON.stringify(attrDesc));

--- a/src/client/decorators/MetaDecorator/DiagramDesigner/templates/AttributeDetailsDialog.html
+++ b/src/client/decorators/MetaDecorator/DiagramDesigner/templates/AttributeDetailsDialog.html
@@ -59,6 +59,13 @@
                             Multiline
                         </label>
                     </div>
+                    <label class="col-sm-4 control-label"></label>
+                    <div id="pPassword" class="col-sm-2 controls">
+                        <label class="checkbox">
+                            <input type="checkbox" id="cbPassword" value="">
+                            Password
+                        </label>
+                    </div>
                 </div>
                 <div class="form-group" id="pDefaultValue">
                     <label class="col-sm-4 control-label" for="inputDefaultValue">Default value</label>

--- a/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
+++ b/src/client/js/Controls/PropertyGrid/PropertyGridPart.js
@@ -21,7 +21,9 @@ define([
         INVALID_BASE_VALUE_BASE = $('<i class="fa fa-exclamation-triangle reset-badge" ' +
             'title="Inherits META-invalid property"/>'),
         INVALID_BUTTON_BASE = $('<i class="glyphicon glyphicon-exclamation-sign reset-badge btn-reset" ' +
-            'title="Remove META-invalid property"/>');
+            'title="Remove META-invalid property"/>'),
+        PASSWORD_BUTTON_BASE = $('<i class="glyphicon glyphicon-eye-open reset-badge btn-reset" ' +
+            'title="Show Password"/>');
 
     PropertyGridPart = function (params) {
         if (params.el) {
@@ -155,6 +157,7 @@ define([
             extraCss = {},
             widget,
             actionBtn,
+            passwordBtn,
             li;
 
         if (this.__widgets[propertyDesc.name] !== undefined) {
@@ -225,6 +228,28 @@ define([
                     event.preventDefault();
                 });
 
+            }
+
+            if(propertyDesc.options.isPassword) {
+                passwordBtn = PASSWORD_BUTTON_BASE.clone();
+                passwordBtn.on('click', function () {
+                    if ($(this).hasClass('glyphicon-eye-open')) {
+                        //was in password mode
+                        $(this).removeClass('glyphicon-eye-open');
+                        $(this).addClass('glyphicon-eye-close');
+                        $(this).prop('title', 'hide password');
+                        self.__widgets[propertyDesc.name].showPassword(true);
+                    } else {
+                        // should hide now
+                        $(this).removeClass('glyphicon-eye-close');
+                        $(this).addClass('glyphicon-eye-open');
+                        $(this).prop('title', 'show password');
+                        self.__widgets[propertyDesc.name].showPassword(false);
+                    }
+                });
+                divAction.append(passwordBtn);
+
+                spnName.addClass('p-reset');
             }
         }
 

--- a/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
@@ -20,8 +20,11 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
 
         this.__input.val(this.propertyValue);
 
-        if(true/*propertyDesc.isPassword*/){
+        if(propertyDesc.options && propertyDesc.options.isPassword){
+
+            this.__isPassword = true;
             this.__input.prop('type','password');
+            this.__input.css("width","100%");
         }
 
         if (propertyDesc.regex) {
@@ -77,6 +80,16 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
     StringWidget.prototype.focus = function () {
         this.__input.focus();
     };
+
+    StringWidget.prototype.showPassword = function (show) {
+        if (this.__isPassword) {
+            if (show) {
+                this.__input.prop('type','text');
+            } else {
+                this.__input.prop('type','password');
+            }
+        }
+    }
 
     return StringWidget;
 });

--- a/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
+++ b/src/client/js/Controls/PropertyGrid/Widgets/StringWidget.js
@@ -17,7 +17,12 @@ define(['js/Controls/PropertyGrid/Widgets/WidgetBase'], function (WidgetBase) {
         WidgetBase.call(this, propertyDesc);
 
         this.__input = INPUT_BASE.clone();
+
         this.__input.val(this.propertyValue);
+
+        if(true/*propertyDesc.isPassword*/){
+            this.__input.prop('type','password');
+        }
 
         if (propertyDesc.regex) {
             propertyDesc.regexMessage = propertyDesc.regexMessage || 'Value has to match regex: ' + propertyDesc.regex;

--- a/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
+++ b/src/client/js/Panels/PropertyEditor/PropertyEditorPanelController.js
@@ -386,6 +386,7 @@ define(['js/logger',
             key,
             range,
             i,
+            isPassword = false,
             extKey,
             repKey,
             cbyKey,
@@ -414,6 +415,7 @@ define(['js/logger',
                 if (commonAttrMeta.hasOwnProperty(key) === false) {
                     continue;
                 }
+                isPassword = commonAttrMeta[key].isPassword ? true : false;
             }
 
             if (onlyRootSelected) {
@@ -468,7 +470,10 @@ define(['js/logger',
             }
 
             if (isAttribute === true) {
-
+                if (isPassword) {
+                    dst[extKey].options = dst[extKey].options || {};
+                    dst[extKey].options.isPassword = true;
+                }
                 if (this._isReadonlyAttribute(selectedNodes, keyParts[0])) {
                     dst[extKey].readOnly = true;
                 } else {


### PR DESCRIPTION
Now the user is able to set a string attribute as password.
This means that by default the UI will hide the actual value (using the 'password' type of input fields), which can then be turned on and off by the additional eye icon in the property editor.
This is the only safeguard this option entails, the value itself is not completely protected, whoever has access to the project, can export it, and use it (or change the meta and see the value...)