### PR TITLE
Library Tooltip update fixed

### DIFF
--- a/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
+++ b/src/client/js/Widgets/TreeBrowser/TreeBrowserWidget.js
@@ -495,7 +495,7 @@ define(['js/logger',
             nodeDataChanged = true;
         }
 
-        if (objDescriptor.hasOwnProperty('libraryInfo') && typeof objDescriptor.librayInfo === 'string' &&
+        if (objDescriptor.hasOwnProperty('libraryInfo') && typeof objDescriptor.libraryInfo === 'string' &&
             objDescriptor.libraryInfo !== node.data.libraryInfo) {
             node.data.libraryInfo = objDescriptor.libraryInfo;
             node.tooltip = objDescriptor.libraryInfo;


### PR DESCRIPTION
In some situations the tooltip of the library information was not updated even though the library refreshed successfully.