### PR TITLE
Add support for node creation, deletion, rename in GraphViz. Close #1748

### DIFF
--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -68,10 +68,6 @@ define(['js/logger',
             this._client.deleteNode(nodeId);
         };
 
-        this._graphVizWidget.setName = (nodeId, name) => {
-            this._client.setAttribute(nodeId, 'name', name);
-        };
-
         this._graphVizWidget.onNodeClose = function (id) {
             var deleteRecursive,
                 node,

--- a/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
+++ b/src/client/js/Panels/GraphViz/GraphVizPanelControl.js
@@ -3,6 +3,7 @@
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
  * @author nabana / https://github.com/nabana
+ * @author brollb / https://github.com/brollb
  */
 
 define(['js/logger',
@@ -57,6 +58,18 @@ define(['js/logger',
 
         this._graphVizWidget.onNodeDblClick = function (id) {
             WebGMEGlobal.State.registerActiveObject(id);
+        };
+
+        this._graphVizWidget.onExtendMenuItems = (nodeId, menuItems) => {
+            return this.onExtendMenuItems(nodeId, menuItems);
+        };
+
+        this._graphVizWidget.deleteNode = nodeId => {
+            this._client.deleteNode(nodeId);
+        };
+
+        this._graphVizWidget.setName = (nodeId, name) => {
+            this._client.setAttribute(nodeId, 'name', name);
         };
 
         this._graphVizWidget.onNodeClose = function (id) {
@@ -353,6 +366,34 @@ define(['js/logger',
         connBtn.hide();
 
         return toolbarEl;
+    };
+
+    GraphVizControl.prototype.onExtendMenuItems = function (nodeId, menuItems) {
+        const node = this._client.getNode(nodeId);
+        const childIds = Object.keys((node && node.getValidChildrenTypesDetailed()) || {});
+        if (childIds.length > 0) {
+            const childMenuItems = {};
+            const validChildren = childIds.forEach(id => {
+                const node = this._client.getNode(id);
+                childMenuItems[id] = {
+                    name: node.getAttribute('name'),
+                    callback: () => {
+                        const params = {
+                            parentId: nodeId,
+                            baseId: id,
+                        };
+                        this._client.createNode(params);
+                    },
+                };
+            });
+
+            menuItems.createNode = {
+                name: 'Create child',
+                icon: 'add',
+                items: childMenuItems,
+            };
+        }
+        return menuItems;
     };
 
 

--- a/src/client/js/Widgets/GraphViz/GraphVizWidget.js
+++ b/src/client/js/Widgets/GraphViz/GraphVizWidget.js
@@ -80,15 +80,6 @@ define([
         const nodeData = $trigger[0].__data__;
         const nodeId = nodeData.id;
         const menuItems = {
-            renameNode: {
-                name: 'Rename',
-                callback: () => {
-                    // TODO: replace this with a better alternative
-                    const name = prompt(`Please enter a new name for ${nodeData.name}`);
-                    this.setName(nodeId, name);
-                },
-                icon: 'edit',
-            },
             deleteNode: {
                 name: 'Delete',
                 icon: 'delete',

--- a/src/client/js/Widgets/GraphViz/GraphVizWidget.js
+++ b/src/client/js/Widgets/GraphViz/GraphVizWidget.js
@@ -3,13 +3,15 @@
 
 /**
  * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author brollb / https://github.com/brollb
  */
 
 define([
     'js/logger',
-    'js/Widgets/GraphViz/GraphVizWidget.Zoom',
+    './GraphVizWidget.Zoom',
     'js/Utils/ComponentSettings',
     'd3',
+    'jquery-contextMenu',
     'css!./styles/GraphVizWidget.css'
 ], function (Logger, GraphVizWidgetZoom, ComponentSettings) {
     'use strict';
@@ -60,12 +62,42 @@ define([
         this._resizeD3Tree(width, height);
 
         this._svg = this.__svg.append('g').attr('transform', 'translate(' + MARGIN + ',' + MARGIN + ')');
+        this._el.contextMenu({
+            selector: 'g.node',
+            build: $trigger => ({
+                items: this._createContextMenu($trigger),
+            })
+        });
 
         this._el.on('dblclick', function (event) {
             event.stopPropagation();
             event.preventDefault();
             self.onBackgroundDblClick();
         });
+    };
+
+    GraphVizWidget.prototype._createContextMenu = function ($trigger) {
+        const nodeData = $trigger[0].__data__;
+        const nodeId = nodeData.id;
+        const menuItems = {
+            renameNode: {
+                name: 'Rename',
+                callback: () => {
+                    // TODO: replace this with a better alternative
+                    const name = prompt(`Please enter a new name for ${nodeData.name}`);
+                    this.setName(nodeId, name);
+                },
+                icon: 'edit',
+            },
+            deleteNode: {
+                name: 'Delete',
+                icon: 'delete',
+                callback: () => this.deleteNode(nodeId)
+            },
+        };
+        this.onExtendMenuItems(nodeId, menuItems);
+
+        return menuItems;
     };
 
     GraphVizWidget.prototype.onWidgetContainerResize = function (width, height) {
@@ -393,6 +425,9 @@ define([
     GraphVizWidget.prototype.destroy = function () {
         this.__svg.remove();
         this.__svg = undefined;
+    };
+
+    GraphVizWidget.prototype.onExtendMenuItems = function (/*nodeId, menuItems*/) {
     };
 
     GraphVizWidget.prototype.onActivate = function () {


### PR DESCRIPTION
This is mostly ready but needs a better way for the user to input the node name on rename. Unfortunately `$.editInPlace` doesn't work for this case since the text box loses focus if the cursor ever leaves the element's bounding box. I am not exactly sure of the cause; I haven't seen it before with `editInPlace` nor `d3`. That said, I am not really convinced it is even the best UX or really required. Currently, I am thinking something like [this](https://code.daypilot.org/17463/javascript-prompt-replacement) might be a better fit anyway.

Here is a screenshot of the addition:
![DeepinScreenshot_select-area_20220607163055](https://user-images.githubusercontent.com/4982789/172486008-001894f3-85e3-4c80-a1ee-77f206f0bc94.png)
