### PR TITLE
Add project info UI for kind and metadata

### DIFF
--- a/src/client/cssfiles/webgme_bootstrap_overrides.css
+++ b/src/client/cssfiles/webgme_bootstrap_overrides.css
@@ -198,6 +198,7 @@ input[type="submit"].btn.btn-micro {
 .navbar-fixed-bottom .navbar-inner {
     height: 26px;
     min-height: 26px;
+    position: relative;
 }
 
 .navbar-fixed-bottom .navbar-inner .iCheckBox {

--- a/src/client/js/Dialogs/ProjectInfo/ProjectInfoDialog.js
+++ b/src/client/js/Dialogs/ProjectInfo/ProjectInfoDialog.js
@@ -1,0 +1,361 @@
+/*globals define, $, WebGMEGlobal*/
+/*jshint browser: true*/
+
+define([
+    'js/logger',
+    'js/Loader/LoaderCircles',
+    'common/storage/util',
+    'common/regexp',
+    'js/util',
+    'superagent',
+    'text!./templates/ProjectInfoDialog.html',
+    'css!./styles/ProjectInfoDialog.css'
+], function (Logger, LoaderCircles, StorageUtil, REGEXP, clientUtil, superagent, dialogTemplate) {
+
+    'use strict';
+
+    function ProjectInfoDialog(client) {
+        this._logger = Logger.create('gme:Dialogs:ProjectInfo:ProjectInfoDialog', WebGMEGlobal.gmeConfig.client.log);
+        this._client = client;
+    }
+
+    ProjectInfoDialog.prototype.show = function (projectId, params) {
+        params = params || {};
+        this._projectId = projectId;
+        this._onSaved = params.onSaved;
+        this._initDialog();
+        this._loadProjectInfo();
+        this._dialog.modal('show');
+    };
+
+    ProjectInfoDialog.prototype._initDialog = function () {
+        var self = this;
+
+        this._dialog = $(dialogTemplate);
+        this._ownerIdList = this._dialog.find('ul.ownerId-list');
+        this._selectedOwner = this._dialog.find('.selected-owner-id');
+        this._nameInput = this._dialog.find('.project-name');
+        this._kindInput = this._dialog.find('.project-kind');
+        this._descriptionInput = this._dialog.find('.project-description');
+        this._auditCreated = this._dialog.find('.audit-created');
+        this._auditModified = this._dialog.find('.audit-modified');
+        this._auditViewed = this._dialog.find('.audit-viewed');
+        this._saveError = this._dialog.find('.save-error');
+        this._btnSave = this._dialog.find('.btn-save');
+        this._userId = WebGMEGlobal.userInfo._id;
+
+        this._populateOwnerList();
+
+        this._btnSave.on('click', function () {
+            self._save();
+        });
+
+        this._ownerIdList.on('click', 'a.ownerId-selection', function () {
+            self._selectedOwnerId = $(this).data('id');
+            self._selectedOwner.text($(this).text());
+        });
+
+        this._dialog.on('hidden.bs.modal', function () {
+            self._ownerIdList.off('click');
+            self._btnSave.off('click');
+            self._dialog.remove();
+            self._dialog = undefined;
+        });
+    };
+
+    ProjectInfoDialog.prototype._populateOwnerList = function () {
+        var self = this;
+
+        this._ownerIdList.empty();
+        this._ownerIdList.append($('<li><a class="ownerId-selection" data-id="' + self._userId + '">' +
+            WebGMEGlobal.getUserDisplayName(self._userId) + '</a></li>'));
+
+        if (WebGMEGlobal.userInfo.adminOrgs.length > 0) {
+            this._ownerIdList.append($('<li role="separator" class="divider"></li>'));
+            WebGMEGlobal.userInfo.adminOrgs.forEach(function (orgInfo) {
+                self._ownerIdList.append($('<li><a class="ownerId-selection" ' +
+                    'data-id="' + WebGMEGlobal.getUserDisplayName(orgInfo._id) + '">' + orgInfo._id + '</a></li>'));
+            });
+        }
+    };
+
+    ProjectInfoDialog.prototype._loadProjectInfo = function () {
+        var self = this,
+            loader = new LoaderCircles({containerElement: this._dialog.find('.modal-content')});
+
+        loader.start();
+
+        this._client.getProjects({rights: true, info: true}, function (err, projects) {
+            var project,
+                i;
+
+            loader.stop();
+            if (err) {
+                self._showError('Could not load project info.');
+                self._btnSave.disable(true);
+                return;
+            }
+
+            for (i = 0; i < projects.length; i += 1) {
+                if (projects[i]._id === self._projectId) {
+                    project = projects[i];
+                    break;
+                }
+            }
+
+            if (!project) {
+                self._showError('Could not load project info.');
+                self._btnSave.disable(true);
+                return;
+            }
+
+            self._applyProjectInfo(project);
+        });
+    };
+
+    ProjectInfoDialog.prototype._applyProjectInfo = function (project) {
+        var info = project.info || {},
+            ownerDisplayName = WebGMEGlobal.getUserDisplayName(project.owner),
+            createdAt = info.createdAt ? new Date(info.createdAt) : null,
+            modifiedAt = info.modifiedAt ? new Date(info.modifiedAt) : null,
+            viewedAt = info.viewedAt ? new Date(info.viewedAt) : null;
+
+        this._project = project;
+        this._originalOwnerId = project.owner;
+        this._selectedOwnerId = project.owner;
+        this._originalName = project.name;
+        this._originalKind = info.kind || '';
+        this._originalDescription = info.description || '';
+
+        this._selectedOwner.text(ownerDisplayName);
+        this._nameInput.val(project.name);
+        this._kindInput.val(info.kind || '');
+        this._descriptionInput.val(info.description || '');
+
+        this._auditCreated.text(this._formatAudit(info.creator, createdAt));
+        this._auditModified.text(this._formatAudit(info.modifier, modifiedAt));
+        this._auditViewed.text(this._formatAudit(info.viewer, viewedAt));
+
+        this._updateEditableState();
+    };
+
+    ProjectInfoDialog.prototype._formatAudit = function (username, date) {
+        if (!date) {
+            return 'N/A';
+        }
+
+        return (username || 'N/A') + ' at ' + clientUtil.formattedDate(date);
+    };
+
+    ProjectInfoDialog.prototype._updateEditableState = function () {
+        var canWrite = this._project.rights && this._project.rights.write === true,
+            canDelete = this._project.rights && this._project.rights.delete === true;
+
+        this._kindInput.prop('disabled', !canWrite);
+        this._descriptionInput.prop('disabled', !canWrite);
+        this._nameInput.prop('disabled', !canDelete);
+        this._dialog.find('.owner-dropdown button').prop('disabled', !canDelete);
+        this._btnSave.prop('disabled', !(canWrite || canDelete));
+    };
+
+    ProjectInfoDialog.prototype._showError = function (message) {
+        this._saveError.text(message).removeClass('hidden');
+    };
+
+    ProjectInfoDialog.prototype._hideError = function () {
+        this._saveError.addClass('hidden').text('');
+    };
+
+    ProjectInfoDialog.prototype._validate = function () {
+        var newName = this._nameInput.val();
+
+        if (!REGEXP.PROJECT_NAME.test(newName)) {
+            return 'Project name contains invalid characters.';
+        }
+
+        return null;
+    };
+
+    ProjectInfoDialog.prototype._save = function () {
+        var self = this,
+            validationError = this._validate(),
+            ownerChanged,
+            nameChanged,
+            infoChanged,
+            newOwnerId,
+            newName,
+            newKind,
+            newDescription,
+            loader;
+
+        this._hideError();
+
+        if (validationError) {
+            this._showError(validationError);
+            return;
+        }
+
+        newOwnerId = this._selectedOwnerId;
+        newName = this._nameInput.val();
+        newKind = this._kindInput.val();
+        newDescription = this._descriptionInput.val();
+        ownerChanged = newOwnerId !== this._originalOwnerId;
+        nameChanged = newName !== this._originalName;
+        infoChanged = newKind !== this._originalKind || newDescription !== this._originalDescription;
+
+        if (!ownerChanged && !nameChanged && !infoChanged) {
+            this._dialog.modal('hide');
+            return;
+        }
+
+        loader = new LoaderCircles({containerElement: this._dialog.find('.modal-content')});
+        loader.start();
+        this._btnSave.disable(true);
+
+        this._applyChanges(this._projectId, ownerChanged, nameChanged, infoChanged,
+            newOwnerId, newName, newKind, newDescription, loader);
+    };
+
+    ProjectInfoDialog.prototype._applyChanges = function (projectId, ownerChanged, nameChanged, infoChanged,
+        newOwnerId, newName, newKind, newDescription, loader) {
+        var self = this,
+            owner,
+            projectName;
+
+        function done(err, newProjectId) {
+            if (err) {
+                loader.stop();
+                self._btnSave.disable(false);
+                self._showError(err.message || String(err));
+                return;
+            }
+
+            if (newProjectId) {
+                projectId = newProjectId;
+            }
+
+            if (ownerChanged) {
+                self._applyChanges(projectId, false, nameChanged, infoChanged,
+                    newOwnerId, newName, newKind, newDescription, loader);
+                return;
+            }
+
+            if (nameChanged) {
+                self._applyChanges(projectId, false, false, infoChanged,
+                    newOwnerId, newName, newKind, newDescription, loader);
+                return;
+            }
+
+            if (infoChanged) {
+                owner = StorageUtil.getOwnerFromProjectId(projectId);
+                projectName = StorageUtil.getProjectNameFromProjectId(projectId);
+                self._patchProjectInfo(owner, projectName, newKind, newDescription, function (patchErr) {
+                    loader.stop();
+                    if (patchErr) {
+                        self._btnSave.disable(false);
+                        self._showError(patchErr.message || String(patchErr));
+                        return;
+                    }
+
+                    self._afterSave(projectId);
+                });
+                return;
+            }
+
+            loader.stop();
+            self._afterSave(projectId);
+        }
+
+        if (ownerChanged) {
+            self._transferProject(projectId, newOwnerId, done);
+        } else if (nameChanged) {
+            self._renameProject(projectId, newName, done);
+        } else if (infoChanged) {
+            owner = StorageUtil.getOwnerFromProjectId(projectId);
+            projectName = StorageUtil.getProjectNameFromProjectId(projectId);
+            self._patchProjectInfo(owner, projectName, newKind, newDescription, function (err) {
+                done(err);
+            });
+        } else {
+            done(null);
+        }
+    };
+
+    ProjectInfoDialog.prototype._transferProject = function (projectId, newOwnerId, callback) {
+        var owner = StorageUtil.getOwnerFromProjectId(projectId),
+            projectName = StorageUtil.getProjectNameFromProjectId(projectId);
+
+        if (typeof this._client.transferProject === 'function') {
+            this._client.transferProject(projectId, newOwnerId, function (err, newProjectId) {
+                callback(err, newProjectId);
+            });
+            return;
+        }
+
+        superagent('POST', 'api/projects/' + owner + '/' + projectName + '/transfer/' + newOwnerId)
+            .end(function (err, res) {
+                if (err || res.status !== 200) {
+                    callback(new Error('Could not transfer project ownership.'));
+                } else {
+                    callback(null, res.body._id);
+                }
+            });
+    };
+
+    ProjectInfoDialog.prototype._renameProject = function (projectId, newProjectName, callback) {
+        var owner = StorageUtil.getOwnerFromProjectId(projectId),
+            projectName = StorageUtil.getProjectNameFromProjectId(projectId);
+
+        if (typeof this._client.renameProject === 'function') {
+            this._client.renameProject(projectId, newProjectName, function (err, newProjectId) {
+                callback(err, newProjectId);
+            });
+            return;
+        }
+
+        superagent('POST', 'api/projects/' + owner + '/' + projectName + '/rename')
+            .send({name: newProjectName})
+            .end(function (err, res) {
+                if (err || res.status !== 200) {
+                    callback(new Error('Could not rename project.'));
+                } else {
+                    callback(null, res.body._id);
+                }
+            });
+    };
+
+    ProjectInfoDialog.prototype._patchProjectInfo = function (owner, projectName, kind, description, callback) {
+        superagent('PATCH', 'api/projects/' + owner + '/' + projectName)
+            .send({kind: kind, description: description})
+            .end(function (err, res) {
+                if (err || res.status !== 200) {
+                    callback(new Error('Could not update project info.'));
+                } else {
+                    callback(null);
+                }
+            });
+    };
+
+    ProjectInfoDialog.prototype._afterSave = function (projectId) {
+        var self = this,
+            activeProjectId = this._client.getActiveProjectId(),
+            originalProjectId = this._projectId;
+
+        this._dialog.modal('hide');
+
+        if (typeof this._onSaved === 'function') {
+            this._onSaved(projectId);
+        }
+
+        if (activeProjectId === originalProjectId && projectId !== activeProjectId) {
+            this._client.selectProject(projectId, null, function (err) {
+                if (err) {
+                    self._logger.error('Could not select renamed/transferred project', err);
+                    document.location.href = window.location.href.split('?')[0];
+                }
+            });
+        }
+    };
+
+    return ProjectInfoDialog;
+});

--- a/src/client/js/Dialogs/ProjectInfo/styles/ProjectInfoDialog.css
+++ b/src/client/js/Dialogs/ProjectInfo/styles/ProjectInfoDialog.css
@@ -1,0 +1,41 @@
+.project-info-dialog .modal-content .modal-header .header-icon {
+  height: 28px;
+  width: 28px;
+  margin-right: 1ex;
+  display: inline-block;
+  vertical-align: middle;
+  background-size: 28px 28px;
+}
+.project-info-dialog .modal-content .modal-header span {
+  font-size: 24px;
+  vertical-align: middle;
+}
+.project-info-dialog .modal-content .modal-body fieldset {
+  margin-bottom: 15px;
+}
+.project-info-dialog .modal-content .modal-body fieldset legend {
+  font-size: 14px;
+  font-weight: bold;
+  border-bottom: none;
+  margin-bottom: 10px;
+}
+.project-info-dialog .modal-content .modal-body .form-control-static {
+  min-height: 20px;
+  padding-top: 7px;
+  margin-bottom: 0;
+}
+.project-info-dialog .modal-content .modal-body .owner-dropdown {
+  width: 100%;
+}
+.project-info-dialog .modal-content .modal-body .owner-dropdown .dropdown-toggle {
+  width: 100%;
+  text-align: left;
+}
+.project-info-dialog .modal-content .modal-body .owner-dropdown .dropdown-toggle .caret {
+  float: right;
+  margin-top: 8px;
+}
+.project-info-dialog .modal-content .modal-body .save-error {
+  margin-top: 10px;
+  margin-bottom: 0;
+}

--- a/src/client/js/Dialogs/ProjectInfo/styles/ProjectInfoDialog.scss
+++ b/src/client/js/Dialogs/ProjectInfo/styles/ProjectInfoDialog.scss
@@ -1,0 +1,57 @@
+.project-info-dialog {
+  .modal-content {
+    .modal-header {
+      .header-icon {
+        height: 28px;
+        width: 28px;
+        margin-right: 1ex;
+        display: inline-block;
+        vertical-align: middle;
+        background-size: 28px 28px;
+      }
+
+      span {
+        font-size: 24px;
+        vertical-align: middle;
+      }
+    }
+
+    .modal-body {
+      fieldset {
+        margin-bottom: 15px;
+
+        legend {
+          font-size: 14px;
+          font-weight: bold;
+          border-bottom: none;
+          margin-bottom: 10px;
+        }
+      }
+
+      .form-control-static {
+        min-height: 20px;
+        padding-top: 7px;
+        margin-bottom: 0;
+      }
+
+      .owner-dropdown {
+        width: 100%;
+
+        .dropdown-toggle {
+          width: 100%;
+          text-align: left;
+
+          .caret {
+            float: right;
+            margin-top: 8px;
+          }
+        }
+      }
+
+      .save-error {
+        margin-top: 10px;
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/src/client/js/Dialogs/ProjectInfo/templates/ProjectInfoDialog.html
+++ b/src/client/js/Dialogs/ProjectInfo/templates/ProjectInfoDialog.html
@@ -1,0 +1,80 @@
+<div class="project-info-dialog modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <i class="header-icon gme-icon"></i><span>Project info</span>
+            </div>
+            <div class="modal-body">
+                <form class="form-horizontal project-info-form">
+                    <fieldset class="identity-section">
+                        <legend>Identity</legend>
+                        <div class="form-group owner-group">
+                            <label class="col-sm-3 control-label">Owner</label>
+                            <div class="col-sm-9">
+                                <div class="btn-group owner-dropdown">
+                                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+                                            aria-haspopup="true" aria-expanded="false">
+                                        <span class="selected-owner-id">Username</span>
+                                        <span class="caret"></span>
+                                    </button>
+                                    <ul class="dropdown-menu ownerId-list"></ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label" for="projectInfoName">Name</label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control project-name" id="projectInfoName"
+                                       placeholder="Project name"/>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <fieldset class="info-section">
+                        <legend>Info</legend>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label" for="projectInfoKind">Kind</label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control project-kind" id="projectInfoKind"
+                                       placeholder="Project kind"/>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label" for="projectInfoDescription">Description</label>
+                            <div class="col-sm-9">
+                                <input type="text" class="form-control project-description" id="projectInfoDescription"
+                                       placeholder="Describe the project"/>
+                            </div>
+                        </div>
+                    </fieldset>
+                    <fieldset class="audit-section">
+                        <legend>History</legend>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Created</label>
+                            <div class="col-sm-9">
+                                <p class="form-control-static audit-created"></p>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Last modified</label>
+                            <div class="col-sm-9">
+                                <p class="form-control-static audit-modified"></p>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Last viewed</label>
+                            <div class="col-sm-9">
+                                <p class="form-control-static audit-viewed"></p>
+                            </div>
+                        </div>
+                    </fieldset>
+                </form>
+                <div class="alert alert-danger save-error hidden" role="alert"></div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button class="btn btn-primary btn-save">Save</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/client/js/Dialogs/Projects/ProjectsDialog.js
+++ b/src/client/js/Dialogs/Projects/ProjectsDialog.js
@@ -336,13 +336,13 @@ define([
             if (show) {
                 self._table.find('.extra-info').removeClass('info-hidden');
                 self._table.addClass('info-displayed');
-                elm.removeClass('fa-chevron-left');
-                elm.addClass('fa-chevron-right');
+                elm.removeClass('fa-chevron-right');
+                elm.addClass('fa-chevron-left');
             } else {
                 self._table.find('.extra-info').addClass('info-hidden');
                 self._table.removeClass('info-displayed');
-                elm.removeClass('fa-chevron-right');
-                elm.addClass('fa-chevron-left');
+                elm.removeClass('fa-chevron-left');
+                elm.addClass('fa-chevron-right');
             }
             event.stopPropagation();
             event.preventDefault();
@@ -358,6 +358,8 @@ define([
                 self._sortType = 'owner';
             } else if (elm.hasClass('title-name')) {
                 self._sortType = 'name';
+            } else if (elm.hasClass('title-kind')) {
+                self._sortType = 'kind';
             } else if (elm.hasClass('title-modified')) {
                 self._sortType = 'modified';
             } else if (elm.hasClass('title-viewed')) {
@@ -604,6 +606,7 @@ define([
                     created: createdAt.getTime(),
                     name: projectName.toUpperCase(),
                     owner: owner.toUpperCase(),
+                    kind: (projectData.info.kind || '').toUpperCase(),
                     info: projectData.info.description
                 });
 
@@ -617,6 +620,43 @@ define([
                 $('<td/>').addClass('name').append(span)
                     .append('<span class="name-read-only">[Read-Only]</span>')
                     .appendTo(tblRow);
+
+                // kind
+                span = $('<input/>').addClass('kind')
+                    .val(projectData.info.kind || '')
+                    .prop('placeholder', 'project kind')
+                    .data('projectId', this._projectIds[i])
+                    .data('kind', projectData.info.kind || '')
+                    .prop('disabled', projectData.rights.write !== true)
+                    .focusout(function (/*event*/) {
+                        $(this).val($(this).data('kind'));
+                    })
+                    .keyup(function (event) {
+                        var owner, projectName, projectId, newKind,
+                            uiItem = $(this);
+
+                        if (event.keyCode === 13) {
+                            projectId = $(this).data('projectId');
+                            newKind = $(this).val();
+
+                            if (uiItem.data('kind') !== uiItem.val()) {
+                                projectName = StorageUtil.getProjectNameFromProjectId(projectId);
+                                owner = StorageUtil.getOwnerFromProjectId(projectId);
+                                self._updateProjectInfo(owner, projectName, {kind: newKind},
+                                    function (err) {
+                                        if (err) {
+                                            self._logger.error(err);
+                                            uiItem.val(uiItem.data('kind'));
+                                        } else {
+                                            uiItem.data('kind', newKind);
+                                            uiItem.val(newKind);
+                                        }
+                                        $(uiItem).blur();
+                                    });
+                            }
+                        }
+                    });
+                $('<td/>').addClass('kind').append(span).appendTo(tblRow);
 
                 //info
                 span = $('<input/>').addClass('description')
@@ -639,7 +679,7 @@ define([
                             if (uiItem.data('description') !== uiItem.val()) {
                                 projectName = StorageUtil.getProjectNameFromProjectId(projectId);
                                 owner = StorageUtil.getOwnerFromProjectId(projectId);
-                                self._updateProjectDescription(owner, projectName, newDescription,
+                                self._updateProjectInfo(owner, projectName, {description: newDescription},
                                     function (err) {
                                         if (err) {
                                             self._logger.error(err);
@@ -684,10 +724,10 @@ define([
 
                 if (projectData.rights.delete === true) {
                     iconsEl.append(
-                        $('<i class="glyphicon glyphicon-trash delete-project extra-info info-hidden"/>')
+                        $('<i class="glyphicon glyphicon-trash delete-project"/>')
                             .data('projectId', this._projectIds[i]));
                 } else {
-                    iconsEl.append('<i class="glyphicon glyphicon-lock locked extra-info info-hidden"/>');
+                    iconsEl.append('<i class="glyphicon glyphicon-lock locked"/>');
                 }
 
                 this._tableBody.append(tblRow);
@@ -698,6 +738,13 @@ define([
 
         if (this._table.hasClass('info-displayed')) {
             this._table.find('.extra-info').removeClass('info-hidden');
+            this._tableHead.find('.btn-info-toggle')
+                .removeClass('fa-chevron-right')
+                .addClass('fa-chevron-left');
+        } else {
+            this._tableHead.find('.btn-info-toggle')
+                .removeClass('fa-chevron-left')
+                .addClass('fa-chevron-right');
         }
 
         self._updateFilter();
@@ -786,9 +833,9 @@ define([
         sortedRows.detach().appendTo(this._tableBody);
     };
 
-    ProjectsDialog.prototype._updateProjectDescription = function (owner, projectName, description, callback) {
+    ProjectsDialog.prototype._updateProjectInfo = function (owner, projectName, info, callback) {
         superagent('PATCH', 'api/projects/' + owner + '/' + projectName)
-            .send({description: description})
+            .send(info)
             .end(function (err, res) {
                 if (err || res.status !== 200) {
                     callback(new Error('cannot update project info'));

--- a/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
+++ b/src/client/js/Dialogs/Projects/styles/ProjectsDialog.css
@@ -117,10 +117,13 @@
     .projects-dialog .modal-content .modal-body table.table.table-projects tbody.project-list tr.project-row td.created {
       font-style: italic;
       color: grey; }
-    .projects-dialog .modal-content .modal-body table.table.table-projects tbody.project-list tr.project-row td .description {
+    .projects-dialog .modal-content .modal-body table.table.table-projects tbody.project-list tr.project-row td .description,
+    .projects-dialog .modal-content .modal-body table.table.table-projects tbody.project-list tr.project-row td .kind {
       border: none;
       background-color: transparent;
       width: 90%; }
+  .projects-dialog .modal-content .modal-body table.table.table-projects.info-displayed tbody.project-list tr.project-row td {
+    font-size: 90%; }
 .projects-dialog .modal-content .modal-footer button.corner-button {
   margin-top: 0.5ex; }
 .projects-dialog .modal-content .modal-footer ul.dropdown-menu {

--- a/src/client/js/Dialogs/Projects/styles/ProjectsDialog.scss
+++ b/src/client/js/Dialogs/Projects/styles/ProjectsDialog.scss
@@ -206,10 +206,20 @@
                 color: grey;
               }
 
-              .description {
+              .description,
+              .kind {
                 border: none;
                 background-color: transparent;
                 width: 90%;
+              }
+            }
+          }
+        }
+        &.info-displayed {
+          tbody.project-list {
+            tr.project-row {
+              td {
+                font-size: 90%;
               }
             }
           }

--- a/src/client/js/Dialogs/Projects/templates/ProjectsDialog.html
+++ b/src/client/js/Dialogs/Projects/templates/ProjectsDialog.html
@@ -21,6 +21,10 @@
                                 <i class="glyphicon glyphicon-sort-by-attributes-alt sorted in-order"/>
                                 <i class="glyphicon glyphicon-sort-by-attributes sorted rev-order"/>
                             </th>
+                            <th class="title-kind">Kind
+                                <i class="glyphicon glyphicon-sort-by-attributes-alt sorted in-order"/>
+                                <i class="glyphicon glyphicon-sort-by-attributes sorted rev-order"/>
+                            </th>
                             <th class="title-info">Info</th>
                             <th class="title-modified">Last Modified
                                 <i class="glyphicon glyphicon-sort-by-attributes-alt sorted in-order"/>
@@ -35,7 +39,7 @@
                                 <i class="glyphicon glyphicon-sort-by-attributes sorted rev-order"/>
                             </th>
                             <th class="title-icons" title="Show/hide details">
-                                <i class="btn-info-toggle fa fa-chevron-left"/>
+                                <i class="btn-info-toggle fa fa-chevron-right"/>
                             </th>
                         </tr>
                         <tr class="with-no-children">

--- a/src/client/js/Panels/FooterControls/FooterControlsPanel.js
+++ b/src/client/js/Panels/FooterControls/FooterControlsPanel.js
@@ -10,6 +10,7 @@ define(['js/PanelBase/PanelBase',
     'js/Widgets/KeyboardManager/KeyboardManagerWidget',
     'js/Widgets/Notification/NotificationWidget',
     'js/Widgets/RunningPluginsDrawerButtonWidget/RunningPluginsDrawerButtonWidget',
+    'js/Widgets/ProjectKind/ProjectKindWidget',
     'js/Utils/ComponentSettings'
 ], function (PanelBase,
              NetworkStatusWidget,
@@ -17,6 +18,7 @@ define(['js/PanelBase/PanelBase',
              KeyboardManagerWidget,
              NotificationWidget,
              RunningPluginsDrawerButtonWidget,
+             ProjectKindWidget,
              ComponentSettings) {
 
     'use strict';
@@ -57,6 +59,10 @@ define(['js/PanelBase/PanelBase',
 
         //add ISIS link
         this.createCredits(navBarInner);
+
+        this._projectKindEl = $('<div class="footer-project-kind inline"></div>');
+        navBarInner.append(this._projectKindEl);
+        this._widgets.push(new ProjectKindWidget(this._projectKindEl, this._client));
 
         //padding from screen right edge
         navBarInner.append(separator.clone());

--- a/src/client/js/Panels/Header/ProjectNavigatorController.js
+++ b/src/client/js/Panels/Header/ProjectNavigatorController.js
@@ -11,6 +11,7 @@ define([
     'angular',
     'js/Loader/ProgressNotification',
     'js/Dialogs/Projects/ProjectsDialog',
+    'js/Dialogs/ProjectInfo/ProjectInfoDialog',
     'js/Dialogs/Merge/MergeDialog',
     'js/Dialogs/ProjectRepository/ProjectRepositoryDialog',
     'js/Dialogs/Branches/BranchesDialog',
@@ -26,6 +27,7 @@ define([
     ng,
     ProgressNotification,
     ProjectsDialog,
+    ProjectInfoDialog,
     MergeDialog,
     ProjectRepositoryDialog,
     BranchesDialog,
@@ -478,6 +480,7 @@ define([
         var self = this,
             i,
             showHistory,
+            showProjectInfo,
             showAllBranchesOrTags,
             deleteProject,
             selectProject,
@@ -503,6 +506,15 @@ define([
 
         showHistory = function (data) {
             self.showHistory(data);
+        };
+
+        showProjectInfo = function (data) {
+            var projectInfoDialog = new ProjectInfoDialog(self.gmeClient);
+            projectInfoDialog.show(data.projectId, {
+                onSaved: function () {
+                    self.updateProjectList();
+                }
+            });
         };
 
         deleteProject = function (data) {
@@ -564,6 +576,14 @@ define([
                 {
                     id: 'top',
                     items: [
+                        {
+                            id: 'projectInfo',
+                            label: 'Project info ...',
+                            iconClass: 'glyphicon glyphicon-cog',
+                            disabled: !rights.read,
+                            action: showProjectInfo,
+                            actionData: { projectId }
+                        },
                         {
                             id: 'showHistory',
                             label: 'Project history ...',

--- a/src/client/js/Widgets/ProjectKind/ProjectKindWidget.js
+++ b/src/client/js/Widgets/ProjectKind/ProjectKindWidget.js
@@ -1,0 +1,109 @@
+/*globals define, WebGMEGlobal, $*/
+/*jshint browser: true*/
+
+define([
+    'js/logger',
+    'js/Constants',
+    'js/Dialogs/ProjectInfo/ProjectInfoDialog',
+    'css!./styles/ProjectKindWidget.css'
+], function (Logger, CONSTANTS, ProjectInfoDialog) {
+
+    'use strict';
+
+    function ProjectKindWidget(containerEl, client) {
+        this._logger = Logger.create('gme:Widgets:ProjectKind:ProjectKindWidget',
+            WebGMEGlobal.gmeConfig.client.log);
+        this._client = client;
+        this._el = containerEl;
+        this._initializeUI();
+        this._logger.debug('Created');
+    }
+
+    ProjectKindWidget.prototype._initializeUI = function () {
+        var self = this;
+
+        this._el.empty();
+        this._btnGroup = $('<div class="btn-group"></div>');
+        this._btn = $('<button type="button" class="btn btn-micro btn-gray project-kind-btn" title="Project kind"/>');
+        this._btnGroup.append(this._btn);
+        this._el.append(this._btnGroup);
+
+        this._btn.on('click', function (event) {
+            var projectId = self._client.getActiveProjectId(),
+                dialog;
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (!projectId) {
+                return;
+            }
+
+            dialog = new ProjectInfoDialog(self._client);
+            dialog.show(projectId, {
+                onSaved: function () {
+                    self._refresh();
+                }
+            });
+        });
+
+        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_OPENED, function () {
+            self._refresh();
+        });
+
+        this._client.addEventListener(CONSTANTS.CLIENT.PROJECT_CLOSED, function () {
+            self._refresh();
+        });
+
+        this._refresh();
+    };
+
+    ProjectKindWidget.prototype._refresh = function () {
+        var self = this,
+            projectId = this._client.getActiveProjectId(),
+            kind;
+
+        if (!projectId) {
+            this._el.hide();
+            return;
+        }
+
+        this._el.show();
+
+        this._client.getProjects({info: true}, function (err, projects) {
+            var i,
+                info;
+
+            if (err || self._client.getActiveProjectId() !== projectId) {
+                return;
+            }
+
+            kind = null;
+            for (i = 0; i < projects.length; i += 1) {
+                if (projects[i]._id === projectId) {
+                    info = projects[i].info || {};
+                    kind = info.kind || null;
+                    break;
+                }
+            }
+
+            if (kind) {
+                self._btn.text(kind);
+                self._btn.attr('title', 'Project kind: ' + kind);
+                self._btn.removeClass('no-kind');
+            } else {
+                self._btn.text('Kind');
+                self._btn.attr('title', 'No project kind set — click to edit');
+                self._btn.addClass('no-kind');
+            }
+        });
+    };
+
+    ProjectKindWidget.prototype.destroy = function () {
+        if (this._btn) {
+            this._btn.off('click');
+        }
+    };
+
+    return ProjectKindWidget;
+});

--- a/src/client/js/Widgets/ProjectKind/styles/ProjectKindWidget.css
+++ b/src/client/js/Widgets/ProjectKind/styles/ProjectKindWidget.css
@@ -1,0 +1,23 @@
+.footer-project-kind .project-kind-btn {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.footer-project-kind .project-kind-btn.no-kind {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.navbar-fixed-bottom .navbar-inner .footer-project-kind {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.navbar-fixed-bottom .navbar-inner .footer-project-kind .btn-group {
+  margin-top: 3px;
+  height: 16px;
+}


### PR DESCRIPTION
## Summary
- Add **Project info** dialog for editing kind, description, owner, and name (with read-only audit fields)
- Add **Kind** column to the projects list with inline editing
- Add footer **Kind** button that opens the same dialog
- Wire **Project info …** into the breadcrumb project menu

## Test plan
- [ ] Open projects list — kind column visible when extra info is expanded; inline edit saves on Enter
- [ ] Create/open a project — footer kind button shows current kind (or placeholder); opens Project info dialog
- [ ] Breadcrumb project menu → **Project info …** opens dialog; save kind/description/owner/name
- [ ] Verify import package flow still works unchanged (no historyio/import changes in this PR)

Made with [Cursor](https://cursor.com)